### PR TITLE
Front page: the easiest way to build a snap is now with build.snapcraft.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,9 +524,10 @@ Hello (beta) 1.2 installed</code></pre>
                 <h2>Get crafting!</h2>
                 <p>Snaps have a very simple internal structure — you can easily
                 craft them by hand.</p>
-                <p>But the easiest way to build a snap is with <dfn>Snapcraft</dfn>, which
+                <p>But if your code is on GitHub, the easiest way to build a snap is with <a class="external" href="https://build.snapcraft.io/">our auto-build service</a>. Every commit is auto-built, and every successful build is released to the “<code class="command-inline">edge</code>” channel.</p>
+                <p>Otherwise, you can use <dfn>Snapcraft</dfn>, which
                 allows building from source and from existing packages. Snapcraft
-                also handles publishing your snaps to the world.</p>
+                also handles releasing your snaps to the world.</p>
                 <p>Read how to create a snap and join the snap-crafting community
                 &mdash; we hang out in the <a class="external" href="https://webchat.freenode.net/?channels=snappy">#snappy channel on Freenode</a> or
                 <a href="mailto:snapcraft@lists.snapcraft.io">snapcraft@lists.snapcraft.io</a>.</p>


### PR DESCRIPTION
## Done

Expands the “Get crafting!” section so that build.snapcraft.io is now the first suggestion.

## Issue / Card

[CanonicalLtd/snapcraft-design#10](https://github.com/CanonicalLtd/snapcraft-design/issues/10): snapcraft.io - add BSI to tutorial on homepage