### PR TITLE
Say language or framework, not just language (covers ROS, Electron, etc)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -168,8 +168,8 @@
     <div class="p-strip is-deep is-bordered">
       <div class="row">
         <div class="col-12">
-          <h2>Snapcraft integrates with your language</h2>
-          <p class="p-heading--five">See how Snapcraft works with your language to make packaging and installing your software easy.</p>
+          <h2>Snapcraft integrates with your tools</h2>
+          <p class="p-heading--five">See how Snapcraft works with your language or framework to make packaging and installing your software easy.</p>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
<img width="721" alt="screen shot 2017-12-13 at 14 31 13" src="https://user-images.githubusercontent.com/1523179/33943932-76402ac0-e012-11e7-903e-1d56b1e37d59.png">

Suggestion from @jamiebennett. Say "language or framework" instead of "language" as we have guides for Electron, MOOS, ROS, and ROS 2.