### PR TITLE
Market page - adding screenshots (step 1)

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -166,7 +166,7 @@ def get_market_snap(snap_name):
             "license": snap_details['license'],
             "icon_url": snap_details['icon_url'],
             "publisher_name": snap_details['publisher_name'],
-
+            "screenshot_urls": snap_details['screenshot_urls'],
             # Check if snap is uploaded or not
             "uploaded": uploaded
         }
@@ -282,6 +282,7 @@ def post_market_snap(snap_name):
                 "license": snap_details['license'],
                 "icon_url": snap_details['icon_url'],
                 "publisher_name": snap_details['publisher_name'],
+                "screenshot_urls": snap_details['screenshot_urls'],
                 "error_list": error_list
             }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -13,12 +13,33 @@ function initSnapIconEdit(iconElId, iconInputId) {
 }
 
 function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, data) {
-  const state = {};
-  state.screenshots = data.map((url) => { return { url }; });
-
+  // DOM elements
   const screenshotsToolbarEl = document.getElementById(screenshotsToolbarElId);
   const screenshotsWrapper = document.getElementById(screenshotsWrapperElId);
 
+  // simple state handling (and serializing as JSON in hidden input)
+  const state = {};
+  const stateInput = document.createElement('input');
+  stateInput.type = "hidden";
+  stateInput.name = "state";
+
+  screenshotsToolbarEl.parentNode.appendChild(stateInput);
+
+  const setState = function(nextState) {
+    for (let key in nextState) {
+      if (nextState.hasOwnProperty(key)) {
+        state[key] = nextState[key];
+      }
+    }
+
+    stateInput.value = JSON.stringify(state);
+  };
+
+  setState({
+    screenshots: data.map((url) => { return { url }; })
+  });
+
+  // templates
   const screenshotTpl = (screenshot) => `
     <div class="col-2">
       <img src="${screenshot.url}" alt="" />
@@ -50,7 +71,9 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
 
     for (var i = 0; i < fileList.length; i++) {
       const file = fileList[i];
-      state.screenshots.push({ file, url: URL.createObjectURL(file) });
+      setState({
+        screenshots: state.screenshots.concat([{ file, url: URL.createObjectURL(file), name: file.name }])
+      });
 
       render();
     }

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -59,7 +59,7 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   };
 
   const render = () => {
-    renderScreenshots(state.images.filter(i => i.type === "screenshot"));
+    renderScreenshots(state.images.filter(image => image.type === "screenshot"));
   };
 
   render();
@@ -72,9 +72,9 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
       setState({
         images: state.images.concat([{ file, url: URL.createObjectURL(file), name: file.name, type: "screenshot" }])
       });
-
-      render();
     }
+
+    render();
   };
 
   document.addEventListener("click", function(event){

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -12,7 +12,7 @@ function initSnapIconEdit(iconElId, iconInputId) {
   });
 }
 
-function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, data) {
+function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, initialState) {
   // DOM elements
   const screenshotsToolbarEl = document.getElementById(screenshotsToolbarElId);
   const screenshotsWrapper = document.getElementById(screenshotsWrapperElId);
@@ -35,9 +35,7 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
     stateInput.value = JSON.stringify(state);
   };
 
-  setState({
-    screenshots: data.map((url) => { return { url }; })
-  });
+  setState(initialState);
 
   // templates
   const screenshotTpl = (screenshot) => `
@@ -61,7 +59,7 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   };
 
   const render = () => {
-    renderScreenshots(state.screenshots);
+    renderScreenshots(state.images.filter(i => i.type === "screenshot"));
   };
 
   render();
