### PR TITLE
Updates Vanilla to latest version and removed unnecessary workarounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "sass-lint": "^1.10.2",
     "topojson-client": "^3.0.0",
-    "vanilla-framework": "^1.6.3",
+    "vanilla-framework": "^1.6.5",
     "watch-cli": "^0.2.2"
   }
 }

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -44,7 +44,7 @@
             <div class="row">
               <div class="col-12">
                 {% for category, message in messages %}
-                  <div id="market-form-status" class="p-notification--{{ category }}" style="display: block">
+                  <div id="market-form-status" class="p-notification--{{ category }}">
                     <p class="p-notification__response">
                         {{ message }}
                     </p>
@@ -52,7 +52,7 @@
                 {% endfor %}
 
                 {% for error in error_list %}
-                  <div class="p-notification--negative" style="display: block">
+                  <div class="p-notification--negative">
                     <p class="p-notification__response">
                         {{ error.message }}
                     </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,9 +3235,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.3.tgz#92271d5dc765d7563659684ed4797e3919160f01"
+vanilla-framework@1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.5.tgz#e6ea7ab6de38c8172e362474258981a57eec0993"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Updates Vanilla to latest version and removed unnecessary workarounds.

### QA

- ./run
- go to any page, it should look fine
- go to your snap market page
- edit something, apply or revert
- notification should appear correctly (in full width)