### PR TITLE
Added Vanilla styling to search form, improved styles of results.

### DIFF
--- a/static/sass/_search-form.scss
+++ b/static/sass/_search-form.scss
@@ -1,0 +1,9 @@
+@mixin search-form {
+  .p-form--search {
+    width: 100%;
+
+    .p-form__group {
+      flex-grow: 1;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -35,3 +35,6 @@
 
 @import 'map';
 @include snap-details-map;
+
+@import 'search-form';
+@include search-form;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -19,6 +19,7 @@
 @include vf-u-margin-collapse;
 @include vf-u-padding-collapse;
 @include vf-u-align;
+@include vf-p-forms;
 
 @import 'patterns_inline-list--compact';
 @include p-inline-list--compact;

--- a/templates/search.html
+++ b/templates/search.html
@@ -48,7 +48,7 @@
 
                 <div class="p-media-object__details">
                   <h3 class="p-media-object__title">
-                    <a href="#">{{ snap.title }}</a>
+                    <a href="/{{ snap.package_name }}">{{ snap.title }}</a>
                   </h3>
                   <p class="p-media-object__content"><a href="/{{ snap.package_name }}">https://snapcraft.io/{{ snap.package_name }}</a></p>
                   <p class="p-media-object__content">{{ snap.summary }}</p>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,6 +1,13 @@
 {% extends "_layout.html" %}
 
-{% block title %}Snap search results for "{{ query }}" — Linux software in the Snap Store{% endblock %}
+{% block title %}
+  {% if query %}
+    Snap search results for "{{ query }}"
+  {% else %}
+    Search Snap Store
+  {% endif %}
+  — Linux software in the Snap Store
+{% endblock %}
 
 {% block content %}
   <section id="main-content" class="p-strip is-shallow">

--- a/templates/search.html
+++ b/templates/search.html
@@ -22,8 +22,8 @@
   <section class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-12">
-        <form action="/search" class="p-form p-form--inline" style="width: 100%">
-          <div class="p-form__group" style="flex-grow: 1;">
+        <form action="/search" class="p-form p-form--inline p-form--search">
+          <div class="p-form__group">
             <label for="search-input" class="u-off-screen">Search</label>
             <input id="search-input" type="search" name="q" value="{{ query }}" class="p-form__control"/>
           </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,21 +3,37 @@
 {% block title %}Snap search results for "{{ query }}" — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
-  <section class="p-strip is-shallow">
+  <section id="main-content" class="p-strip is-shallow">
     <div class="row">
       <div class="col-12">
-        <form action="/search">
-          <fieldset>
+        {% if query %}
+          {% if snaps %}
+            <h1>We’ve found some snaps for "{{ query }}"</h1>
+          {% else %}
+            <h1>Sorry, we couldn’t find "{{ query }}"</h1>
+          {% endif %}
+        {% else %}
+          <h1>Search Snap Store</h1>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-12">
+        <form action="/search" class="p-form p-form--inline" style="width: 100%">
+          <div class="p-form__group" style="flex-grow: 1;">
             <label for="search-input" class="u-off-screen">Search</label>
-            <input type="search" name="q" value="{{ query }}"/>
+            <input id="search-input" type="search" name="q" value="{{ query }}" class="p-form__control"/>
+          </div>
             <button type="submit" alt="search" class="p-button--neutral u-align--left">Search</button>
-          </fieldset>
         </form>
       </div>
     </div>
   </section>
 
-  <section class="p-strip">
+  <section class="p-strip is-shallow">
     <div class="row">
       <div class="col-8">
         <ul class="p-list">
@@ -36,7 +52,7 @@
                   </h3>
                   <p class="p-media-object__content"><a href="/{{ snap.package_name }}">https://snapcraft.io/{{ snap.package_name }}</a></p>
                   <p class="p-media-object__content">{{ snap.summary }}</p>
-                  <p class="p-media-object__content">{{ snap.description }}</p>
+                  <p class="p-media-object__content">{{ snap.description | truncate(200) }}</p>
                   <ul class="p-media-object__meta-list">
                     <li class="p-media-object__meta-list-item">
                       <span class="u-off-screen">Publisher: </span>{{ snap.publisher }}
@@ -52,13 +68,13 @@
   </section>
 
   {% if links %}
-  <section class="p-strip">
+  <section class="p-strip is-shallow">
     <nav class="row">
-      <div class="col-6 u-align--left">
+      <div class="col-6 prefix-1 u-align--left">
         {% if links.first %}<a href="{{ links.first }}">&#171;&nbsp;First</a>&nbsp;{% endif %}
         {% if links.prev %}<a href="{{ links.prev }}">&#8249;&nbsp;Previous</a>{% endif %}
       </div>
-      <div class="col-6 u-align--right">
+      <div class="col-6 suffix-1 u-align--right">
         {% if links.next %}<a href="{{ links.next }}">Next&nbsp;&#8250;</a>{% endif %}
         {% if links.last %}&nbsp;<a href="{{ links.last }}">Last&nbsp;&#187;</a>{% endif %}
       </div>


### PR DESCRIPTION
Fixes #109 

Done:
- added Vanilla form styling to search input
- truncating snap descriptions to 200 characters
- improved pagination styling

QA:
- ./run
- go to search page: http://localhost:8004/search
- search with results: http://localhost:8004/search?q=gnome
- search without results: http://localhost:8004/search?q=nothing

Or try demo at: http://snapcraft.io-pr-142.run.demo.haus/search

<img width="1055" alt="screen shot 2017-11-14 at 15 08 19" src="https://user-images.githubusercontent.com/83575/32784270-a4ddd29a-c94e-11e7-9907-470deeed8f5d.png">
<img width="1031" alt="screen shot 2017-11-14 at 15 08 32" src="https://user-images.githubusercontent.com/83575/32784269-a4aa906a-c94e-11e7-81ab-d66e42c65a54.png">
 <img width="1037" alt="screen shot 2017-11-14 at 15 08 51" src="https://user-images.githubusercontent.com/83575/32784268-a44c9122-c94e-11e7-85a3-abd5e13e20b5.png">