### PR TITLE
Show license information

### DIFF
--- a/app.py
+++ b/app.py
@@ -204,6 +204,7 @@ def snap_details(snap_name):
         'icon_url': details['icon_url'],
         'version': details['version'],
         'revision': details['revision'],
+        'license': details['license'],
         'publisher': details['publisher'],
         'screenshot_urls': details['screenshot_urls'],
         'prices': details['prices'],

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -55,6 +55,7 @@
         <table class="p-table-key-value">
           <tr><th width="100">Version</th><td>{{ version }}</td></tr>
           <tr><th>Size</th><td>{{ filesize }}</td></tr>
+          <tr><th>License</th><td>{{ license }}</td></tr>
         </table>
       </div>
     </div>


### PR DESCRIPTION
I've just put it at the bottom of the key-value table for snap info at the moment.

However, this will need a UX review to check it's okay.

Fixes #77

QA
--

`./run`, go to e.g.: http://0.0.0.0:8022/dwarf-fortress/.

It's probably also worth trying a few different snaps just in case one of them has a long license, to see if that looks okay.

If it doesn't look okay, maybe I should comment out the template change to get this PR merged, and then let a frontender take over.