### PR TITLE
Fixes vanilla version in yarn lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,7 +3235,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.6.5:
+vanilla-framework@^1.6.5:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.5.tgz#e6ea7ab6de38c8172e362474258981a57eec0993"
 


### PR DESCRIPTION
Seems that yarn.lock has different version of vanilla then package.json