### PR TITLE
Accept /discover with or without slash

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,7 +168,7 @@ def homepage():
     return flask.render_template('index.html')
 
 
-@app.route('/discover')
+@app.route('/discover/')
 def discover():
     return flask.render_template('discover.html')
 


### PR DESCRIPTION
In Flash, if you define a route as `/something` it will *only* apply
*without* the slash.

If you define it as `/something/` (with a slash on the end) it will
redirect /something -> /something/. This is what we want in most cases,
and in this case.

QA
--

``` bash
$ ./run serve --detach
$ curl -I http://127.0.0.1:8004/discover/
HTTP/1.0 200OK
...
```