### PR TITLE
Updates Ubuntu logo to fix its aspect ratio.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -106,7 +106,7 @@
       <div class="row">
         <div class="col-12 p-logo-links">
           <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-ubuntu">
-            <img src="https://assets.ubuntu.com/v1/d6c13911-ubuntu.png" alt="" />
+            <img src="https://assets.ubuntu.com/v1/4e18e57c-logo-ubuntu--in-card.png" alt="" />
           </a>
           <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-debian">
             <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="" />


### PR DESCRIPTION
Fixes #179 

### QA

- go to home page (http://snapcraft.io-pr-211.run.demo.haus/)
- Ubuntu logo in OS section should have correct aspect ratio (not look squashed).

<img width="596" alt="screen shot 2018-01-03 at 13 57 35" src="https://user-images.githubusercontent.com/83575/34521452-1c62bf68-f08e-11e7-953b-b6ad15c754aa.png">

  