### PR TITLE
Adds flash notifications when market page form is saved or reverted

### DIFF
--- a/app.py
+++ b/app.py
@@ -951,21 +951,27 @@ def post_market_snap(snap_name):
         'whitelist_countries'
     ]
 
-    body_json = {
-        key: flask.request.form[key]
-        for key in whitelist if key in flask.request.form
-    }
+    if 'submit_revert' in flask.request.form:
+        flask.flash("All changes reverted.", 'information')
+    else:
+        body_json = {
+            key: flask.request.form[key]
+            for key in whitelist if key in flask.request.form
+        }
 
-    metadata = snap_metadata(flask.request.form['snap_id'], body_json)
+        metadata = snap_metadata(flask.request.form['snap_id'], body_json)
 
-    if 'error_list' in metadata:
-        return flask.render_template(
-            'publisher/market.html',
-            snap_id=flask.request.form['snap_id'],
-            snap_name=snap_name,
-            metadata=flask.request.form,
-            error_list=metadata['error_list']
-        )
+        if 'error_list' in metadata:
+            return flask.render_template(
+                'publisher/market.html',
+                snap_id=flask.request.form['snap_id'],
+                snap_name=snap_name,
+                metadata=flask.request.form,
+                error_list=metadata['error_list']
+            )
+
+        flask.flash("Changes applied successfully.", 'positive')
+
     return flask.redirect(
         "/account/snaps/{snap_name}/market/".format(
             snap_name=snap_name

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -12,8 +12,27 @@ function initSnapIconEdit(iconElId, iconInputId) {
   });
 }
 
+function initFormNotification(formElId, notificationElId) {
+  var form = document.getElementById(formElId);
+
+  form.addEventListener("change", function() {
+    var notification = document.getElementById(notificationElId);
+    if (notification) {
+      notification.parentNode.removeChild(notification);
+    }
+  });
+  var notification = document.getElementById(notificationElId);
+
+  if (notification) {
+    setTimeout(function(){
+      notification.parentNode.removeChild(notification);
+    }, 20000);
+  }
+}
+
 const market = {
-  initSnapIconEdit
+  initSnapIconEdit,
+  initFormNotification
 };
 
 export default market;

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -26,7 +26,7 @@
     </section>
 
     <div class="p-strip is-shallow">
-      <form method="POST" enctype='multipart/form-data'>
+      <form id="market-form" method="POST" enctype='multipart/form-data'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <input type="hidden" name="snap_id" value="{{ snap_id }}" />
         <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>
@@ -44,7 +44,7 @@
             <div class="row">
               <div class="col-12">
                 {% for category, message in messages %}
-                  <div class="p-notification--{{ category }}" style="display: block">
+                  <div id="market-form-status" class="p-notification--{{ category }}" style="display: block">
                     <p class="p-notification__response">
                         {{ message }}
                     </p>
@@ -177,4 +177,8 @@
   snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
 </script>
 #}
+
+<script>
+  snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");
+</script>
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -33,11 +33,28 @@
 
         <div class="row">
           <div class="col-12 u-align--right">
-              <a href="/account/snaps/{{ snap_name }}/market" class="p-button--neutral">Revert</a>
-              <input type="submit" class="p-button--positive" value="Apply" />
+              <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert" />
+              <input type="submit" class="p-button--positive" name="submit_apply" value="Apply" />
               <hr />
           </div>
         </div>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            <div class="row">
+              <div class="col-12">
+                {% for category, message in messages %}
+                  <div class="p-notification--{{ category }}" style="display: block">
+                    <p class="p-notification__response">
+                        {{ message }}
+                    </p>
+                    </div>
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
+        {% endwith %}
+
         <div class="row">
           <div class="col-2">
             {# p-editable-icon removed until we can properly edit the icon #}


### PR DESCRIPTION
First part of https://github.com/CanonicalLtd/snapcraft-design/issues/249

Adds flash notification message when market page form is saved or reverted.
It currently doesn't check if there were any changes in the form. Just shows a message based on which button was used.

Also, follow up PR will be added later to remove the notification after some delay and when changes are made in the form.

### QA
- ./run
- go to market page of a snap you own
- click Apply or Revert
- proper message should appear
- edit form, message should be removed
- click Apply or Revert
- message should appear
- wait 20 seconds, message should be removed



<img width="1023" alt="screen shot 2018-01-24 at 16 39 32" src="https://user-images.githubusercontent.com/83575/35341278-96c6720c-0125-11e8-9e22-ec4e07c06e1b.png">
<img width="1036" alt="screen shot 2018-01-24 at 16 39 23" src="https://user-images.githubusercontent.com/83575/35341279-96e3037c-0125-11e8-8b8f-8e098fb12fa3.png">
