### PR TITLE
Update header tabs

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -54,9 +54,8 @@
                     {% assign current = page.url | downcase | split: '/' %}
                     <ul>
                         <li {% if current[1] == 'community' %}class='active'{% endif %}><a href="/community">Community</a></li>
-                        <li {% if current[1] == 'create' %}class='active'{% endif %}><a href="/create">Create</a></li>
                         <li {% if current[1] == 'docs' %}class='active'{% endif %}><a href="/docs">Docs</a></li>
-                        <li><a class="external" href="https://developer.ubuntu.com/en/snappy/support/faq/">FAQ</a></li>
+                        <li><a class="external" href="https://tutorials.ubuntu.com">Tutorials</a></li>
                     </ul>
                 </div>
             </nav>


### PR DESCRIPTION
## Done

* Drop /create from the exposed nav, superseeded by the first snap tutorial which is performing much better with users
* Drop outdated FAQ
* Surface tutorials

## Screenshots

![screenshot from 2017-04-18 17-59-44](https://cloud.githubusercontent.com/assets/18480003/25140499/dddc01fe-2460-11e7-9daf-6ce0460cb5e3.png)
