### PR TITLE
Fix links to per-distro Snappy install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,31 +17,31 @@ layout: default
             <div class="seven-col equal-height__item last-col">
                 <ul class="inline-logos">
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#ubuntu"><img class="inline-logos__image" src="{{ site.asset_path }}c086ad34-logo-ubuntu_st_no-black_orange-hex.svg" alt="ubuntu" /></a>
+                        <a href="/docs/core/install-ubuntu"><img class="inline-logos__image" src="{{ site.asset_path }}c086ad34-logo-ubuntu_st_no-black_orange-hex.svg" alt="Ubuntu" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#arch"><img class="inline-logos__image" src="{{ site.asset_path }}e0b23092-archlinux.svg" alt="archlinux" /></a>
+                        <a href="/docs/core/install-arch-linux"><img class="inline-logos__image" src="{{ site.asset_path }}e0b23092-archlinux.svg" alt="Arch Linux" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#debian"><img class="inline-logos__image" src="{{ site.asset_path }}2eafb62e-openlogo.svg" alt="debian" /></a>
+                        <a href="/docs/core/install-debian"><img class="inline-logos__image" src="{{ site.asset_path }}2eafb62e-openlogo.svg" alt="Debian" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#gentoo"><img class="inline-logos__image" src="{{ site.asset_path }}b6fa25ef-Gentoo-trans02.png" alt="gentoo" /></a>
+                        <a href="/docs/core/install-gentoo"><img class="inline-logos__image" src="{{ site.asset_path }}b6fa25ef-Gentoo-trans02.png" alt="Gentoo" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#fedora"><img class="inline-logos__image" src="{{ site.asset_path }}1a53bedd-fedora.svg" alt="fedora" /></a>
+                        <a href="/docs/core/install-fedora"><img class="inline-logos__image" src="{{ site.asset_path }}1a53bedd-fedora.svg" alt="Fedora" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#opensuse"><img class="inline-logos__image" src="{{ site.asset_path }}06469a26-official-logo-color.svg" alt="suse" /></a>
+                        <a href="/docs/core/install-opensuse"><img class="inline-logos__image" src="{{ site.asset_path }}06469a26-official-logo-color.svg" alt="openSUSE" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#openembeddedyocto"><img class="inline-logos__image" src="{{ site.asset_path }}d243274d-openembedded-logo.svg" alt="openembedded" /></a>
+                        <a href="/docs/core/install-oe-yocto"><img class="inline-logos__image" src="{{ site.asset_path }}d243274d-openembedded-logo.svg" alt="OpenEmbedded" /></a>
                     </li>
                     <li class="inline-logos__item">
-                        <a href="/docs/core/install#openembeddedyocto"><img class="inline-logos__image" src="{{ site.asset_path }}d9a1a359-yocto-project-transp.png" alt="yocto project" />
+                        <a href="/docs/core/install-oe-yocto"><img class="inline-logos__image" src="{{ site.asset_path }}d9a1a359-yocto-project-transp.png" alt="Yocto Project" />
                     </li>
                     <li class="inline-logos__item last-col">
-                        <a href="/docs/core/install#openwrt"><img class="inline-logos__image" src="{{ site.asset_path }}ba58e5e3-Openwrt_Logo.svg" alt="OpenWrt" /></a>
+                        <a href="/docs/core/install-openwrt"><img class="inline-logos__image" src="{{ site.asset_path }}ba58e5e3-Openwrt_Logo.svg" alt="OpenWrt" /></a>
                     </li>
                 </ul>
 


### PR DESCRIPTION
The per-distribution install instructions for Snappy have been broken for quite a while now, and now that there's been progress on supporting distributions other than Ubuntu, this really should be fixed now, so people know about it.

## Done

* Fixed the links for per-distro Snappy install instructions

## QA

1. Load the new home page
2. Click one of the distro logos to go to the appropriate install instructions page

## Issue / Card

N/A

## Screenshots

N/A
