### PR TITLE
Measure territories and remove installs

### DIFF
--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -79,10 +79,9 @@ export default function renderMap(el, snapData) {
             .style('display', 'block');
 
           let content = ['<span class="u-no-margin--top">', countrySnapData.name];
-          // Commented out but still relevant once we've updated how this will work
-          // if (countrySnapData['number_of_users'] !== undefined) {
-          //   content.push(`<br />${countrySnapData['number_of_users']} active devices`);
-          // }
+          if (countrySnapData['number_of_users'] !== undefined) {
+            content.push(`<br />${countrySnapData['number_of_users']} active devices`);
+          }
           content.push('</span>');
           tooltipMsg.html(
             `<span

--- a/static/js/publisher/metrics/filters.js
+++ b/static/js/publisher/metrics/filters.js
@@ -1,10 +1,10 @@
-function period(selector) {
+function selector(selector, name) {
   const dropDown = document.querySelector(selector);
 
   function onChange() {
     let params = new URLSearchParams(window.location.search);
 
-    params.set('period', this.value);
+    params.set(name, this.value);
 
     window.location.search = params.toString();
   }
@@ -12,4 +12,4 @@ function period(selector) {
   dropDown.addEventListener('change', onChange);
 }
 
-export { period };
+export { selector };

--- a/static/js/publisher/metrics/metrics.js
+++ b/static/js/publisher/metrics/metrics.js
@@ -1,6 +1,5 @@
 /* globals d3 bb moment */
 
-import installsMetrics from './graphs/installs';
 import activeDevicesMetrics from './graphs/activeDevices';
 import territoriesMetrics from './graphs/territories';
 
@@ -12,21 +11,6 @@ function renderMetrics(metrics) {
   if (!d3 || !bb) {
     return false;
   }
-
-  // Installs Metrics
-  let installs = metrics.installs;
-  // Prepend 'installs'.
-  installs.values.unshift('active_devices');
-
-  installs.buckets = installs.buckets.map(bucket => {
-    return moment(bucket);
-  });
-  installs.buckets.unshift('x');
-
-  installsMetrics(
-    installs.buckets,
-    installs.values
-  );
 
   // Active devices
   let activeDevices = {

--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -1,5 +1,5 @@
 import metrics from './metrics/metrics';
-import { period } from './metrics/filters';
+import { selector } from './metrics/filters';
 import market from './market/market';
 
-export { metrics, period, market };
+export { metrics, selector, market };

--- a/static/sass/_map.scss
+++ b/static/sass/_map.scss
@@ -1,6 +1,6 @@
 @mixin snap-details-map {
   // generated from d3 GeBu chromatic scale
-  $color-country-default: rgb(229, 245, 223);
+  $color-country-default: rgb(247, 247, 247);
   $color-country-boundary: $color-x-light;
 
   .snapcraft-territories {

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -27,14 +27,6 @@
     <section class="p-strip is-shallow">
       <div class="row">
         <div class="grid">
-          <div class="col-3">
-            <select class="p-form__control metrics-period">
-              <option value="7d"{% if metric_period == '7d' %} selected="selected"{% endif %}>Past 7 days</option>
-              <option value="30d"{% if metric_period == '30d' %} selected="selected"{% endif %}>Past 30 days</option>
-              <option value="3m"{% if metric_period == '3m' %} selected="selected"{% endif %}>Past 3 months</option>
-              <option value="1y"{% if metric_period == '1y' %} selected="selected"{% endif %}>Past year</option>
-            </select>
-          </div>
           {#<div class="col-3">
             <select class="p-form__control" disabled="disabled">
               <option value="all">All tracks and branches</option>
@@ -44,32 +36,28 @@
       </div>
       <div class="row">
         <div class="u-clearfix">
-          <h3 class="u-float--left">New devices</h3>
-          <div class="p-heading--three u-float--right u-no-margin--top">
-            <strong>{{ installs_total }}</strong>
-          </div>
-        </div>
-        <hr />
-        <div id="installs_metrics" class="snapcraft-metrics__graph">
-        </div>
-      </div>
-      <div class="row">
-        <div class="u-clearfix">
-          <h3 class="u-float--left">Daily active devices</h3>
+          <h3 class="u-float--left">Weekly active devices</h3>
           <div class="p-heading--three u-float--right u-no-margin--top">
             <strong>{{ latest_active_devices }}</strong>
           </div>
         </div>
         <hr />
-        {#
-          <div class="grid u-clearfix">
-            <div class="col-3">
-              <select class="p-form__control">
-                <option value="version">By version</option>
-              </select>
-            </div>
+        <div class="grid u-clearfix">
+          <div class="col-3">
+            <select class="p-form__control metrics-period">
+              <option value="7d"{% if metric_period == '7d' %} selected="selected"{% endif %}>Past 7 days</option>
+              <option value="30d"{% if metric_period == '30d' %} selected="selected"{% endif %}>Past 30 days</option>
+              <option value="3m"{% if metric_period == '3m' %} selected="selected"{% endif %}>Past 3 months</option>
+              <option value="1y"{% if metric_period == '1y' %} selected="selected"{% endif %}>Past year</option>
+            </select>
           </div>
-        #}
+          <div class="col-3">
+            <select class="p-form__control active-devices">
+              <option value="version"{% if active_device_metric == 'version' %} selected="selected"{% endif %}>By version</option>
+              <option value="os"{% if active_device_metric == 'os' %} selected="selected"{% endif %}>By OS</option>
+            </select>
+          </div>
+        </div>
         <div id="active_devices" class="snapcraft-metrics__graph snapcraft-metrics__active-devices"></div>
       </div>
       <div class="row">
@@ -81,7 +69,6 @@
                 <strong>{{ territories_total }}</strong>
               </div>
             </div>
-            <hr />
             <div id="territories" class="snapcraft-territories">
           </div>
           {#
@@ -117,9 +104,9 @@
 
 <script src="/static/js/dist/publisher.js"></script>
 <script>
-  snapcraft.publisher.period('.metrics-period');
+  snapcraft.publisher.selector('.metrics-period', 'period');
+  snapcraft.publisher.selector('.active-devices', 'active-devices');
   snapcraft.publisher.metrics({
-    installs: {{ installs|safe }},
     activeDevices: {{ active_devices|safe }},
     territories: {{ territories|safe }}
   });


### PR DESCRIPTION
## Changes

- Installs graph removed
- Measure territories grey for lowest shade
- Territories changed to weekly metric

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account
- Click on a snap with metrics data
- The top 'Installs' graph should not longer be there
- The 'Territories' map should have grey as the lowest colour scale and the tooltips should show exact numbers