### PR TITLE
Access private snaps on market and measure pages

### DIFF
--- a/modules/public/api.py
+++ b/modules/public/api.py
@@ -124,8 +124,3 @@ def get_public_metrics(snap_name, json):
     )
 
     return metrics_response.json()
-
-
-def get_snap_id(snap_name):
-    snap_details = get_snap_details(snap_name)
-    return snap_details['snap_id']

--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -37,6 +37,11 @@ SCREENSHOTS_QUERY_URL = ''.join([
     'snaps/{snap_id}/binary-metadata'
 ])
 
+SNAP_INFO_URL = ''.join([
+    DASHBOARD_API,
+    'snaps/info/{snap_name}',
+])
+
 
 def get_authorization_header():
     authorization = authentication.get_authorization_header(
@@ -114,6 +119,21 @@ def get_publisher_metrics(json):
     return metrics_response.json()
 
 
+def get_snap_info(snap_name):
+    response = cache.get(
+        SNAP_INFO_URL.format(snap_name=snap_name),
+        headers=get_authorization_header()
+    )
+
+    return response.json()
+
+
+def get_snap_id(snap_name):
+    snap_info = get_snap_info(snap_name)
+
+    return snap_info['snap_id']
+
+
 def snap_metadata(snap_id, json=None):
     method = "PUT" if json is not None else None
 
@@ -160,3 +180,8 @@ def snap_screenshots(snap_id, data=None, files=None):
     )
 
     return screenshot_response.json()
+
+
+def is_snap_uploaded(snap_name):
+    user_snaps = get_account()
+    return user_snaps['snaps']['16'][snap_name]['uploaded']

--- a/templates/account.html
+++ b/templates/account.html
@@ -39,7 +39,13 @@
                   </tr>
                   {% for snap in user_snaps|sort %}
                       <tr>
-                          <td><a href="/account/snaps/{{snap}}/market">{{snap}}</a></td>
+                          <td>
+                              {% if user_snaps[snap].uploaded %}
+                                  <a href="/account/snaps/{{snap}}/market">{{snap}}</a>
+                              {% else %}
+                                  {{snap}}
+                              {% endif %}
+                          </td>
                           <td>{{ user_snaps[snap].status }}</td>
                           <td>{% if user_snaps[snap].price %} user_snaps[snap].price {% else %} 0 {% endif %}</td>
                       </tr>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -12,6 +12,7 @@
         <h1 class="u-no-margin--top">{{ title }}</h1>
       </div>
     </section>
+
     <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
@@ -26,152 +27,147 @@
     </section>
 
     <div class="p-strip is-shallow">
-      <form id="market-form" method="POST" enctype='multipart/form-data'>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <input type="hidden" name="snap_id" value="{{ snap_id }}" />
-        <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>
-
-        <div class="row">
-          <div class="col-12 u-align--right">
-              <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert" />
-              <input type="submit" class="p-button--positive" name="submit_apply" value="Apply" />
-              <hr />
+      {% if not uploaded %}
+          <div class="row">
+            <div class="col-12">
+                <div class="p-notification--negative">
+                  <p class="p-notification__response">
+                      You need to upload your snap before updating snap metadata.
+                  </p>
+                </div>
+            </div>
           </div>
-        </div>
+      {% else %}
+        <form id="market-form" method="POST" enctype='multipart/form-data'>
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <input type="hidden" name="snap_id" value="{{ snap_id }}" />
+          <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>
 
-        {% with messages = get_flashed_messages(with_categories=true) %}
-          {% if messages or error_list %}
-            <div class="row">
-              <div class="col-12">
-                {% for category, message in messages %}
-                  <div id="market-form-status" class="p-notification--{{ category }}">
-                    <p class="p-notification__response">
-                        {{ message }}
-                    </p>
-                  </div>
-                {% endfor %}
+          <div class="row">
+            <div class="col-12 u-align--right">
+                <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert" {% if not uploaded %}disabled{% endif %}/>
+                <input type="submit" class="p-button--positive" name="submit_apply" value="Apply" {% if not uploaded %}disabled{% endif %}/>
+                <hr />
+            </div>
+          </div>
 
