### PR TITLE
Add link to status.snapcraft.io

### DIFF
--- a/_includes/footer-legal.html
+++ b/_includes/footer-legal.html
@@ -2,7 +2,8 @@
 
 <ul class="footer__links">
     <li class="footer__list-item"><a href="http://www.ubuntu.com/legal">Legal information</a><span class="footer__dot"> &#183;</span></li>
-    <li class="footer__list-item"><a href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a></li>
+    <li class="footer__list-item"><a href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a><span class="footer__dot"> &#183;</span></li>
+    <li class="footer__list-item"><a href="http://status.snapcraft.io/">Service status</a></li>
 </ul>
 
 <p class="note six-col">Yocto Project and all related marks and logos are trademarks of The Linux Foundation. This website is not, in any way, endorsed by the Yocto Project or The Linux Foundation.</p>


### PR DESCRIPTION
## Done

Add link to status.snapcraft.io in footer

## QA

- Follow the instructions in README.md to get started 
- Go to http://127.0.0.1:4000 and make sure the additional link looks and works as you’d hope 

## Issue / Card

Fixes #323 