### PR TITLE
Fixing watch script to look at correct scss path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
     "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace static/css/styles.css && postcss static/css/styles.css --use cssnano > static/css/styles.min.css",
-    "watch": "watch -p '_sass/*.scss' -c 'yarn run build'",
+    "watch": "watch -p 'static/sass/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata"
   },
   "author": "Canonical webteam",


### PR DESCRIPTION
With update of ./run script watch task was updated and started pointing at incorrect scss folder.
This fix reverts watch script back to point to correct static/scss path.

## QA

`./run watch`

Files in static/scss should be built and watched for changes