### PR TITLE
Update tutorials link on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,7 @@
             <li class="p-navigation__link" role="menuitem"><a href="/store">Store</a></li>
             <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com">Tutorials</a></li>
+            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
             <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
QA
--

`./run`

Go to homepage, click tutorials link in header. Check it matches the same link in the header of the other pages on the site.