### PR TITLE
Make sure COMMIT_ID is an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN pip3 install gunicorn
 
 # Set git commit ID
 ARG COMMIT_ID
+ENV COMMIT_ID=${COMMIT_ID}
 RUN test -n "${COMMIT_ID}"
 
 # Import code, install code dependencies


### PR DESCRIPTION
Provide the ID of the commit at which point the code was built, as a HTTP header in the response from the docker container.

For production - so we can easily see which version of the code is running on a unit.

QA
--

``` bash
$ docker build .  # Check it complains without COMMIT_ID
The command '/bin/sh -c test -n "${COMMIT_ID}"' returned a non-zero code: 1
$ docker build --tag snapio --build-arg COMMIT_ID=`git rev-parse HEAD` .  # Build with COMMIT_ID
$ docker run --rm --name snapio-throwaway --daemonize --publish 8097:80 snapio
$ curl -I localhost:8097 | grep 'X-'
X-commit-ID: 018f47199c3709e9d0bceb33bef30546ee76e820
X-Hostname: 096dbd5ae462
$ docker kill snapio-throwaway
```