### PR TITLE
We should use .env.local instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once the containers are setup, you can visit <http://127.0.0.1:8004> in your bro
 
 ### Use staging APIs
 
-To use staging APIs locally you can edit the file `.env.` and add the following lines:
+To use staging APIs locally you can add the following lines to an`.env.local` file:
 
 ```bash
 SNAPCRAFT_IO_API=https://api.staging.snapcraft.io/api/v1/


### PR DESCRIPTION
`.env` is *committed to the codebase*. Therefore it should only contain
environment variables that are intended to *always be used* in local
development, for everyone.

The staging API server is intended to be a temporary setting that should
*not be committed* to the repository. So `.env.local` (which is in
.gitignore) should be used
instead.

QA
--

Try using `.env.local` instead of `.env`, check it still works for connecting to the staging API server instead of the live one.