### PR TITLE
Add missing language guides to the front page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -174,11 +174,29 @@
       </div>
       <div class="row">
         <div class="col-12 p-logo-links">
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/python">
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/pre-built">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/27e2a770-logo-python.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/4890ee03-icon-prepackaged-apps.png" alt=""/>
             </header>
-            <p class="u-no-margin">Python</p>
+            <p class="u-no-margin">Pre-built apps</p>
+          </a>
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/c">
+            <header class="p-card__header">
+              <img src="https://assets.ubuntu.com/v1/485f8203-cpp_logo.png" alt=""/>
+            </header>
+            <p class="u-no-margin">C/C++</p>
+          </a>
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/go">
+            <header class="p-card__header">
+              <img src="https://assets.ubuntu.com/v1/53990c77-logo-go.png" alt=""/>
+            </header>
+            <p class="u-no-margin">Go</p>
+          </a>
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/java">
+            <header class="p-card__header">
+              <img src="https://assets.ubuntu.com/v1/9c609032-150px-Java_logo.png" alt=""/>
+            </header>
+            <p class="u-no-margin">Java</p>
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/node">
             <header class="p-card__header">
@@ -186,11 +204,29 @@
             </header>
             <p class="u-no-margin">Node.js</p>
           </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/go">
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/electron">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/53990c77-logo-go.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/c8a76d95-electron.svg" alt=""/>
             </header>
-            <p class="u-no-margin">Go</p>
+            <p class="u-no-margin">Electron</p>
+          </a>
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/python">
+            <header class="p-card__header">
+              <img src="https://assets.ubuntu.com/v1/27e2a770-logo-python.png" alt=""/>
+            </header>
+            <p class="u-no-margin">Python</p>
+          </a>
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ruby">
+            <header class="p-card__header">
+              <img src="https://assets.ubuntu.com/v1/e6bb225e-ruby-logo.png" alt=""/>
+            </header>
+            <p class="u-no-margin">Ruby</p>
+          </a>
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/rust">
+            <header class="p-card__header">
+              <img src="https://assets.ubuntu.com/v1/a1303290-rust.png" alt=""/>
+            </header>
+            <p class="u-no-margin">Rust</p>
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/moos">
             <header class="p-card__header">
@@ -204,11 +240,11 @@
             </header>
             <p class="u-no-margin">ROS</p>
           </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/pre-built">
+          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros2">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/4890ee03-icon-prepackaged-apps.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/9b32c9a4-3979232.png" alt=""/>
             </header>
-            <p class="u-no-margin">Pre-built apps</p>
+            <p class="u-no-margin">ROS 2</p>
           </a>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -182,7 +182,7 @@
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/c">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/485f8203-cpp_logo.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/ae5902bf-logo-cpp.png" alt=""/>
             </header>
             <p class="u-no-margin">C/C++</p>
           </a>
@@ -194,7 +194,7 @@
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/java">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/9c609032-150px-Java_logo.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/4fb34568-logo-java.png" alt=""/>
             </header>
             <p class="u-no-margin">Java</p>
           </a>
@@ -206,7 +206,7 @@
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/electron">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/c8a76d95-electron.svg" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/6ee78042-logo-electron.png" alt=""/>
             </header>
             <p class="u-no-margin">Electron</p>
           </a>
@@ -218,13 +218,13 @@
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ruby">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/e6bb225e-ruby-logo.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/1ce42763-logo-ruby.png" alt=""/>
             </header>
             <p class="u-no-margin">Ruby</p>
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/rust">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/a1303290-rust.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/387bfca8-logo-rust.png" alt=""/>
             </header>
             <p class="u-no-margin">Rust</p>
           </a>
@@ -242,7 +242,7 @@
           </a>
           <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros2">
             <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/9b32c9a4-3979232.png" alt=""/>
+              <img src="https://assets.ubuntu.com/v1/788b4b66-logo-ros2.png" alt=""/>
             </header>
             <p class="u-no-margin">ROS 2</p>
           </a>


### PR DESCRIPTION
<img width="1019" alt="screen shot 2017-12-13 at 14 19 34" src="https://user-images.githubusercontent.com/1523179/33943443-0780e72e-e011-11e7-8a89-b3fa9e343291.png">

This branch adds the missing language guides to the front page.