### PR TITLE
Update Community page to Include link to Forum

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -22,9 +22,9 @@ layout: default
             <div class="equal-height--vertical-divider">
 
                 <div class="six-col box">
-                    <h3><a href="https://forum.snapcraft.io">Talk about Snapcraft on the Forum ›</a></h3>
+                    <h3><a href="https://forum.snapcraft.io">Talk about Snapcraft on the forum &nbsp;&rsaquo</a></h3>
                     <p>Got ideas for how Snapcraft could be improved? Want to be an active part of the community and get involved? 
-                    Head over to the official <a class="external" href="https://forum.snapcraft.io">Snapcraft Forum</a> 
+                    Head over to the official <a class="external" href="https://forum.snapcraft.io">Snapcraft forum</a> 
                     to collaborate and get help.</p>
                 </div>
                 

--- a/community/index.html
+++ b/community/index.html
@@ -22,6 +22,13 @@ layout: default
             <div class="equal-height--vertical-divider">
 
                 <div class="six-col box">
+                    <h3><a href="https://forum.snapcraft.io">Talk about Snapcraft on the Forum ›</a></h3>
+                    <p>Got ideas for how Snapcraft could be improved? Want to be an active part of the community and get involved? 
+                    Head over to the official <a class="external" href="https://forum.snapcraft.io">Snapcraft Forum</a> 
+                    to collaborate and get help.</p>
+                </div>
+                
+                <div class="six-col box">
                     <h3><a href="http://stackoverflow.com/questions/ask?tags=snapcraft">Got a question? Ask on Stack Overflow ›</a></h3>
                     <p>If you’re stuck, the chances are that someone else has encountered
                     the same problem and they can help. Take a look at the

--- a/community/index.html
+++ b/community/index.html
@@ -22,7 +22,7 @@ layout: default
             <div class="equal-height--vertical-divider">
 
                 <div class="six-col box">
-                    <h3><a href="https://forum.snapcraft.io">Talk about Snapcraft on the forum &nbsp;&rsaquo</a></h3>
+                    <h3><a href="https://forum.snapcraft.io">Talk about Snapcraft on the forum&nbsp;&rsaquo</a></h3>
                     <p>Got ideas for how Snapcraft could be improved? Want to be an active part of the community and get involved? 
                     Head over to the official <a class="external" href="https://forum.snapcraft.io">Snapcraft forum</a> 
                     to collaborate and get help.</p>


### PR DESCRIPTION
My first stab at copy associated with the forum, feedback welcome.

## Done

- Added the link to the [Snapcraft Forum](https://forum.snapcraft.io) with some copy.

## Issue / Card

Addresses [this issue](https://github.com/canonical-websites/snapcraft.io/issues/297) raised during Snapcraft Docs Day (March 31, 2017).

Fixes #297