### PR TITLE
Updated community links (rocket chat instead of IRC).

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
                         <a href="#nav" class="nav-toggle__link open"></a>
                         <a href="#" class="nav-toggle__link close"></a>
                     </div>
-                    
+
                     <ul>
                         <li><a href="https://build.snapcraft.io">Build</a></li>
                         <li ><a href="/docs">Docs</a></li>
@@ -590,9 +590,9 @@ Hello (beta) 1.2 installed</code></pre>
                 <p>Otherwise, you can use <dfn>Snapcraft</dfn>, which
                 allows building from source and from existing packages. Snapcraft
                 also handles releasing your snaps to the world.</p>
-                <p>Read how to create a snap and join the snap-crafting community
-                &mdash; we hang out in the <a class="external" href="https://webchat.freenode.net/?channels=snappy">#snappy channel on Freenode</a> or
-                <a href="mailto:snapcraft@lists.snapcraft.io">snapcraft@lists.snapcraft.io</a>.</p>
+                <p>Read <a href="/docs/build-snaps/your-first-snap">how to create a snap</a>,
+                join the snap-crafting community on <a href="https://forum.snapcraft.io/" class="external">our forum</a>
+                or ask questions real-time <a href="https://rocket.ubuntu.com/channel/snapcraft" class="external">on Rocket Chat</a>.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Updated 'Get crafting' paragraph with rocket chat instead of IRC

Fixes #64 

### QA

- ./run
- go to home page
- Get crafting section should contain link to rocket chat instead of IRC

<img width="731" alt="screen shot 2017-09-26 at 10 34 16" src="https://user-images.githubusercontent.com/83575/30850695-9fb28140-a2a6-11e7-81bd-8ac8b70e0ea4.png">
