### PR TITLE
Adds map back to snap details page

### DIFF
--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -45,14 +45,12 @@
         </table>
       </div>
     </div>
-    {# bartaz: hiding map until we get correct data from API
     <div class="row" style="margin-top: 2rem">
       <div class="col-12">
         <h4>Where people are using {{ snap_title }}</h4>
         <div id="js-snap-map" class="map"></div>
       </div>
     </div>
-    #}
   </div>
 
 
@@ -70,7 +68,6 @@
 {% endblock %}
 
 {% block scripts %}
-  {# bartaz: hiding map until we get correct data from API
   <script src="/static/js/modules/d3.min.js"></script>
   <script src="/static/js/modules/d3-geo.min.js"></script>
   <script src="/static/js/modules/topojson-client.min.js"></script>
@@ -80,5 +77,4 @@
   <script>
     renderMap('#js-snap-map', {{ countries|tojson }});
   </script>
-  #}
 {% endblock %}


### PR DESCRIPTION
Fixes #153 

Brings the map back to snap details page.

### QA:

Go to any snap page:
http://snapcraft.io-pr-154.run.demo.haus/core/
http://snapcraft.io-pr-154.run.demo.haus/gnome-calculator/

Map should be shown.