### PR TITLE
Removes URL and moves publisher up in snap search results.

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -57,14 +57,13 @@
                   <h3 class="p-media-object__title">
                     <a href="/{{ snap.package_name }}">{{ snap.title }}</a>
                   </h3>
-                  <p class="p-media-object__content"><a href="/{{ snap.package_name }}">https://snapcraft.io/{{ snap.package_name }}</a></p>
-                  <p class="p-media-object__content">{{ snap.summary }}</p>
-                  <p class="p-media-object__content">{{ snap.description | truncate(200) }}</p>
-                  <ul class="p-media-object__meta-list">
+                  <ul class="p-media-object__meta-list u-no-margin">
                     <li class="p-media-object__meta-list-item">
                       <span class="u-off-screen">Publisher: </span>{{ snap.publisher }}
                     </li>
                   </ul>
+                  <p class="p-media-object__content">{{ snap.summary }}</p>
+                  <p class="p-media-object__content">{{ snap.description | truncate(200) }}</p>
                 </div>
               </div>
             </li>


### PR DESCRIPTION
Fixes #147

As discussed on review meeting:
- removed URL from under snap name
- moved publisher info up under snap name

<img width="895" alt="screen shot 2017-11-20 at 12 35 53" src="https://user-images.githubusercontent.com/83575/33017079-45d00820-cdf1-11e7-858c-afcc53e6c217.png">

QA:

Go to: http://snapcraft.io-pr-149.run.demo.haus/search?q=phone
- in search results under snap name there should be a publisher name (not linked URL)
