### PR TITLE
UI for editing icon on market page

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -1,0 +1,19 @@
+function initSnapIconEdit(iconElId, iconInputId) {
+  const snapIconInput = document.getElementById(iconInputId);
+  const snapIconEl = document.getElementById(iconElId);
+
+  snapIconInput.addEventListener("change", function(){
+    const fileList = this.files;
+    snapIconEl.src = URL.createObjectURL(fileList[0]);
+  });
+
+  snapIconEl.addEventListener("click", function() {
+    snapIconInput.click();
+  });
+}
+
+const market = {
+  initSnapIconEdit
+};
+
+export default market;

--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -1,4 +1,5 @@
 import metrics from './metrics/metrics';
 import { period } from './metrics/filters';
+import market from './market/market';
 
-export { metrics, period };
+export { metrics, period, market };

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -1,7 +1,28 @@
 @mixin snapcraft-market {
 
   .p-editable-icon {
+    $white-overlay-color: rgba(255, 255, 255, .5);
+
     cursor: pointer;
+    position: relative;
+
+    img {
+      height: 100%;
+      width: 100%;
+    }
+
+    &::after {
+      background: transparent;
+      border-radius: 50%;
+      bottom: 0;
+      box-shadow: 0 0 0 20px $white-overlay-color;
+      content: "";
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
   }
 
 }

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -2,6 +2,7 @@
 
   .p-editable-icon {
     $white-overlay-color: rgba(255, 255, 255, .5);
+    $black-overlay-color: rgba(0, 0, 0, .5);
 
     cursor: pointer;
     position: relative;
@@ -22,6 +23,22 @@
       position: absolute;
       right: 0;
       top: 0;
+    }
+
+    &::before {
+      background: $black-overlay-color;
+      background-image: url('#{$assets-path}e90af3d3-edit-icon-white.svg');
+      background-position: 50% 50%;
+      background-repeat: no-repeat;
+      border-radius: 0 0 100px 100px; // radius has to be in px to create half circle
+      bottom: 0;
+      content: "";
+      display: block;
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 50%;
     }
   }
 

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -1,0 +1,7 @@
+@mixin snapcraft-market {
+
+  .p-editable-icon {
+    cursor: pointer;
+  }
+
+}

--- a/static/sass/_utilities_margin-sizing.scss
+++ b/static/sass/_utilities_margin-sizing.scss
@@ -1,0 +1,45 @@
+@import 'vanilla-framework/scss/vanilla/settings';
+
+@mixin u-margin-sizing {
+  .u-margin-medium {
+    margin: $sp-medium !important;
+
+    &--top {
+      margin-top: $sp-medium !important;
+    }
+
+    &--right {
+      margin-right: $sp-medium !important;
+    }
+
+    &--bottom {
+      margin-bottom: $sp-medium !important;
+    }
+
+    &--left {
+      margin-left: $sp-medium !important;
+    }
+  }
+
+  .u-margin-small {
+    margin: $sp-small !important;
+
+    &--top {
+      margin-top: $sp-small !important;
+    }
+
+    &--right {
+      margin-right: $sp-small !important;
+    }
+
+    &--bottom {
+      margin-bottom: $sp-small !important;
+    }
+
+    &--left {
+      margin-left: $sp-small !important;
+    }
+  }
+
+  // ... etc for other spacing values (xx-small, x-small, large, x-large...)
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -75,6 +75,9 @@ $color-accent: $color-brand;
 @import 'snapcraft_metrics';
 @include snapcraft-metrics;
 
+@import 'snapcraft_market';
+@include snapcraft-market;
+
 @import 'patterns_testimonial';
 @include vf-p-testimonial;
 

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -9,7 +9,7 @@
     <section class="p-strip is-shallow">
       <div class="row">
         <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-        <h1 class="u-no-margin--top">{{ snap_title }}</h1>
+        <h1 class="u-no-margin--top">{{ title }}</h1>
       </div>
     </section>
     <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
@@ -40,11 +40,15 @@
         </div>
         <div class="row">
           <div class="col-2">
-            {% if icon_url %}
-              <img id="snap_icon_image" class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ title }} snap" />
-            {% else %}
-              <img id="snap_icon_image" class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
-            {% endif %}
+
+            <img id="snap_icon_image" class="p-media-object__image--large p-editable-icon"
+              {% if icon_url %}
+                src="{{ icon_url }}" alt="{{ title }} snap"
+              {% else %}
+                src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
+              {% endif %}
+            />
+
           </div>
           <div class="col-8">
             <label for="snap-title">Title:</label>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -29,6 +29,8 @@
       <form method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <input type="hidden" name="snap_id" value="{{ snap_id }}" />
+        <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>
+
         <div class="row">
           <div class="col-12 u-align--right">
               <a href="/account/snaps/{{ snap_name }}/market" class="p-button--neutral">Revert</a>
@@ -39,9 +41,9 @@
         <div class="row">
           <div class="col-2">
             {% if icon_url %}
-              <img class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ title }} snap" />
+              <img id="snap_icon_image" class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ title }} snap" />
             {% else %}
-              <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
+              <img id="snap_icon_image" class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
             {% endif %}
           </div>
           <div class="col-8">
@@ -147,5 +149,8 @@
 {% endblock %}
 
 {% block scripts %}
-
+<script src="/static/js/dist/publisher.js"></script>
+<script>
+  snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
+</script>
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -40,8 +40,8 @@
         </div>
         <div class="row">
           <div class="col-2">
-
-            <div class="p-media-object__image--large p-editable-icon">
+            {# p-editable-icon removed until we can properly edit the icon #}
+            <div class="p-media-object__image--large {# p-editable-icon #}">
               <img id="snap_icon_image"
                 {% if icon_url %}
                   src="{{ icon_url }}" alt="{{ title }} snap"
@@ -155,7 +155,9 @@
 
 {% block scripts %}
 <script src="/static/js/dist/publisher.js"></script>
+{# TODO: disabled until we can properly post the icon
 <script>
   snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
 </script>
+#}
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -26,7 +26,7 @@
     </section>
 
     <div class="p-strip is-shallow">
-      <form method="POST">
+      <form method="POST" enctype='multipart/form-data'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <input type="hidden" name="snap_id" value="{{ snap_id }}" />
         <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -41,14 +41,15 @@
         <div class="row">
           <div class="col-2">
 
-            <img id="snap_icon_image" class="p-media-object__image--large p-editable-icon"
-              {% if icon_url %}
-                src="{{ icon_url }}" alt="{{ title }} snap"
-              {% else %}
-                src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
-              {% endif %}
-            />
-
+            <div class="p-media-object__image--large p-editable-icon">
+              <img id="snap_icon_image"
+                {% if icon_url %}
+                  src="{{ icon_url }}" alt="{{ title }} snap"
+                {% else %}
+                  src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
+                {% endif %}
+              />
+            </div>
           </div>
           <div class="col-8">
             <label for="snap-title">Title:</label>


### PR DESCRIPTION
Fixes #248

Adds a UI for editing icon on snap market page.

NOTE: there is currently no backend API done for saving the icon, so it wont actually change when saved

UPDATE: icon editing code is there but is disabled so we can merge it without making functionality available yet

### QA

- ./run
- go to market page of a snap you own
- click on an icon to edit it
- choose different image to replace icon with
- icon should update on the page

