### PR TITLE
Basic snap market page

### DIFF
--- a/app.py
+++ b/app.py
@@ -659,7 +659,7 @@ def _get_from_cache(url, headers, json=None, method=None):
 # Publisher views
 # ===
 @app.route('/snaps/<snap_name>/measure')
-def publisher_snap(snap_name):
+def publisher_snap_measure(snap_name):
     """
     A view to display the snap measure page for specific snaps.
 
@@ -861,7 +861,7 @@ def get_market_snap(snap_name):
         'publisher/market.html',
         snap_id=snap_id,
         snap_name=snap_name,
-        metadata=metadata
+        **metadata
     )
 
 

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,11 +1,156 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market page — Linux software in the Snap Store
+  Market details for {{ snap_title }}
 {% endblock %}
 
 {% block content %}
+  <div id="main-content" class="u-no-margin--top">
+    <section class="p-strip is-shallow">
+      <div class="row">
+        <p><a href="/snaps">My snaps&nbsp;&rsaquo;</a></p>
+        <h1 class="u-no-margin--top">{{ snap_title }}</h1>
+      </div>
+    </section>
+    <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+      <nav class="p-tabs">
+        <ul class="p-tabs__list" role="tablist">
+          <li class="p-tabs__item" role="presentation">
+            <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section1">Measure</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab" aria-controls="section2" aria-selected="true">Market</a>
+          </li>
+        </ul>
+      </nav>
+    </section>
 
-{{ metadata }}
+    <div class="p-strip is-shallow">
+      <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <input type="hidden" name="snap_id" value="{{ snap_id }}" />
+        <div class="row">
+          <div class="col-12 u-align--right">
+              <a href="/account/snaps/{{ snap_name }}/market" class="p-button--neutral">Revert</a>
+              <input type="submit" class="p-button--positive" value="Apply" />
+              <hr />
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-2">
+            {% if icon_url %}
+              <img class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ title }} snap" />
+            {% else %}
+              <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
+            {% endif %}
+          </div>
+          <div class="col-8">
+            <label for="snap-title">Title:</label>
+            <input id="snap-title" type="text" name="title" value="{{ title }}" />
+          </div>
+        </div>
+
+        <!--
+        <div class="row">
+          <div class="col-2">
+            <label>Publisher: </label>
+          </div>
+          <div class="col-8">
+            {{ publisher }}
+          </div>
+        </div>
+      -->
+
+        <div class="row">
+          <div class="col-12">
+            <hr />
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-2">
+            <label>Summary: </label>
+          </div>
+          <div class="col-8">
+            <input type="text" name="summary" value="{{ summary }}" />
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-2">
+            <label>Description: </label>
+          </div>
+          <div class="col-8">
+            <textarea name="description">{{ description }}</textarea>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-12">
+            <hr />
+          </div>
+        </div>
+
+        <!--
+        <div class="row">
+          <div class="col-2">
+            <label>Version: </label>
+          </div>
+          <div class="col-8">
+            <input type="text" value="{{ version }}" />
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-2">
+            <label>Size: </label>
+          </div>
+          <div class="col-8">
+            {{ filesize }}
+          </div>
+        </div>
+      -->
+
+        <div class="row">
+          <div class="col-2">
+            <label>License: </label>
+          </div>
+          <div class="col-8">
+            {{ license }}
+            <!-- <input type="text" value="{{ license }}" /> -->
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-12">
+            <hr />
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-2">
+            <label>Developer website: </label>
+          </div>
+          <div class="col-8">
+            <input type="text" name="contact_url" value="{{ contact_url }}" />
+          </div>
+        </div>
+      </form>
+    </div>
+
+    {% if api_error %}
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> API request failed
+          </p>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
+  </div>
+{% endblock %}
+
+{% block scripts %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes #214 

Adds basic market page to edit title, summary, description and contact URL of the snap.


### QA

- Go to market page of your snap (in stable channel): http://snapcraft.io-pr-229.run.demo.haus/account/snaps/SNAP_NAME/market
- Form should appear
- You should be able to edit snap metadata

<img width="1085" alt="screen shot 2018-01-11 at 10 00 19" src="https://user-images.githubusercontent.com/83575/34816796-49f24db2-f6b6-11e7-808b-6c56c5ad8bf7.png">
