### PR TITLE
Exempt CSRF protection for login view

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,6 +229,7 @@ def community_redirect():
 
 @app.route('/login', methods=['GET', 'POST'])
 @oid.loginhandler
+@csrf.exempt
 def login():
     if authentication.is_authenticated(flask.session):
         return flask.redirect(oid.get_next_url())


### PR DESCRIPTION
# Summary

Exempt CSRF protection for login view

# QA

- `./run`
- http://0.0.0.0:8004/account
- Login should work
