### PR TITLE
Provide more country data to templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import humanize
 import re
 import bleach
 import urllib
+import pycountry
 from dateutil import parser, relativedelta
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
@@ -137,7 +138,24 @@ def snap_details(snap_name):
         percentages_with_nulls = country_percentages['values']
         percentages = [p for p in percentages_with_nulls if p is not None]
         average_percentage = sum(percentages) / len(percentages)
-        user_percentage_by_country[country_code] = average_percentage
+
+        try:
+            country_info = pycountry.countries.lookup(country_code)
+        except LookupError:
+            country_info = None
+
+        if country_info:
+            user_percentage_by_country[country_info.numeric] = {
+                'name': country_info.name,
+                'code': country_info.alpha_2,
+                'percentage_of_users': average_percentage
+            }
+        else:
+            user_percentage_by_country[country_code] = {
+                'name': None,
+                'code': None,
+                'percentage_of_users': average_percentage
+            }
 
     description = details['description'].strip()
     paragraphs = re.compile(r'[\n\r]{2,}').split(description)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask==0.12.2
 python-dateutil==2.6.1
 humanize==0.5.1
 requests-cache==0.4.13
+pycountry==17.9.23

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -6,9 +6,12 @@
   <!-- Illustration of country data -->
 <!--
   <table>
+    <thead>
+      <tr><th>Numeric code</th><th>Country name</th><th>Country code</th><th>Percentage of users</th></tr>
+    </thead>
     <tbody>
-      {% for country, percent in user_percentage_by_country.items() %}
-        <tr><th>{{ country }}</th><td>{{ percent }}</td></tr>
+      {% for country_numeric, info in user_percentage_by_country.items() %}
+        <tr><td>{{ country_numeric }}</td><td>{{ info.name }}</td><td>{{ info.code }}</td><td>{{ info.percentage_of_users }}</td></tr>
       {% endfor %}
     </tbody>
   </table>


### PR DESCRIPTION
Now we pass through:

``` python
{
  "{ 3-digit code }": {
    "name": "{ country name }",
    "code": "{ 2 letter code }",
    "percentage_of_users": "{ percentage of users of this snap from this country }"
  },
  ...,
  "unknown": {
    "name": None,
    "code": None,
    "percentage_of_users": "{ percentage of users without country data }"
  }
}
```

Fixes #74

QA
--

``` bash
./run
```

Now browse to <http://0.0.0.0:8022/lxd/> and view source to see the table of new country data.