-                {% for error in error_list %}
-                  <div class="p-notification--negative">
-                    <p class="p-notification__response">
-                        {{ error.message }}
-                    </p>
-                  </div>
-                {% endfor %}
+          {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages or error_list %}
+              <div class="row">
+                <div class="col-12">
+                  {% for category, message in messages %}
+                    <div id="market-form-status" class="p-notification--{{ category }}">
+                      <p class="p-notification__response">
+                          {{ message }}
+                      </p>
+                    </div>
+                  {% endfor %}
+
+                  {% for error in error_list %}
+                    <div class="p-notification--negative">
+                      <p class="p-notification__response">
+                          {{ error.message }}
+                      </p>
+                    </div>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+          {% endwith %}
+
+          <div class="row">
+            <div class="col-2">
+              <div class="p-media-object__image--large p-editable-icon">
+                <img id="snap_icon_image"
+                  {% if icon_url %}
+                    src="{{ icon_url }}" alt="{{ title }} snap"
+                  {% else %}
+                    src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
+                  {% endif %}
+                />
               </div>
             </div>
-          {% endif %}
-        {% endwith %}
-
-        <div class="row">
-          <div class="col-2">
-            <div class="p-media-object__image--large p-editable-icon">
-              <img id="snap_icon_image"
-                {% if details.icon_url %}
-                  src="{{ details.icon_url }}" alt="{{ title }} snap"
-                {% else %}
-                  src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
-                {% endif %}
-              />
+            <div class="col-8">
+              <label for="snap-title">Title:</label>
+              <input id="snap-title" type="text" name="title" value="{{ title }}" {% if not uploaded %}readonly{% endif %}/>
             </div>
           </div>
-          <div class="col-8">
-            <label for="snap-title">Title:</label>
-            <input id="snap-title" type="text" name="title" value="{{ title }}" />
-          </div>
-        </div>
 
-        <div class="row">
-          <div class="col-2">
-            <label>Publisher: </label>
+          <div class="row">
+            <div class="col-2">
+              <label>Publisher: </label>
+            </div>
+            <div class="col-8">
+                {{ publisher_name }}
+            </div>
           </div>
-          <div class="col-8">
-            {{ details.publisher }}
-          </div>
-        </div>
 
-        <div class="row">
-          <div class="col-12">
-            <hr />
+          <div class="row">
+            <div class="col-12">
+              <hr />
+            </div>
           </div>
-        </div>
 
-        <div class="row">
-          <div class="col-2">
-            <label>Summary: </label>
+          <div class="row">
+            <div class="col-2">
+              <label>Summary: </label>
+            </div>
+            <div class="col-8">
+              <input type="text" name="summary" value="{{ summary }}" {% if not uploaded %}readonly{% endif %}/>
+            </div>
           </div>
-          <div class="col-8">
-            <input type="text" name="summary" value="{{ summary }}" />
+          <div class="row">
+            <div class="col-2">
+              <label>Description: </label>
+            </div>
+            <div class="col-8">
+              <textarea name="description" {% if not uploaded %}readonly{% endif %}>{{ description }}</textarea>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="col-2">
-            <label>Description: </label>
-          </div>
-          <div class="col-8">
-            <textarea name="description">{{ description }}</textarea>
-          </div>
-        </div>
 
-        <div class="row">
-          <div class="col-12">
-            <hr />
+          <div class="row">
+            <div class="col-12">
+              <hr />
+            </div>
           </div>
-        </div>
 
+          <div class="row">
+            <div class="col-2">
+              <label>License: </label>
+            </div>
+            <div class="col-8">
+              {{ license }}
+            </div>
+          </div>
 
-        <div class="row">
-          <div class="col-2">
-            <label>Version: </label>
+          <div class="row">
+            <div class="col-12">
+              <hr />
+            </div>
           </div>
