### PR TITLE
Match the spec by pointing at the language guides

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,7 @@
         <div class="col-12">
           <p class="p-heading--two">Package, distribute, and update any app for Linux and IoT</p>
           <p class="p-heading--five">Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.</p>
-          <a href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap" class="p-button--positive">Build your first snap</a>
+          <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Build your first snap</a>
           <a href="https://build.snapcraft.io" class="p-button--neutral">Get started using GitHub</a>
         </div>
       </div>


### PR DESCRIPTION
[The spec](https://docs.google.com/document/d/1f0JLEcM3d9eAbM-adKaN96E9wWYGCyUSsmjQDbTa0l8/edit) has the language guides as the target for the main call to action. However, the site currently points at tutorials.ubuntu.com (which tells them to install Ubuntu Core, amongst other erroneous things).

This branch fixes the CTA to point at the language guides.