@@ -69,10 +67,10 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   const onScreenshotsChange = function() {
     const fileList = this.files;
 
-    for (var i = 0; i < fileList.length; i++) {
+    for (let i = 0; i < fileList.length; i++) {
       const file = fileList[i];
       setState({
-        screenshots: state.screenshots.concat([{ file, url: URL.createObjectURL(file), name: file.name }])
+        images: state.images.concat([{ file, url: URL.createObjectURL(file), name: file.name, type: "screenshot" }])
       });
 
       render();
@@ -80,7 +78,9 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   };
 
   document.addEventListener("click", function(event){
-    if (event.target.classList.contains('js-add-screenshots')) {
+    if (event.target.classList.contains('js-add-screenshots')
+        || event.target.parentNode.classList.contains('js-add-screenshots')
+      ) {
       event.preventDefault();
 
       const input = document.createElement('input');

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -70,7 +70,12 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
     for (let i = 0; i < fileList.length; i++) {
       const file = fileList[i];
       setState({
-        images: state.images.concat([{ file, url: URL.createObjectURL(file), name: file.name, type: "screenshot" }])
+        images: state.images.concat([{
+          file, url: URL.createObjectURL(file),
+          name: file.name,
+          type: "screenshot",
+          status: "new"
+        }])
       });
     }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -12,6 +12,57 @@ function initSnapIconEdit(iconElId, iconInputId) {
   });
 }
 
+function initSnapScreenshotsEdit(addElId, screenshotsToolbarElId, screenshotsWrapperElId, data) {
+  const state = {};
+  state.screenshots = data.map((url) => { return { url }; });
+
+  const addScreenshotsEl = document.getElementById(addElId);
+  const screenshotsToolbarEl = document.getElementById(screenshotsToolbarElId);
+  const screenshotsWrapper = document.getElementById(screenshotsWrapperElId);
+
+  const screenshotTpl = (screenshot) => `
+    <div class="col-2">
+      <img src="${screenshot.url}" alt="" />
+    </div>
+  `;
+
+  const renderScreenshots = (screenshots) => {
+    screenshotsWrapper.innerHTML = screenshots.map(screenshotTpl).join("");
+  };
+
+  const render = () => {
+    renderScreenshots(state.screenshots);
+  };
+
+  render();
+
+  const onScreenshotsChange = function() {
+    const fileList = this.files;
+
+    for (var i = 0; i < fileList.length; i++) {
+      const file = fileList[i];
+      state.screenshots.push({ file, url: URL.createObjectURL(file) });
+
+      render();
+    }
+  };
+
+  addScreenshotsEl.addEventListener("click", function(event) {
+    event.preventDefault();
+
+    const input = document.createElement('input');
+    input.type = "file";
+    input.multiple = "multiple";
+    input.accept = "image/*";
+    input.name="screenshots";
+    input.hidden = "hidden";
+
+    screenshotsToolbarEl.parentNode.appendChild(input);
+    input.addEventListener("change", onScreenshotsChange);
+    input.click();
+  });
+}
+
 function initFormNotification(formElId, notificationElId) {
   var form = document.getElementById(formElId);
 
@@ -32,7 +83,8 @@ function initFormNotification(formElId, notificationElId) {
 
 const market = {
   initSnapIconEdit,
-  initFormNotification
+  initFormNotification,
+  initSnapScreenshotsEdit
 };
 
 export default market;

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -12,11 +12,10 @@ function initSnapIconEdit(iconElId, iconInputId) {
   });
 }
 
-function initSnapScreenshotsEdit(addElId, screenshotsToolbarElId, screenshotsWrapperElId, data) {
+function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, data) {
   const state = {};
   state.screenshots = data.map((url) => { return { url }; });
 
-  const addScreenshotsEl = document.getElementById(addElId);
   const screenshotsToolbarEl = document.getElementById(screenshotsToolbarElId);
   const screenshotsWrapper = document.getElementById(screenshotsWrapperElId);
 
@@ -26,8 +25,18 @@ function initSnapScreenshotsEdit(addElId, screenshotsToolbarElId, screenshotsWra
     </div>
   `;
 
+  const emptyTpl = () => `
+    <div class="col-12">
+      <a class="p-empty-add-screenshots js-add-screenshots">Add images</a>
+    </div>
+  `;
+
   const renderScreenshots = (screenshots) => {
-    screenshotsWrapper.innerHTML = screenshots.map(screenshotTpl).join("");
+    if (screenshots.length) {
+      screenshotsWrapper.innerHTML = screenshots.map(screenshotTpl).join("");
+    } else {
+      screenshotsWrapper.innerHTML = emptyTpl();
+    }
   };
 
   const render = () => {
@@ -47,19 +56,21 @@ function initSnapScreenshotsEdit(addElId, screenshotsToolbarElId, screenshotsWra
     }
   };
 
-  addScreenshotsEl.addEventListener("click", function(event) {
-    event.preventDefault();
+  document.addEventListener("click", function(event){
+    if (event.target.classList.contains('js-add-screenshots')) {
+      event.preventDefault();
 
-    const input = document.createElement('input');
-    input.type = "file";
-    input.multiple = "multiple";
-    input.accept = "image/*";
-    input.name="screenshots";
-    input.hidden = "hidden";
+      const input = document.createElement('input');
+      input.type = "file";
+      input.multiple = "multiple";
+      input.accept = "image/*";
+      input.name="screenshots";
+      input.hidden = "hidden";
 
-    screenshotsToolbarEl.parentNode.appendChild(input);
-    input.addEventListener("change", onScreenshotsChange);
-    input.click();
+      screenshotsToolbarEl.parentNode.appendChild(input);
+      input.addEventListener("change", onScreenshotsChange);
+      input.click();
+    }
   });
 }
 

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -1,0 +1,7 @@
+@mixin snapcraft-market-screenshots {
+  .p-screenshots-toolbar {
+    align-items: baseline;
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -4,4 +4,11 @@
     display: flex;
     justify-content: space-between;
   }
+
+  .p-empty-add-screenshots {
+    background: $color-light;
+    display: block;
+    padding: $sp-x-large;
+    text-align: center;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -89,3 +89,6 @@ $color-accent: $color-brand;
 
 @import 'snapcraft_custom-typography';
 @include snapcraft-custom-typography;
+
+@import 'snapcraft_market_screenshots';
+@include snapcraft-market-screenshots;

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -199,7 +199,15 @@
   snapcraft.publisher.market.initSnapScreenshotsEdit(
     "screenshots-toolbar",
     "snap-screenshots",
-    {{ details.screenshot_urls|tojson }}
+    {
+      images: [
+        { url: {{ details.icon_url|tojson }}, type: "icon" },
+
+        {% for screenshot_url in details.screenshot_urls %}
+          { url: {{ screenshot_url|tojson }}, type: "screenshot" },
+        {% endfor %}
+      ]
+    }
   );
 </script>
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -204,7 +204,7 @@
         { url: {{ icon_url|tojson }}, type: "icon" },
 
         {% for screenshot_url in screenshot_urls %}
-          { url: {{ screenshot_url|tojson }}, type: "screenshot" },
+          { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
         {% endfor %}
       ]
     }

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -192,6 +192,7 @@
 {% endblock %}
 
 {% block scripts %}
+{% if uploaded %}
 <script src="/static/js/dist/publisher.js"></script>
 <script>
   snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
@@ -210,4 +211,5 @@
     }
   );
 </script>
+{% endif %}
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -133,16 +133,14 @@
 
           <div class="row">
             <div class="col-12">
-              <label>Screenshots:</label>
+              <div class="p-screenshots-toolbar" id="screenshots-toolbar">
+                <label>Screenshots:</label>
+                <button class="p-button-neutral" id="snap-add-screenshot"><i class="p-icon--plus"></i></button>
+              </div>
             </div>
           </div>
 
-          <div class="row">
-              {% for screenshot in details.screenshot_urls %}
-              <div class="col-2">
-                <img src={{ screenshot }} alt="" />
-              </div>
-              {% endfor %}
+          <div class="row" id="snap-screenshots">
           </div>
 
           <div class="row">
@@ -198,5 +196,11 @@
 <script>
   snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
   snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");
+  snapcraft.publisher.market.initSnapScreenshotsEdit(
+    "snap-add-screenshot",
+    "screenshots-toolbar",
+    "snap-screenshots",
+    {{ details.screenshot_urls|tojson }}
+  );
 </script>
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -201,9 +201,9 @@
     "snap-screenshots",
     {
       images: [
-        { url: {{ details.icon_url|tojson }}, type: "icon" },
+        { url: {{ icon_url|tojson }}, type: "icon" },
 
-        {% for screenshot_url in details.screenshot_urls %}
+        {% for screenshot_url in screenshot_urls %}
           { url: {{ screenshot_url|tojson }}, type: "screenshot" },
         {% endfor %}
       ]

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -132,6 +132,26 @@
           </div>
 
           <div class="row">
+            <div class="col-12">
+              <label>Screenshots:</label>
+            </div>
+          </div>
+
+          <div class="row">
+              {% for screenshot in details.screenshot_urls %}
+              <div class="col-2">
+                <img src={{ screenshot }} alt="" />
+              </div>
+              {% endfor %}
+          </div>
+
+          <div class="row">
+            <div class="col-12">
+              <hr />
+            </div>
+          </div>
+
+          <div class="row">
             <div class="col-2">
               <label>License: </label>
             </div>
@@ -155,19 +175,19 @@
             </div>
           </div>
         </form>
-        {% endif %}
-      </div>
+      {% endif %}
+    </div>
 
-      {% if api_error %}
-      <div class="row">
-        <div class="col-12">
-          <div class="p-notification--negative">
-            <p class="p-notification__response">
-              <span class="p-notification__status">Error:</span> API request failed
-            </p>
-          </div>
+    {% if api_error %}
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> API request failed
+          </p>
         </div>
       </div>
+    </div>
     {% endif %}
 
   </div>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -135,7 +135,7 @@
             <div class="col-12">
               <div class="p-screenshots-toolbar" id="screenshots-toolbar">
                 <label>Screenshots:</label>
-                <button class="p-button-neutral" id="snap-add-screenshot"><i class="p-icon--plus"></i></button>
+                <button class="p-button-neutral js-add-screenshots" id="snap-add-screenshot"><i class="p-icon--plus"></i></button>
               </div>
             </div>
           </div>
@@ -197,7 +197,6 @@
   snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
   snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");
   snapcraft.publisher.market.initSnapScreenshotsEdit(
-    "snap-add-screenshot",
     "screenshots-toolbar",
     "snap-screenshots",
     {{ details.screenshot_urls|tojson }}


### PR DESCRIPTION
Adds basic screenshots UI to market page form.

- Currently it's only possible to add screenshots.
- Because of current backend implementation added screenshots **override** screenshots added previously when saved
- Not possible to move or delete screenshots yet
- No validation on number of screenshots yet

## QA

- ./run
- go to market page of snap you own
- existing screenshots should appear (if you have any)
- add some screenshots
- screenshots should show up
- click "Apply" to save - screenshots should be uploaded and saved in dashboard

<img width="1017" alt="screen shot 2018-02-05 at 14 22 00" src="https://user-images.githubusercontent.com/83575/35810663-c3a1d0f8-0a8c-11e8-9e2f-08439dd93bbb.png">

<img width="1024" alt="screen shot 2018-02-05 at 14 22 53" src="https://user-images.githubusercontent.com/83575/35810662-c389ce72-0a8c-11e8-93cd-60854e3e283c.png">

