### PR TITLE
Add realease enpoint for publishers

### DIFF
--- a/templates/publisher/release.html
+++ b/templates/publisher/release.html
@@ -1,0 +1,11 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+  Release page — Linux software in the Snap Store
+{% endblock %}
+
+{% block content %}
+
+{{ status }}
+
+{% endblock %}


### PR DESCRIPTION
# Summary

Added backend endpoint to access the release page with a basic template

# QA 

- `./run`
- `http://0.0.0.0:8004/account/snaps/SNAP YOU OWN/release/`
- See data about the releases