### PR TITLE
Use flask-openid stateless version

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,7 +65,8 @@ uncached_session.mount(
 )
 
 oid = OpenID(
-    app,
+    app=app,
+    stateless=True,
     safe_roots=[],
     extension_responses=[MacaroonResponse]
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bleach==2.0.0
 Flask==0.12.2
-Flask-OpenID==1.2.5
+Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2
 humanize==0.5.1
 pycountry==17.9.23


### PR DESCRIPTION
# Summary
The library used (Flask-OpenId) is not stateless. We are going to use the fork that fixes this problem: 
https://github.com/nward/flask-openid

This should be removed if the PR is merged in the future:
https://github.com/mitsuhiko/flask-openid/pull/50

# QA
- `./run`
- http://0.0.0.0:8004/account
- Make sure you can still login and access your account page