### PR TITLE
Fixes copyright notice in footer of directory page layout.

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,6 +92,17 @@ def get_featured_snaps():
     return get_searched_snaps(featured_response.json())
 
 
+# Context processors
+# ===
+@app.context_processor
+def inject_datetime():
+    """
+    Adds current date to all the templates, so we can display
+    current year in the footer copyright disclaimer.
+    """
+    return dict(now=datetime.datetime.utcnow())
+
+
 # Error handlers
 # ===
 @app.errorhandler(404)
@@ -191,8 +202,7 @@ def get_pages_details(links):
 def homepage():
     return flask.render_template(
         'index.html',
-        featured_snaps=get_featured_snaps(),
-        now=datetime.datetime.utcnow()
+        featured_snaps=get_featured_snaps()
     )
 
 

--- a/app.py
+++ b/app.py
@@ -92,17 +92,6 @@ def get_featured_snaps():
     return get_searched_snaps(featured_response.json())
 
 
-# Context processors
-# ===
-@app.context_processor
-def inject_datetime():
-    """
-    Adds current date to all the templates, so we can display
-    current year in the footer copyright disclaimer.
-    """
-    return dict(now=datetime.datetime.utcnow())
-
-
 # Error handlers
 # ===
 @app.errorhandler(404)

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -41,7 +41,7 @@
       <footer class="p-footer u-no-margin--top">
         <div class="row">
           <div class="col-6">
-            <p>&copy; {{ now.year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+            <p>&copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
 
             <nav class="u-no-margin">
               <ul class="p-footer__links">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -41,7 +41,7 @@
       <footer class="p-footer u-no-margin--top">
         <div class="row">
           <div class="col-6">
-            <p>Directory &copy; 2017 Canonical Ltd.</p>
+            <p>&copy; {{ now.year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
 
             <nav class="u-no-margin">
               <ul class="p-footer__links">

--- a/templates/index.html
+++ b/templates/index.html
@@ -331,7 +331,7 @@
     <footer class="p-footer p-strip--light">
       <div class="row">
         <div class="col-8">
-          <p>&copy; {{ now.year }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+          <p>&copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
           <p>Powered by <a href="https://www.ubuntu.com/kubernetes">the Canonical Distribution of Kubernetes</a></p>
           <p>
             <a class="p-link--external" href="https://github.com/snapcore/snapcraft">Fork Snapcraft on GitHub</a>


### PR DESCRIPTION
Updates footer copyright notice on directory pages (discover, search, snap details) so it contains full copyright of Canonical and Ubuntu.

<img width="1067" alt="screen shot 2017-12-13 at 13 32 11" src="https://user-images.githubusercontent.com/83575/33941389-5ad3ed9c-e00a-11e7-9f01-d55ad3ff87fd.png">

### QA

- ./run serve
- go to http://localhost:8004/discover http://localhost:8004/lxd
- footer should contain "© 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd."