### PR TITLE
Discover featured snaps

### DIFF
--- a/app.py
+++ b/app.py
@@ -194,7 +194,11 @@ def homepage():
 
 @app.route('/index2')
 def new_homepage():
-    return flask.render_template('index2.html', now=datetime.datetime.utcnow())
+    return flask.render_template(
+        'index2.html',
+        featured_snaps=get_featured_snaps(),
+        now=datetime.datetime.utcnow()
+    )
 
 
 @app.route('/discover/')

--- a/templates/discover.html
+++ b/templates/discover.html
@@ -25,7 +25,36 @@
     </div>
   </section>
 
-  <!--
-    {{ featured_snaps }}
-  -->
+  <section class="p-strip is-deep is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <h2>Featured snaps</h2>
+      </div>
+    </div>
+    <div class="row">
+      {% for snap in featured_snaps %}
+        <div class="col-3">
+          <div class="p-heading-icon">
+            <div class="p-heading-icon__header">
+              <a class="p-heading-icon__img" href="/{{ snap.package_name }}">
+                {% if snap.icon_url %}
+                  <img src="{{ snap.icon_url }}" alt="">
+                {% else %}
+                  <img src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="">
+                {% endif %}
+              </a>
+              <h5 class="u-no-margin"><a href="/{{ snap.package_name }}">{{ snap.title }}</a></h5>
+            </div>
+          </div>
+        </div>
+
+        {# end the row after every 4th snap #}
+        {% if (loop.index % 4 == 0) and not loop.last %}
+          </div>
+          <div class="row">
+        {% endif %}
+
+      {% endfor %}
+    </div>
+  </section>
 {% endblock %}

--- a/templates/discover.html
+++ b/templates/discover.html
@@ -39,7 +39,7 @@
               {% if snap.icon_url %}
                 <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
               {% else %}
-                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="">
+                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
               {% endif %}
               <h5 class="u-no-margin">{{ snap.title }}</h5>
             </a>

--- a/templates/discover.html
+++ b/templates/discover.html
@@ -35,16 +35,14 @@
       {% for snap in featured_snaps %}
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/{{ snap.package_name }}">
-                {% if snap.icon_url %}
-                  <img src="{{ snap.icon_url }}" alt="">
-                {% else %}
-                  <img src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="">
-                {% endif %}
-              </a>
-              <h5 class="u-no-margin"><a href="/{{ snap.package_name }}">{{ snap.title }}</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/{{ snap.package_name }}">
+              {% if snap.icon_url %}
+                <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
+              {% else %}
+                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="">
+              {% endif %}
+              <h5 class="u-no-margin">{{ snap.title }}</h5>
+            </a>
           </div>
         </div>
 

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -292,84 +292,68 @@
       <div class="row">
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/atom">
-                <img src="https://assets.ubuntu.com/v1/694b2e80-atom.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/atom">Atom</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/atom">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/694b2e80-atom.png" alt="" />
+              <h5 class="u-no-margin">Atom</h5>
+            </a>
           </div>
         </div>
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/brackets">
-                <img src="https://assets.ubuntu.com/v1/7a350f60-brackets.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/brackets">Brackets</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/brackets">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/7a350f60-brackets.png" alt="" />
+              <h5 class="u-no-margin">Brackets</h5>
+            </a>
           </div>
         </div>
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/discord">
-                <img src="https://assets.ubuntu.com/v1/cbb032ba-discord.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/discord">Discord</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/discord">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/cbb032ba-discord.png" alt="" />
+              <h5 class="u-no-margin">Discord</h5>
+            </a>
           </div>
         </div>
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/go">
-                <img src="https://assets.ubuntu.com/v1/b3e93ee1-golang.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/go">Golang</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/go">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b3e93ee1-golang.png" alt="" />
+              <h5 class="u-no-margin">Golang</h5>
+            </a>
           </div>
         </div>
       </div>
       <div class="row">
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/heroku">
-                <img src="https://assets.ubuntu.com/v1/7b67962b-heroku.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/heroku">Heroku</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/heroku">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/7b67962b-heroku.png" alt="" />
+              <h5 class="u-no-margin">Heroku</h5>
+            </a>
           </div>
         </div>
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/hiri">
-                <img src="https://assets.ubuntu.com/v1/3add0342-hiri.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/hiri">Hiri</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/hiri">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/3add0342-hiri.png" alt="" />
+              <h5 class="u-no-margin">Hiri</h5>
+            </a>
           </div>
         </div>
         <div class="col-3">
           <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/teleconsole">
-                <img src="https://assets.ubuntu.com/v1/5b323b7b-teleconsole.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/teleconsole">Teleconsole</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/teleconsole">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5b323b7b-teleconsole.png" alt="" />
+              <h5 class="u-no-margin">Teleconsole</h5>
+            </a>
           </div>
         </div>
         <div class="col-3">
           <div class="p-heading-icon">
-            <div href="/wavebox" class="p-heading-icon__header">
-              <a class="p-heading-icon__img" href="/wavebox">
-                <img src="https://assets.ubuntu.com/v1/6e8ec552-wavebox.png" alt="" />
-              </a>
-              <h5 class="u-no-margin"><a href="/wavebox">Wavebox</a></h5>
-            </div>
+            <a class="p-heading-icon__header" href="/wavebox">
+              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6e8ec552-wavebox.png" alt="" />
+              <h5 class="u-no-margin">Wavebox</h5>
+            </a>
           </div>
         </div>
       </div>

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -290,72 +290,27 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/atom">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/694b2e80-atom.png" alt="" />
-              <h5 class="u-no-margin">Atom</h5>
-            </a>
+        {% for snap in featured_snaps %}
+          <div class="col-3">
+            <div class="p-heading-icon">
+              <a class="p-heading-icon__header" href="/{{ snap.package_name }}">
+                {% if snap.icon_url %}
+                  <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
+                {% else %}
+                  <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="">
+                {% endif %}
+                <h5 class="u-no-margin">{{ snap.title }}</h5>
+              </a>
+            </div>
           </div>
-        </div>
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/brackets">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/7a350f60-brackets.png" alt="" />
-              <h5 class="u-no-margin">Brackets</h5>
-            </a>
-          </div>
-        </div>
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/discord">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/cbb032ba-discord.png" alt="" />
-              <h5 class="u-no-margin">Discord</h5>
-            </a>
-          </div>
-        </div>
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/go">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/b3e93ee1-golang.png" alt="" />
-              <h5 class="u-no-margin">Golang</h5>
-            </a>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/heroku">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/7b67962b-heroku.png" alt="" />
-              <h5 class="u-no-margin">Heroku</h5>
-            </a>
-          </div>
-        </div>
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/hiri">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/3add0342-hiri.png" alt="" />
-              <h5 class="u-no-margin">Hiri</h5>
-            </a>
-          </div>
-        </div>
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/teleconsole">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5b323b7b-teleconsole.png" alt="" />
-              <h5 class="u-no-margin">Teleconsole</h5>
-            </a>
-          </div>
-        </div>
-        <div class="col-3">
-          <div class="p-heading-icon">
-            <a class="p-heading-icon__header" href="/wavebox">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6e8ec552-wavebox.png" alt="" />
-              <h5 class="u-no-margin">Wavebox</h5>
-            </a>
-          </div>
-        </div>
+
+          {# end the row after every 4th snap #}
+          {% if (loop.index % 4 == 0) and not loop.last %}
+            </div>
+            <div class="row">
+          {% endif %}
+
+        {% endfor %}
       </div>
     </div>
 

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -297,7 +297,7 @@
                 {% if snap.icon_url %}
                   <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
                 {% else %}
-                  <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="">
+                  <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
                 {% endif %}
                 <h5 class="u-no-margin">{{ snap.title }}</h5>
               </a>

--- a/templates/search.html
+++ b/templates/search.html
@@ -46,7 +46,7 @@
               {% if snap.icon_url %}
                 <img src="{{ snap.icon_url }}" class="p-media-object__image" alt="">
               {% else %}
-                <img src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" class="p-media-object__image" alt="">
+                <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-media-object__image" alt="">
               {% endif %}
 
               <div class="p-media-object__details">

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -10,7 +10,7 @@
           {% if icon_url %}
             <img class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
           {% else %}
-            <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/610689b1-default-package-icon.svg" alt="" />
+            <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
           {% endif %}
           <div class="p-media-object__details">
             <h1>{{ snap_title }}</h1>


### PR DESCRIPTION
Adds featured snaps from store API to discover page.
Also updates featured snaps on home page to make them clickable as a whole block.

Fixes #162 

### QA

- ./run
- Go to http://localhost:8004/discover
- Featured snaps should be shown

Or: http://snapcraft.io-pr-166.run.demo.haus/discover/

<img width="1027" alt="screen shot 2017-12-05 at 13 16 41" src="https://user-images.githubusercontent.com/83575/33606686-9b41dc60-d9be-11e7-8361-ce91b6b470eb.png">
