### PR TITLE
Add CSRF protection library

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=8004
 SECRET_KEY=local_development_fake_key
+WTF_CSRF_SECRET_KEY=this_is_a_random_string

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import os
 import socket
 from dateutil import parser, relativedelta
 from flask_openid import OpenID
+from flask_wtf.csrf import CSRFProtect
 from macaroon import MacaroonRequest, MacaroonResponse
 from math import floor
 from requests.packages.urllib3.util.retry import Retry
@@ -29,6 +30,7 @@ from random import randint
 
 app = flask.Flask(__name__)
 app.secret_key = os.environ['SECRET_KEY']
+app.wtf_csrf_secret_key = os.environ['WTF_CSRF_SECRET_KEY']
 
 # Setup session to retry requests 5 times
 uncached_session = requests.Session()
@@ -47,6 +49,8 @@ oid = OpenID(
     safe_roots=[],
     extension_responses=[MacaroonResponse]
 )
+
+csrf = CSRFProtect(app)
 
 # The cache expires after 5 seconds
 cached_session = requests_cache.CachedSession(expire_after=5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bleach==2.0.0
 Flask==0.12.2
 Flask-OpenID==1.2.5
+Flask-WTF==0.14.2
 humanize==0.5.1
 pycountry==17.9.23
 pymacaroons==0.12.0


### PR DESCRIPTION
# Summary 

Added CSRF protection for the website, for this I used this [library](http://flask-wtf.readthedocs.io/en/stable/csrf.html#html-forms). Now when building forms we should add this: http://flask-wtf.readthedocs.io/en/stable/csrf.html#html-forms

This will be really tested when writing our firsts forms.

# QA

-`./run`
- No errors
