### PR TITLE
Routing fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -241,10 +241,7 @@ def login_required(func):
 
 
 def redirect_to_login():
-    return flask.redirect(''.join([
-        'login?next=',
-        flask.request.url_rule.rule,
-    ]))
+    return flask.redirect('login/?next=' + flask.request.url_rule.rule)
 
 
 def normalize_searched_snaps(search_results):

--- a/app.py
+++ b/app.py
@@ -439,7 +439,7 @@ def get_account():
             return response.raise_for_status
         else:
             return flask.redirect(
-                verified_response.redirect
+                verified_response['redirect']
             )
 
     print('HTTP/1.1 {} {}'.format(response.status_code, response.reason))

--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ def community_redirect():
     return flask.redirect('/')
 
 
-@app.route('/login', methods=['GET', 'POST'])
+@app.route('/login/', methods=['GET', 'POST'])
 @oid.loginhandler
 @csrf.exempt
 def login():
@@ -400,14 +400,14 @@ def after_login(resp):
     return flask.redirect('/account')
 
 
-@app.route('/logout')
+@app.route('/logout/')
 def logout():
     if authentication.is_authenticated(flask.session):
         authentication.empty_session(flask.session)
     return flask.redirect('/')
 
 
-@app.route('/account')
+@app.route('/account/')
 @login_required
 def get_account():
     authorization = authentication.get_authorization_header(
@@ -427,8 +427,8 @@ def get_account():
         response,
         flask.session,
         ACCOUNT_URL,
-        '/account',
-        '/login'
+        '/account/',
+        '/login/'
     )
 
     if verified_response is not None:
@@ -539,7 +539,7 @@ def snaps():
     )
 
 
-@app.route('/search')
+@app.route('/search/')
 def search_snap():
     snap_searched = flask.request.args.get('q', default='', type=str)
     if(not snap_searched):

--- a/templates/account.html
+++ b/templates/account.html
@@ -39,7 +39,7 @@
                   </tr>
                   {% for snap in user_snaps|sort %}
                       <tr>
-                          <td><a href="/account/snaps/{{snap}}/market/">{{snap}}</a></td>
+                          <td><a href="/account/snaps/{{snap}}/market">{{snap}}</a></td>
                           <td>{{ user_snaps[snap].status }}</td>
                           <td>{% if user_snaps[snap].price %} user_snaps[snap].price {% else %} 0 {% endif %}</td>
                       </tr>

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -16,10 +16,10 @@
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
           <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/market/" class="p-tabs__link" tabindex="0" role="tab">Market</a>
+            <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab">Market</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/measure/" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Measure</a>
+            <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Measure</a>
           </li>
         </ul>
       </nav>

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@
 
 import app
 import unittest
+from urllib.parse import urlparse, urlunparse
 
 
 class WebAppTestCase(unittest.TestCase):
@@ -9,28 +10,105 @@ class WebAppTestCase(unittest.TestCase):
         self.app = app.app.test_client()
         self.app.testing = True
 
+    # Static pages
+    # ==
+
     def test_homepage(self):
-        response = self.app.get('/')
-        assert response.status_code == 200
-        assert "Ubuntu and Canonical are registered" in str(response.data)
+        self._check_basic_page('/')
 
-    def test_redirect_to_add_slash(self):
-        response = self.app.get('/canonical-livepatch')
-        location = response.headers.get('Location')
+    def test_storefront(self):
+        response = self._check_basic_page('/store')
+        assert 'type="search"' in str(response.data)
 
-        assert response.status_code in (301, 302)
-        assert location == "http://localhost/canonical-livepatch/"
+    def test_search(self):
+        redirect = self._get_response('/search')
+        assert redirect.status_code == 302
+        assert redirect.headers.get('Location') == "http://localhost/store"
+
+        response = self._check_basic_page('/search?q=livepatch')
+        assert 'type="search"' in str(response.data)
+        assert 'canonical-livepatch' in str(response.data)
+
+    def test_not_found(self):
+        response = self._get_response('/store/nothing-page')
+
+        assert response.status_code == 404
+        assert "Page not found" in str(response.data)
+
+    # Account pages
+    # ===
+
+    def test_account(self):
+        """
+        Naive check that the basic redirects to the authentication system
+        are working for the /account page
+        """
+
+        local_redirect = self._get_response('/account')
+        redirect_url = "http://localhost/login?next=/account"
+        assert local_redirect.status_code == 302
+        assert local_redirect.headers.get('Location') == redirect_url
+
+        ext_redirect = self._get_response('/login?next=/account')
+        ext2_redirect = self._get_response('/login?next=/account')
+        assert ext_redirect.status_code == 302
+        assert ext2_redirect.status_code == 302
+        assert 'login.ubuntu.com' in ext_redirect.headers.get('Location')
+        assert 'login.ubuntu.com' in ext2_redirect.headers.get('Location')
+
+    # Snap details pages
+    # ==
 
     def test_canonical_livepatch_snap(self):
-        response = self.app.get('/canonical-livepatch/')
+        response = self._check_basic_page('/canonical-livepatch')
+        assert "canonical-livepatch" in str(response.data)
 
-        assert response.status_code == 200
+    def test_lxd_snap(self):
+        response = self._check_basic_page('/lxd')
+        assert "LXD" in str(response.data)
 
     def test_non_existent_snap(self):
-        response = self.app.get('/non-existent-snap/')
+        response = self._get_response('/non-existent-snap')
 
         assert response.status_code == 404
         assert "Snap not found" in str(response.data)
+
+    # Helper methods
+    # ==
+
+    def _get_response(self, uri):
+        """
+        Given a basic app path (e.g. '/page'), check that any trailing
+        slashes are removed with a 302 redirect, and return the response
+        for the principal URL
+        """
+
+        # Check trailing slashes trigger redirect
+        parsed_uri = urlparse(uri)
+        slash_uri = urlunparse(parsed_uri._replace(path=parsed_uri.path + '/'))
+        redirect_response = self.app.get(slash_uri)
+        assert redirect_response.status_code == 302
+
+        url = "http://localhost" + uri
+        assert redirect_response.headers.get('Location') == url
+
+        return self.app.get(uri)
+
+    def _check_basic_page(self, uri):
+        """
+        Check that a URI returns an HTML page that will redirect to remove
+        slashes, returns a 200 and contains the standard footer text
+        """
+
+        if uri == '/':
+            response = self.app.get(uri)
+        else:
+            response = self._get_response(uri)
+
+        assert response.status_code == 200
+        assert "Ubuntu and Canonical are registered" in str(response.data)
+
+        return response
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Tidy code slightly
- Fix redirection error
- Correct URL paths for URLs without slashes

QA
--

``` bash
./run
```

Then navigate to `/account` and `/account/`, with and without being already logged in. Check everything still works, and that `/account/` is now *not* a 404.