### PR TITLE
Add market endpoint

### DIFF
--- a/authentication.py
+++ b/authentication.py
@@ -55,7 +55,7 @@ def request_macaroon():
     response = requests.request(
         url='https://dashboard.snapcraft.io/dev/api/acl/',
         method='POST',
-        json={'permissions': ['package_access']},
+        json={'permissions': ['package_access', 'package_upload']},
         headers={
             'Accept': 'application/json, application/hal+json',
             'Content-Type': 'application/json',

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,0 +1,11 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+  Market page — Linux software in the Snap Store
+{% endblock %}
+
+{% block content %}
+
+{{ metadata }}
+
+{% endblock %}


### PR DESCRIPTION
# Summary

Add market endpoint with basic html page

# QA

- `./run`
- If you are logged in: http://0.0.0.0:8004/logout
- http://0.0.0.0:8004/account/snaps/INSERT A SNAP YOU HAVE ACCESS TO/market
- Should redirect to login
- There is a bug in the openid library we use so the next url is /account
- http://0.0.0.0:8004/account/snaps/INSERT A SNAP YOU HAVE ACCESS TO/market
- You should see a JSON with the metadata of you snap