### PR TITLE
Move featured snaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,119 @@ layout: default
         </div>
     </section>
 
+    <section id="snapcraft_home_featured-snaps" class="row">
+        <div class="wrapper">
+            <div class="seven-col">
+                <h2>Featured snaps</h2>
+            </div>
+
+            <ul class="grid-list twelve-col no-bullets no-margin-bottom equal-height">
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}e512b0e2-jenkins.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Jenkins</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}b3155b2d-Rocket-dot-Chat.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Rocket.Chat</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}3ad2e1e3-notes.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Notes</h3>
+                    </div>
+                </li>
+
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}476aaa77-cassandra.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Apache Cassandra</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}c9ded7dd-nats_png.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>NATS</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}aacc8ea7-shout.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Shout</h3>
+                    </div>
+                </li>
+
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}de9ddfd4-stellarium.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Stellarium</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}c675c7a0-webdm.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>WebDM</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}5eca4c49-arango_png.png" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>ArangoDB</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-row">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}1da2538b-krita.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Krita</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-row">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}33f5e395-vlc.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>VLC</h3>
+                    </div>
+                </li>
+                <li class="equal-height__align-vertically grid-list__item four-col last-col last-row">
+                    <div class="one-col ">
+                        <img class="grid-list__img" src="{{ site.asset_path }}d4a78a2c-blender.svg" alt="icon">
+                    </div>
+                    <div class="three-col last-col">
+                        <h3>Blender</h3>
+                    </div>
+                </li>
+            </ul>
+
+            <div class="twelve-col">
+                <p class="complementing-note">Check out snaps on <a href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a>, or use the command line to install any of these great snaps.</p>
+            </div>
+        </div>
+    </section>
+
     <section id="snapcraft_home_how-snaps-work" class="row">
         <div class="wrapper">
             <div class="eight-col">
@@ -401,120 +514,6 @@ Hello, snap padawan!</code></pre>
 
 <pre class="command-line code-block"><code>$ sudo snap install hello --beta
 Hello (beta) 1.2 installed</code></pre>
-            </div>
-        </div>
-    </section>
-
-
-    <section id="snapcraft_home_featured-snaps" class="row">
-        <div class="wrapper">
-            <div class="seven-col">
-                <h2>Featured snaps</h2>
-            </div>
-
-            <ul class="grid-list twelve-col no-bullets no-margin-bottom equal-height">
-                <li class="equal-height__align-vertically grid-list__item four-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}e512b0e2-jenkins.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Jenkins</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}b3155b2d-Rocket-dot-Chat.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Rocket.Chat</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col last-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}3ad2e1e3-notes.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Notes</h3>
-                    </div>
-                </li>
-
-                <li class="equal-height__align-vertically grid-list__item four-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}476aaa77-cassandra.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Apache Cassandra</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}c9ded7dd-nats_png.png" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>NATS</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col last-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}aacc8ea7-shout.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Shout</h3>
-                    </div>
-                </li>
-
-                <li class="equal-height__align-vertically grid-list__item four-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}de9ddfd4-stellarium.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Stellarium</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}c675c7a0-webdm.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>WebDM</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col last-col">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}5eca4c49-arango_png.png" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>ArangoDB</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col last-row">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}1da2538b-krita.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Krita</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col last-row">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}33f5e395-vlc.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>VLC</h3>
-                    </div>
-                </li>
-                <li class="equal-height__align-vertically grid-list__item four-col last-col last-row">
-                    <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}d4a78a2c-blender.svg" alt="icon">
-                    </div>
-                    <div class="three-col last-col">
-                        <h3>Blender</h3>
-                    </div>
-                </li>
-            </ul>
-
-            <div class="twelve-col">
-                <p class="complementing-note">Check out snaps on <a href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a>, or use the command line to install any of these great snaps.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Done

Move featured snaps immediately above the “How do snaps work?” section

## QA

- Follow the instructions in README.md to get started
- Go to http://127.0.0.1:4000 and make sure featured snaps are immediately above the “How do snaps work?” section as apposed to below it as it is on live

## Issue / Card

Fixes #324