### PR TITLE
Put the language guides in a grid with logos

### DIFF
--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -16,6 +16,7 @@ $ubuntu-orange:    #dd4814;
 @import "base";
 @import "header";
 @import "documentation";
+@import "inline-logos";
 @import "footer";
 
 @import "command-line";


### PR DESCRIPTION
In support of https://github.com/CanonicalLtd/snappy-docs/pull/104