### PR TITLE
Exclude Jekyll vendor files from building

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,8 @@ exclude: [
   'translate-html',
   'import-docs.sh',
   'update-docs-layout.py',
-  'po-html'
+  'po-html',
+  'vendor/bundle'
 ]
 permalink: /:title
 


### PR DESCRIPTION
Exclude vendor files from Jekyll when pulled via bundler. It tries to build test files, which fail.