### PR TITLE
Average map data over a week

### DIFF
--- a/app.py
+++ b/app.py
@@ -249,7 +249,7 @@ def snap_details(snap_name):
     with appropriate sanitation.
     """
     today = datetime.datetime.utcnow().date()
-    month_ago = today - relativedelta.relativedelta(months=1)
+    week_ago = today - relativedelta.relativedelta(weeks=1)
 
     details_response = _get_from_cache(
         snap_details_url.format(snap_name=snap_name),
@@ -271,7 +271,7 @@ def snap_details(snap_name):
         {
             "metric_name": "installed_base_by_country_percent",
             "snap_id": details['snap_id'],
-            "start": month_ago.strftime('%Y-%m-%d'),
+            "start": week_ago.strftime('%Y-%m-%d'),
             "end": today.strftime('%Y-%m-%d')
         }
     ]


### PR DESCRIPTION
The map was previously showing usage averaged over the preceding month.
@cprov was concerned that this might not show fresh enough data for new
snaps, so I'm changing it to show an average over the last week.

Fixes #167

QA
--

``` bash
./run
```

go to e.g. <http://0.0.0.0:8004/lxd/> and check the map still works.

Try to find cases of fairly new snaps where the data looks different than on live. Or if you can't find any, just trust that it's working ;)