### PR TITLE
Update uappexplorer link on frontpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ layout: default
             </ul>
 
             <div class="twelve-col">
-                <p class="complementing-note">Check out snaps on <a href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a>, or use the command line to install any of these great snaps.</p>
+                <p class="complementing-note">Check out snaps on <a href="https://uappexplorer.com/snaps">uappexplorer.com</a>, or use the command line to install any of these great snaps.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
The url for browsing snaps on uappexplorer has changed.
https://uappexplorer.com/apps?type=snappy -> https://uappexplorer.com/snaps