### PR TITLE
Add logging to stdout/stderr production units

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ ADD . .
 RUN pip3 install -r requirements.txt
 
 # Setup commands to run server
-ENTRYPOINT ["gunicorn", "app:app", "-b"]
+ENTRYPOINT ["gunicorn", "app:app", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
 CMD ["0.0.0.0:80"]
 


### PR DESCRIPTION
QA
--

``` bash
./run build
docker build --tag snapcraft.io .
docker run -ti -p 80:80 snapcraft.io
```

Now go to <http://127.0.0.1:80>, and then check back in the terminal and see you get output telling you that `/` has been hit.