### PR TITLE
Adds sticky footer pattern

### DIFF
--- a/static/sass/_patterns_sticky_footer.scss
+++ b/static/sass/_patterns_sticky_footer.scss
@@ -1,0 +1,15 @@
+@mixin p-sticky-footer {
+  .p-sticky-footer {
+    margin-top: auto;
+  }
+
+  html,
+  body {
+    height: 100%;
+  }
+
+  .has-sticky-footer {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -38,3 +38,6 @@
 
 @import 'search-form';
 @include search-form;
+
+@import 'patterns_sticky_footer';
+@include p-sticky-footer;

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -17,7 +17,7 @@
     <!-- End Google Tag Manager -->
   </head>
 
-  <body>
+  <body class="has-sticky-footer">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KCGXHQS"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -37,7 +37,7 @@
 
     {% block content %}{% endblock %}
 
-    <div class="p-strip--light u-no-padding">
+    <div class="p-strip--light u-no-padding p-sticky-footer">
       <footer class="p-footer u-no-margin--top">
         <div class="row">
           <div class="col-6">


### PR DESCRIPTION
Fixes #146 

Adds new pattern to make footer stick to the bottom of the page when there is little content on the page.

QA:
Go to:
http://snapcraft.io-pr-151.run.demo.haus/search
or
http://snapcraft.io-pr-151.run.demo.haus/core/

Footer should be at the bottom of the screen.

![screen shot 2017-11-21 at 13 16 40](https://user-images.githubusercontent.com/83575/33072063-46e04b9e-cebe-11e7-8504-fc63069ed084.png)
![screen shot 2017-11-21 at 13 16 32](https://user-images.githubusercontent.com/83575/33072064-46f63d96-cebe-11e7-8eb4-9b5f335acef3.png)