-          <div class="col-8">
-            {{ details.version }}
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-2">
-            <label>Size: </label>
-          </div>
-          <div class="col-8">
-            {{ details.filesize }}
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-2">
-            <label>License: </label>
-          </div>
-          <div class="col-8">
-            {{ license }}
-          </div>
-        </div>
 
-        <div class="row">
-          <div class="col-12">
-            <hr />
+          <div class="row">
+            <div class="col-2">
+              <label>Developer website: </label>
+            </div>
+            <div class="col-8">
+              <input type="text" name="contact" value="{{ contact }}" {% if not uploaded %}readonly{% endif %}/>
+            </div>
           </div>
-        </div>
+        </form>
+        {% endif %}
+      </div>
 
-        <div class="row">
-          <div class="col-2">
-            <label>Developer website: </label>
+      {% if api_error %}
+      <div class="row">
+        <div class="col-12">
+          <div class="p-notification--negative">
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> API request failed
+            </p>
           </div>
-          <div class="col-8">
-            <input type="text" name="contact" value="{{ contact }}" />
-          </div>
-        </div>
-      </form>
-    </div>
-
-    {% if api_error %}
-    <div class="row">
-      <div class="col-12">
-        <div class="p-notification--negative">
-          <p class="p-notification__response">
-            <span class="p-notification__status">Error:</span> API request failed
-          </p>
         </div>
       </div>
-    </div>
     {% endif %}
 
   </div>

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -9,9 +9,10 @@
     <section class="p-strip is-shallow">
       <div class="row">
         <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-        <h1 class="u-no-margin--top">{{ snap_name }}</h1>
+        <h1 class="u-no-margin--top">{{ snap_title }}</h1>
       </div>
     </section>
+
     <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
@@ -25,72 +26,84 @@
       </nav>
     </section>
     <section class="p-strip is-shallow">
