### PR TITLE
Link to docs, not tutorials.ubuntu.com, for "Learn to craft your first snap"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,7 @@
                 <p class="intro">Package any app for every Linux desktop,
                 server, cloud or device, and deliver updates directly.</p>
                 <p>
-                  <a href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap"><button class="p-button--primary" style="margin-right: 0.75rem; margin-bottom: 0.75rem;">Learn to craft your first snap</button></a> or <a href="https://build.snapcraft.io" class="external">Auto-build and publish from your GitHub repos</a>
+                  <a href="https://docs.snapcraft.io/build-snaps/"><button class="p-button--primary" style="margin-right: 0.75rem; margin-bottom: 0.75rem;">Learn to craft your first snap</button></a> or <a href="https://build.snapcraft.io" class="external">Auto-build and publish from your GitHub repos</a>
                 </p>
             </div>
             <div class="twelve-col">


### PR DESCRIPTION
Fixes #119.