### PR TITLE
Adds snap details to market page

### DIFF
--- a/app.py
+++ b/app.py
@@ -901,13 +901,23 @@ def get_market_snap(snap_name):
     snap_id = get_snap_id(snap_name)
     metadata = snap_metadata(snap_id)
     screenshots = snap_screenshots(snap_id)
+    details = get_snap_details(snap_name)
+
+    # Transformed API data
+    details['filesize'] = humanize.naturalsize(details['binary_filesize'])
+    details['last_updated'] = (
+        humanize.naturaldate(
+            parser.parse(details.get('last_updated'))
+        )
+    )
 
     return flask.render_template(
         'publisher/market.html',
         snap_id=snap_id,
         snap_name=snap_name,
         **metadata,
-        screenshots=screenshots
+        screenshots=screenshots,
+        details=details
     )
 
 

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -50,16 +50,14 @@
           </div>
         </div>
 
-        <!--
         <div class="row">
           <div class="col-2">
             <label>Publisher: </label>
           </div>
           <div class="col-8">
-            {{ publisher }}
+            {{ details.publisher }}
           </div>
         </div>
-      -->
 
         <div class="row">
           <div class="col-12">
@@ -90,13 +88,13 @@
           </div>
         </div>
 
-        <!--
+
         <div class="row">
           <div class="col-2">
             <label>Version: </label>
           </div>
           <div class="col-8">
-            <input type="text" value="{{ version }}" />
+            {{ details.version }}
           </div>
         </div>
         <div class="row">
@@ -104,18 +102,15 @@
             <label>Size: </label>
           </div>
           <div class="col-8">
-            {{ filesize }}
+            {{ details.filesize }}
           </div>
         </div>
-      -->
-
         <div class="row">
           <div class="col-2">
             <label>License: </label>
           </div>
           <div class="col-8">
             {{ license }}
-            <!-- <input type="text" value="{{ license }}" /> -->
           </div>
         </div>
 


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/245 and https://github.com/CanonicalLtd/snapcraft-design/issues/247

### QA

- ./run
- go to market page of snap you own
- snap details such as publisher, size, version, etc should be visible together with the form

<img width="1049" alt="screen shot 2018-01-18 at 15 27 23" src="https://user-images.githubusercontent.com/83575/35102985-d12cc09c-fc64-11e7-8371-8d38a36f441a.png">
