### PR TITLE
Adjust tutorials link to query snap tutorials

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -55,7 +55,7 @@
             </li>
             <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com">Tutorials</a></li>
+            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
This change makes the tutorials link more relevant for snapcrafters.

https://tutorials.ubuntu.com/ -> https://tutorials.ubuntu.com/?q=snap