-      <div class="row">
-        <div class="grid">
-          {#<div class="col-3">
-            <select class="p-form__control" disabled="disabled">
-              <option value="all">All tracks and branches</option>
-            </select>
-          </div>#}
-        </div>
-      </div>
-      <div class="row">
-        <div class="u-clearfix">
-          <h3 class="u-float--left">Weekly active devices</h3>
-          <div class="p-heading--three u-float--right u-no-margin--top">
-            <strong>{{ latest_active_devices }}</strong>
+      {% if not uploaded %}
+        <div class="row">
+          <div class="col-12">
+              <div class="p-notification--negative">
+                <p class="p-notification__response">
+                    You need to upload your snap before accessing measures.
+                </p>
+              </div>
           </div>
         </div>
-        <hr />
-        <div class="grid u-clearfix">
-          <div class="col-3">
-            <select class="p-form__control metrics-period">
-              <option value="7d"{% if metric_period == '7d' %} selected="selected"{% endif %}>Past 7 days</option>
-              <option value="30d"{% if metric_period == '30d' %} selected="selected"{% endif %}>Past 30 days</option>
-              <option value="3m"{% if metric_period == '3m' %} selected="selected"{% endif %}>Past 3 months</option>
-              <option value="1y"{% if metric_period == '1y' %} selected="selected"{% endif %}>Past year</option>
-            </select>
-          </div>
-          <div class="col-3">
-            <select class="p-form__control active-devices">
-              <option value="version"{% if active_device_metric == 'version' %} selected="selected"{% endif %}>By version</option>
-              <option value="os"{% if active_device_metric == 'os' %} selected="selected"{% endif %}>By OS</option>
-            </select>
+      {% else %}
+        <div class="row">
+          <div class="grid">
+            {#<div class="col-3">
+              <select class="p-form__control" disabled="disabled">
+                <option value="all">All tracks and branches</option>
+              </select>
+            </div>#}
           </div>
         </div>
-        <div id="active_devices" class="snapcraft-metrics__graph snapcraft-metrics__active-devices"></div>
-      </div>
-      <div class="row">
-        {#<div class="grid">
-          <div class="col-6">#}
-            <div class="u-clearfix">
-              <h3 class="u-float--left">Territories</h3>
-              <div class="p-heading--three u-float--right u-no-margin--top">
-                <strong>{{ territories_total }}</strong>
-              </div>
+        <div class="row">
+          <div class="u-clearfix">
+            <h3 class="u-float--left">Weekly active devices</h3>
+            <div class="p-heading--three u-float--right u-no-margin--top">
+              <strong>{{ latest_active_devices }}</strong>
             </div>
-            <div id="territories" class="snapcraft-territories">
           </div>
-          {#
-          <div class="col-6 last-col">
-            <div class="u-clearfix">
-              <h3 class="u-float--left">Retention</h3>
-              <div class="p-heading--three u-float--right u-no-margin--top">
-                <strong>29%</strong>
-              </div>
+          <hr />
+          <div class="grid u-clearfix">
+            <div class="col-3">
+              <select class="p-form__control metrics-period">
+                <option value="7d"{% if metric_period == '7d' %} selected="selected"{% endif %}>Past 7 days</option>
+                <option value="30d"{% if metric_period == '30d' %} selected="selected"{% endif %}>Past 30 days</option>
+                <option value="3m"{% if metric_period == '3m' %} selected="selected"{% endif %}>Past 3 months</option>
+                <option value="1y"{% if metric_period == '1y' %} selected="selected"{% endif %}>Past year</option>
+              </select>
             </div>
-            <div class="grid">
-              <div class="col-3 u-no-margin--left">
-                <select>
-                  <option>by version</option>
-                </select>
-              </div>
+            <div class="col-3">
+              <select class="p-form__control active-devices">
+                <option value="version"{% if active_device_metric == 'version' %} selected="selected"{% endif %}>By version</option>
+                <option value="os"{% if active_device_metric == 'os' %} selected="selected"{% endif %}>By OS</option>
+              </select>
             </div>
-            <p>GRAPH</p>
           </div>
-          #}
-        {#</div>
-      </div>#}
+          <div id="active_devices" class="snapcraft-metrics__graph snapcraft-metrics__active-devices"></div>
+        </div>
+        <div class="row">
+          {#<div class="grid">
+            <div class="col-6">#}
+              <div class="u-clearfix">
+                <h3 class="u-float--left">Territories</h3>
+                <div class="p-heading--three u-float--right u-no-margin--top">
+                  <strong>{{ territories_total }}</strong>
+                </div>
+              </div>
+              <div id="territories" class="snapcraft-territories">
+            </div>
+            {#
+            <div class="col-6 last-col">
+              <div class="u-clearfix">
+                <h3 class="u-float--left">Retention</h3>
+                <div class="p-heading--three u-float--right u-no-margin--top">
+                  <strong>29%</strong>
+                </div>
+              </div>
+              <div class="grid">
+                <div class="col-3 u-no-margin--left">
+                  <select>
+                    <option>by version</option>
+                  </select>
+                </div>
+              </div>
+              <p>GRAPH</p>
+            </div>
+            #}
+          {#</div>
+        </div>#}
+      {% endif %}
     </section>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Summary

Access private snaps for publisher

# QA

- `./run`
- http://0.0.0.0:8004/account/snaps/PRIVATE_SNAP/measure/
- http://0.0.0.0:8004/account/snaps/PRIVATE_SNAP/market/
- http://0.0.0.0:8004/account/snaps/SNAP/measure/
- http://0.0.0.0:8004/account/snaps/SNAP/market/
- Access a non uploaded snap:
- http://0.0.0.0:8004/account all non uploaded snaps shouldn't have a link to the market/measure page
- http://0.0.0.0:8004/account/snaps/NOT_UPLOADED_SNAP/measure/
- Should display page with an error message
- http://0.0.0.0:8004/account/snaps/NOT_UPLOADED_SNAP/market/
- Should display page with error message, and all fields in readonly mode
- If you force HTML to send a request, the request shouldn't be proccessed