### PR TITLE
Remove external icon link from build

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -53,7 +53,7 @@
                 href="/store/">Store
               </a>
             </li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://build.snapcraft.io">Build</a></li>
+            <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com">Tutorials</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,7 +79,7 @@
           </span>
           <ul class="p-navigation__links" role="menu">
             <li class="p-navigation__link" role="menuitem"><a href="/store/">Store</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://build.snapcraft.io">Build</a></li>
+            <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com">Tutorials</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>


### PR DESCRIPTION
As BSI includes 'Store' without an external link, it seems only fair for SI to include 'Build' without an external link.

- Pull this branch
- `./run`
- Goto http://0.0.0.0:8004/ and http://0.0.0.0:8004/store/ and ensure the navigation looks the same
- Approve this PR.