### PR TITLE
Using autoprefixer both in minified and non-minified styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
-    "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer -b 'last 2 versions' < static/css/styles.css | postcss --use cssnano > static/css/styles.min.css",
+    "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace static/css/styles.css && postcss static/css/styles.css --use cssnano > static/css/styles.min.css",
     "watch": "watch -p '_sass/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata"
   },


### PR DESCRIPTION
Updated build script to add prefixes both to `styles.css` and `styles.min.css`.

## QA

- ./run build
- both  `styles.css` and `styles.min.css` should contain browser prefixes

Or:

- ./run
- go to snap page in Chrome
- external links icon should show up properly