### PR TITLE
Drop links to JetBrains snaps

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -194,10 +194,10 @@
                 </li>
                 <li class="equal-height__align-vertically grid-list__item four-col last-col">
                     <div class="one-col ">
-                        <a href="/gogland"><img class="grid-list__img" src="https://assets.ubuntu.com/v1/58652d89-gogland.png" alt="icon"></a>
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/58652d89-gogland.png" alt="icon">
                     </div>
                     <div class="three-col last-col">
-                        <h3><a href="/gogland">Gogland</a></h3>
+                        <h3>Gogland</h3>
                     </div>
                 </li>
 
@@ -227,10 +227,10 @@
                 </li>
                 <li class="equal-height__align-vertically grid-list__item four-col last-row">
                     <div class="one-col ">
-                        <a href="/pycharm-professional"><img class="grid-list__img" src="https://assets.ubuntu.com/v1/8a19c654-pycharm.png" alt="icon"></a>
+                        <img class="grid-list__img" src="https://assets.ubuntu.com/v1/8a19c654-pycharm.png" alt="icon">
                     </div>
                     <div class="three-col last-col">
-                        <h3><a href="/pycharm-professional">PyCharm</a></h3>
+                        <h3>PyCharm</h3>
                     </div>
                 </li>
                 <li class="equal-height__align-vertically grid-list__item four-col last-row">


### PR DESCRIPTION
These now 404. Step one is to drop these links. A follow on PR will find apps we can link to replace these.