### PR TITLE
Update the Vanilla dependency to v.1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
     "topojson-client": "^3.0.0",
-    "vanilla-framework": "^1.6.2",
+    "vanilla-framework": "^1.6.3",
     "watch-cli": "^0.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,9 +3091,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.2.tgz#fbff4d785f62c7470ade935a5a1b7d1d8c84ba66"
+vanilla-framework@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.3.tgz#92271d5dc765d7563659684ed4797e3919160f01"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Done
Update the Vanilla dependency to v.1.6.3

## QA
- I struggled to get this site to run well on my machine
- After running `./run` the minified file is not created and have a different filename (index.css vs styles.css)
@bartaz @nottrobin do you know why?

Fixes https://github.com/vanilla-framework/vanilla-framework/issues/1470