### PR TITLE
Adds "Why use snaps?" section to discover page.

### DIFF
--- a/templates/discover.html
+++ b/templates/discover.html
@@ -55,4 +55,26 @@
       {% endfor %}
     </div>
   </section>
+
+  <section class="p-strip is-deep is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <h2>Why use snaps?</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-4">
+        <h3>Quick to install</h3>
+        <p>Snaps are self-contained, separate from the system. No complex dependencies, and no interfering with each other. Whichever system you’re running, a snap will work the same way.</p>
+      </div>
+      <div class="col-4">
+        <h3>Safe to run</h3>
+        <p>Not only are snaps kept separate, their data is kept separate too. Snaps communicate with each other only in ways that you approve.</p>
+      </div>
+      <div class="col-4">
+        <h3>Easy to update</h3>
+        <p>Updates are automatic, and download only what’s changed. You can test alphas/betas if you want, switching back to stable at any time. And any update can be reversed.</p>
+      </div>
+    </div>
+  </section>
 {% endblock %}


### PR DESCRIPTION
Fixes #163

Adds "Why use snaps?" section to discover page.

Copy doc: https://docs.google.com/document/d/1ZSlu1S8qgiXoL8p95smo7ZWaAkTxlems8NANsk2w30k/edit
Visual design: https://github.com/canonicalltd/snapcraft-design/issues/197#issuecomment-351370582

### QA:

- ./run serve
- go to https://localhost:8004/discover
- "Why use snaps?" section should be visible in the bottom of the page


or http://snapcraft.io-pr-184.run.demo.haus/discover

<img width="1078" alt="screen shot 2017-12-13 at 14 15 42" src="https://user-images.githubusercontent.com/83575/33940792-b38289e8-e010-11e7-8fb7-55c075094c7d.png">
