### PR TITLE
Add search endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -197,7 +197,7 @@ def search_snap():
     }
 
     return flask.render_template(
-        'snap-search.html',
+        'search.html',
         **context
     )
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,27 @@
+{% extends "_layout.html" %}
+
+{% block title %}{{ snap_title }} — Linux software in the Snap Store{% endblock %}
+
+{% block content %}
+  <ul>
+  {% for snap in snaps %}
+    <li>
+      <h3>{{ snap.title }}</h1>
+      <table>
+        {% for key, value in snap.items() %}
+          <tr>
+            <th>{{ key }}</th>
+            <td>{{ value }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+    </li>
+  {% endfor %}
+
+  <nav>
+    {% if links.first %}<a href="{{ links.first }}">First</a>{% endif %}
+    {% if links.prev %}<a href="{{ links.prev }}">Previous</a>{% endif %}
+    {% if links.next %}<a href="{{ links.next }}">Next</a>{% endif %}
+    {% if links.last %}<a href="{{ links.last }}">Last</a>{% endif %}
+  </nav>
+{% endblock %}

--- a/templates/snap-search.html
+++ b/templates/snap-search.html
@@ -1,0 +1,7 @@
+{% extends "_layout.html" %}
+
+{% block title %}{{ snap_title }} — Linux software in the Snap Store{% endblock %}
+
+{% block content %}
+<div>{{ _embedded }}</div>
+{% endblock %}

--- a/templates/snap-search.html
+++ b/templates/snap-search.html
@@ -3,5 +3,5 @@
 {% block title %}{{ snap_title }} — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
-<div>{{ _embedded }}</div>
+<div>{{ links }}</div>
 {% endblock %}

--- a/templates/snap-search.html
+++ b/templates/snap-search.html
@@ -1,7 +1,0 @@
-{% extends "_layout.html" %}
-
-{% block title %}{{ snap_title }} — Linux software in the Snap Store{% endblock %}
-
-{% block content %}
-<div>{{ links }}</div>
-{% endblock %}


### PR DESCRIPTION
# Summary

Added the search endpoint on the server. It renders a temporary page that diplays a JSON of the searched result. For the moment the search response isn't modified from what I receive from the [snapcraft search API](https://search.apps.ubuntu.com/docs/#id5).

# QA

- `./run`
- http://0.0.0.0:8004/search?q=web&limit=2&offset=60
- Play with the limit and the offset (on the url :smile:) and check that the results are different.