### PR TITLE
Updates snapcraft logo (and extracts header into partial template).

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -2,8 +2,8 @@
   <div class="row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
-        <a href="/">
-          <img class="u-float-left" src="https://assets.ubuntu.com/v1/863eb087-snapcraft_green-red_su_no_spacing.svg" height="30" width="130" alt="Snapcraft" />
+        <a class="p-navigation__link" href="/">
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/863eb087-snapcraft_green-red_su_no_spacing.svg" alt="Snapcraft" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/2964e9eb-snapcraft-logo--web.svg" alt="Snapcraft" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,0 +1,30 @@
+<header id="navigation" class="p-navigation">
+  <div class="row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a href="/">
+          <img class="u-float-left" src="https://assets.ubuntu.com/v1/863eb087-snapcraft_green-red_su_no_spacing.svg" height="30" width="130" alt="Snapcraft" />
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav" role="menubar">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link" role="menuitem">
+          <a
+            {% if page_slug and page_slug == 'store' %} class="is-selected"{% endif %}
+            href="/store">Store
+          </a>
+        </li>
+        <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
+        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
+        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
+        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/863eb087-snapcraft_green-red_su_no_spacing.svg" alt="Snapcraft" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -13,6 +13,9 @@
       <meta property="twitter:site" content="@snapcraftio" />
     {% endblock %}
 
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
+
     <title>{% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="/static/minified/styles.css" />
 

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -31,36 +31,7 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    <header id="navigation" class="p-navigation">
-      <div class="row">
-        <div class="p-navigation__banner">
-          <div class="p-navigation__logo">
-            <a href="/">
-              <img class="u-float-left" src="https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg" width="148" alt="Snapcraft.io" />
-            </a>
-          </div>
-          <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-          <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
-        </div>
-        <nav class="p-navigation__nav" role="menubar">
-          <span class="u-off-screen">
-            <a href="#main-content">Jump to main content</a>
-          </span>
-          <ul class="p-navigation__links" role="menu">
-            <li class="p-navigation__link" role="menuitem">
-              <a
-                {% if page_slug and page_slug == 'store' %} class="is-selected"{% endif %}
-                href="/store">Store
-              </a>
-            </li>
-            <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
-          </ul>
-        </nav>
-      </div>
-    </header>
+    {% include "_header.html" %}
 
     {% block content %}{% endblock %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,31 +62,7 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    <header id="navigation" class="p-navigation">
-      <div class="row">
-        <div class="p-navigation__banner">
-          <div class="p-navigation__logo">
-            <a href="/">
-              <img class="u-float-left" src="https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg" width="148" alt="Snapcraft.io" />
-            </a>
-          </div>
-          <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-          <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
-        </div>
-        <nav class="p-navigation__nav" role="menubar">
-          <span class="u-off-screen">
-            <a href="#main-content">Jump to main content</a>
-          </span>
-          <ul class="p-navigation__links" role="menu">
-            <li class="p-navigation__link" role="menuitem"><a href="/store">Store</a></li>
-            <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
-            <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
-          </ul>
-        </nav>
-      </div>
-    </header>
+    {% include "_header.html" %}
 
     <div id="main-content" class="p-strip--accent p-strip--image is-dark is-deep snapcraft-banner-background">
       <h1 class="u-off-screen">Snapcraft</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
     <meta property="twitter:site" content="@snapcraftio" />
 
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
+
     <title>Snapcraft - Snaps are universal Linux packages</title>
 
     <!-- Google Optimize page-hiding -->


### PR DESCRIPTION
Fixes #252 

Updates logo in header to a new branding.
Also extracts header navigation to a partial template to keep it consistent between different layouts used in the app.

## QA
- ./run
- go to home page
- go to any other page
- header should have new logo branding

<img width="1233" alt="screen shot 2018-02-08 at 09 58 34" src="https://user-images.githubusercontent.com/83575/35964010-c17ac470-0cb6-11e8-943c-d1f7eafaf360.png">

<img width="1233" alt="screen shot 2018-02-08 at 09 59 02" src="https://user-images.githubusercontent.com/83575/35964009-c14da3dc-0cb6-11e8-9ff6-d8bfa2846cfb.png">
