### PR TITLE
Removed install button from Android.

### DIFF
--- a/app.py
+++ b/app.py
@@ -649,7 +649,10 @@ def snap_details(snap_name):
         'countries': country_data,
 
         # Context info
-        'is_linux': 'Linux' in flask.request.headers['User-Agent']
+        'is_linux': (
+            'Linux' in flask.request.headers['User-Agent'] and
+            'Android' not in flask.request.headers['User-Agent']
+        )
     }
 
     return flask.render_template(


### PR DESCRIPTION
Fixes #207 

### QA

- ./run
- visit snap details page on android phone (or emulator in Chrome)
- install button should not be visible

<img width="418" alt="screen shot 2018-01-18 at 16 40 58" src="https://user-images.githubusercontent.com/83575/35106404-699349e2-fc6e-11e7-827b-5161a28a903f.png">
