### PR TITLE
Basic HTML for search input

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,7 @@ def search_snap():
         snaps = []
 
     context = {
+        "query": snap_searched,
         "snaps": snaps,
         "links": get_pages_details(searched_results['_links'])
     }

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,17 +3,43 @@
 {% block title %}{{ snap_title }} — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
+  <form action="/search">
+    <fieldset>
+      <label for="search-input" class="u-off-screen">Search</label>
+      <input type="search" name="q" value="{{ query }}"/>
+      <button type="submit" alt="search" class="p-button--neutral u-align--left">Search</button>
+    </fieldset>
+  </form>
+
   <ul>
   {% for snap in snaps %}
     <li>
       <h3>{{ snap.title }}</h1>
       <table>
-        {% for key, value in snap.items() %}
-          <tr>
-            <th>{{ key }}</th>
-            <td>{{ value }}</td>
-          </tr>
-        {% endfor %}
+        <tr>
+          <th>Summary</th>
+          <td>{{ snap.summary }}</td>
+        </tr>
+        <tr>
+          <th>Description</th>
+          <td>{{ snap.description }}</td>
+        </tr>
+        <tr>
+          <th>Publisher</th>
+          <td>{{ snap.publisher }}</td>
+        </tr>
+        <tr>
+          <th>Package name</th>
+          <td>{{ snap.package_name }}</td>
+        </tr>
+        {% if snap.icon_url %}
+        <tr>
+          <th>Icon</th>
+          <td>
+              <img src="{{ snap.icon_url }}" alt="" />
+          </td>
+        </tr>
+        {% endif %}
       </table>
     </li>
   {% endfor %}


### PR DESCRIPTION
Fixes #107 

Added basic HTML for search input and only showing useful info in search results.

### QA

- ./run serve
- Go to http://localhost:8022/search?q=core
- Use search input to search for something else

<img width="892" alt="screen shot 2017-11-10 at 16 16 13" src="https://user-images.githubusercontent.com/83575/32664849-c1b58be8-c632-11e7-92d5-53a1b2c01d04.png">
