### PR TITLE
Adds social media meta tags for nicer sharing.

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -5,6 +5,14 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block meta %}
+      <meta property="og:title" content="{{ self.title() }}"/>
+      <meta property="og:site_name" content="Snapcraft"/>
+      <meta property="og:type" content="website"/>
+      <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
+      <meta property="twitter:site" content="@snapcraftio" />
+    {% endblock %}
+
     <title>{% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="/static/minified/styles.css" />
 

--- a/templates/discover.html
+++ b/templates/discover.html
@@ -1,8 +1,6 @@
 {% extends "_layout.html" %}
 
-{% block title %}
-  Discover snaps for any Linux device — Linux software in the Snap Store
-{% endblock %}
+{% block title %}Discover snaps for any Linux device — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
   <section id="main-content" class="p-strip--accent p-strip--image is-dark is-deep snapcraft-banner-background">

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
     for(var e,l='article aside footer header nav section time'.split(' ');e=l.pop();document.createElement(e));
     </script>
 
-    <meta name="description" content="Introducing snaps and commands to install and remove them on Ubuntu 16.04 LTS.">
+    <meta name="description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.">
 
     <link rel="stylesheet" href="/static/minified/styles.css">
   </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <meta property="og:title" content="Snapcraft - Snaps are universal Linux packages"/>
+    <meta property="og:site_name" content="Snapcraft"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
+    <meta property="twitter:site" content="@snapcraftio" />
+
     <title>Snapcraft - Snaps are universal Linux packages</title>
 
     <!-- Google Optimize page-hiding -->

--- a/templates/promoted.html
+++ b/templates/promoted.html
@@ -1,8 +1,6 @@
 {% extends "_layout.html" %}
 
-{% block title %}
-  Promoted Snaps — Linux software in the Snap Store
-{% endblock %}
+{% block title %}Promoted Snaps — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
   <section class="p-strip is-shallow">

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -2,6 +2,16 @@
 
 {% block title %}{{ snap_title }} — Linux software in the Snap Store{% endblock %}
 
+{% block meta %}
+  <meta property="og:title" content="{{ snap_title }} — Linux software in the Snap Store"/>
+  <meta property="og:url" content="https://snapcraft.io/{{ package_name }}/"/>
+  <meta property="og:site_name" content="Snapcraft"/>
+  <meta property="og:type" content="product"/>
+
+  {% if summary %}<meta property="og:description" content="{{ summary }}"/>{% endif %}
+  {% if icon_url %}<meta property="og:image" content="{{ icon_url }}"/>{% endif %}
+{% endblock %}
+
 {% block content %}
   <div class="p-strip is-shallow is-bordered">
     <div class="row">


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snappy-design-squad/issues/313

Adds Open Graph meta tags to snapcraft.io pages.

### QA

- go to snap detail page (http://snapcraft.io-pr-212.run.demo.haus/brave/)
- view source
- additional meta tags should be there
- try sharing demo page on facebook - nice preview should appear
  
<img width="485" alt="screen shot 2018-01-03 at 15 18 48" src="https://user-images.githubusercontent.com/83575/34523882-a6c80e6e-f099-11e7-92ab-ecae9be351ed.png">
<img width="485" alt="screen shot 2018-01-03 at 15 14 32" src="https://user-images.githubusercontent.com/83575/34523883-a6e35048-f099-11e7-89b1-30888345ae99.png">

