### PR TITLE
Adds a channel badge to snap details page.

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ request_timeout = 2
 # Request only stable snaps
 snap_details_url = (
     "https://api.snapcraft.io/api/v1/snaps/details/{snap_name}"
-    "?channel=stable"
+    "?channel="
 )
 details_query_headers = {
     'X-Ubuntu-Series': '16',
@@ -338,6 +338,7 @@ def snap_details(snap_name):
         'icon_url': details['icon_url'],
         'version': details['version'],
         'revision': details['revision'],
+        'channel': details['channel'],
         'license': details['license'],
         'publisher': details['publisher'],
         'screenshot_urls': details['screenshot_urls'],

--- a/static/sass/_snapcraft_channel.scss
+++ b/static/sass/_snapcraft_channel.scss
@@ -1,0 +1,33 @@
+@mixin snapcraft-channel {
+
+  %p-snap-channel {
+    position: relative;
+
+    &::after {
+      background: $color-snapcraft-light;
+      border-radius: 2px;
+      font-size: 1rem;
+      left: 100%;
+      margin-left: $sp-x-small;
+      padding: $sp-xx-small $sp-x-small;
+      position: absolute;
+      top: 0;
+    }
+  }
+
+  .p-snap-channel--beta {
+    @extend %p-snap-channel;
+
+    &::after {
+      content: 'Beta';
+    }
+  }
+
+  .p-snap-channel--candidate {
+    @extend %p-snap-channel;
+
+    &::after {
+      content: 'Preview';
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -2,6 +2,8 @@
 $color-brand: #00302f; // TODO: this is a temprary brand colour
 $color-accent: $color-brand;
 
+$color-snapcraft-light: #c0dfd0;
+
 // vanilla patterns
 @import 'vanilla-framework/scss/vanilla';
 
@@ -83,3 +85,6 @@ $color-accent: $color-brand;
 
 @import 'snapcraft_custom-typography';
 @include snapcraft-custom-typography;
+
+@import 'snapcraft_channel';
+@include snapcraft-channel;

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -13,7 +13,7 @@
             <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
           {% endif %}
           <div class="p-media-object__details">
-            <h1>{{ snap_title }}</h1>
+            <h1><span class="{% if channel == 'beta' %}p-snap-channel--beta{% endif %} {% if channel == 'candidate' %}p-snap-channel--candidate{% endif %}">{{ snap_title }}</span></h1>
             <p class="p-media-object__content--large">{{ publisher }}</p>
 
             <p class="p-media-object__content--large">


### PR DESCRIPTION
Fixes #145

Adds channel badge to snap details page.

### QA

- ./run
- go to snap details page of a snap in beta or candidate
- badge saying 'Beta' or 'Preview' should appear

Some examples (these may stop working if new revisions are released to channels by publishers):
Example stable snap (no badge): http://snapcraft.io-pr-193.run.demo.haus/phpstorm/
Example 'beta' snap: http://snapcraft.io-pr-193.run.demo.haus/webstorm/
Example 'preview' snap: http://snapcraft.io-pr-193.run.demo.haus/brave/

<img width="635" alt="screen shot 2017-12-19 at 14 01 35" src="https://user-images.githubusercontent.com/83575/34158331-2a9ddb3c-e4c5-11e7-9280-e6128194ac12.png">
<img width="626" alt="screen shot 2017-12-19 at 14 00 37" src="https://user-images.githubusercontent.com/83575/34158332-2ab66184-e4c5-11e7-8eae-0c641a9982a1.png">
