### PR TITLE
Replace Elementary with .NET quote

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -229,8 +229,8 @@
         </div>
         <div class="col-4">
           <blockquote class="p-testimonial">
-            <p class="p-heading--five">The format isolation allows for less opportunity to break the system or otherwise force abandonment – you can use newer libraries than the system offers without altering the base.</p>
-            <cite class="p-testimonial--citation p-heading--five">Daniel Fore, Founder, <a href="https://elementary.io" class="p-link--external">Elementary</a></cite>
+            <p class="p-heading--five">We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication.</p>
+            <cite class="p-testimonial--citation p-heading--five">Lee Coward and Rakesh Singh, <a href="https://www.microsoft.com/net/" class="p-link--external">.NET (Microsoft)</a></cite>
           </blockquote>
         </div>
         <div class="col-4">


### PR DESCRIPTION
snapcraft.io was deployed with the wrong set of quotes. [The spec has](https://docs.google.com/document/d/1f0JLEcM3d9eAbM-adKaN96E9wWYGCyUSsmjQDbTa0l8/edit) Heroku, .NET, and Sea Machines.

This branch fixes it:
<img width="1012" alt="screen shot 2017-12-13 at 12 47 45" src="https://user-images.githubusercontent.com/1523179/33939752-3d930638-e004-11e7-897d-2337ac23688b.png">
