### PR TITLE
Adds error notifications to market page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1070,7 +1070,7 @@ def post_market_snap(snap_name):
                 **context
             )
 
-    flask.flash("Changes applied successfully.", 'positive')
+        flask.flash("Changes applied successfully.", 'positive')
 
     return flask.redirect(
         "/account/snaps/{snap_name}/market/".format(

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -40,7 +40,7 @@
         </div>
 
         {% with messages = get_flashed_messages(with_categories=true) %}
-          {% if messages %}
+          {% if messages or error_list %}
             <div class="row">
               <div class="col-12">
                 {% for category, message in messages %}
@@ -48,7 +48,15 @@
                     <p class="p-notification__response">
                         {{ message }}
                     </p>
-                    </div>
+                  </div>
+                {% endfor %}
+
+                {% for error in error_list %}
+                  <div class="p-notification--negative" style="display: block">
+                    <p class="p-notification__response">
+                        {{ error.message }}
+                    </p>
+                  </div>
                 {% endfor %}
               </div>
             </div>


### PR DESCRIPTION
Fixes #263 

## QA
- ./run
- go to market page of snap you own
- click on an icon and choose an image bigger than 256px
- click Apply
- error notification should appear

<img width="1039" alt="screen shot 2018-01-30 at 10 22 56" src="https://user-images.githubusercontent.com/83575/35558210-b3fe36b2-05a7-11e8-9ac1-eef2932a5df0.png">
