### PR TITLE
Redirects for docs and community

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,8 @@ metrics_query_headers = {
 }
 
 
+# Error handlers
+# ===
 @app.errorhandler(404)
 def page_not_found(error):
     """
@@ -65,6 +67,21 @@ def page_not_found(error):
     ), 404
 
 
+# Redirects
+# ===
+@app.route('/docs/', defaults={'path': ''})
+@app.route('/docs/<path:path>')
+def docs_redirect(path):
+    return flask.redirect('https://docs.snapcraft.io/' + path)
+
+
+@app.route('/community/')
+def community_redirect():
+    return flask.redirect('/')
+
+
+# Normal views
+# ===
 @app.route('/')
 def homepage():
     return flask.render_template('index.html')


### PR DESCRIPTION
Redirect /community to the homepage, as it was in the old
[snapcraft.io-static-pages repo](https://github.com/canonical-websites/snapcraft.io-static-pages/).

Redirect /docs to docs.snapcraft.io. This is in preparation for when
docs.snapcraft.io becomes the home of snapcraft docs. It won't effect
anything right now, because [kubernetes takes care of](https://github.com/canonical-webteam/k8s-deployments/blob/master/staging.snapcraft.io/snapcraft.io-ingress.yaml#L27) routing /docs to
the docs application, before it hits this application.

QA
--

Run the server in one terminal window:

``` bash
$ ./run
```

In a different terminal window, check `/community/` redirects to the 
homepage, and `/docs/some/page` redirects to `docs.snapcraft.io`:

``` bash
$ curl -sI 127.0.0.1:8022/community/ | grep Location
Location: http://127.0.0.1:8022/
$ curl -sI 127.0.0.1:8022/docs/some/page/ | grep Location
Location: https://docs.snapcraft.io/some/page/
```