### PR TITLE
Fix redirections to http problem

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,9 +27,11 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
 from urllib.parse import urlparse, parse_qs
 from operator import itemgetter
+from werkzeug.contrib.fixers import ProxyFix
 
 
 app = flask.Flask(__name__)
+app.wsgi_app = ProxyFix(app.wsgi_app)
 app.secret_key = os.environ['SECRET_KEY']
 app.wtf_csrf_secret_key = os.environ['WTF_CSRF_SECRET_KEY']
 


### PR DESCRIPTION
When using HTTPS and trying to connect to an external service (here login.ubuntu.com) the external service reads our http host.

To fix this we need to add `X-Forwarded-Proto` in the header. The solution comes from:
https://stackoverflow.com/questions/23347387/x-forwarded-proto-and-flask/23504684#23504684

To QA you can use caddy locally with this configuration and try to login to your account: https://gist.github.com/WillMoggridge/545a71c21f7162bdd6aa8dcd47aff6c3