### PR TITLE
Send already existing screenshots in info

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -4,7 +4,7 @@ import hashlib
 import modules.public.views as public_views
 import modules.publisher.api as api
 from dateutil import relativedelta
-from json import dumps
+from json import dumps, loads
 from operator import itemgetter
 
 
@@ -220,6 +220,16 @@ def post_market_snap(snap_name):
         info = []
         images_files = []
         images_json = None
+
+        # Add existing screenshots
+        screenshots_uploaded = api.snap_screenshots(
+            flask.request.form['snap_id']
+        )
+        state_screenshots = loads(flask.request.form['state'])['images']
+        for screenshot in state_screenshots:
+            for screenshot_uploaded in screenshots_uploaded:
+                if screenshot['url'] == screenshot_uploaded['url']:
+                    info.append(screenshot_uploaded)
 
         icon = flask.request.files.get('icon')
         if icon is not None:

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -135,7 +135,8 @@ def publisher_snap_measure(snap_name):
         'territories': country_data,
 
         # Context info
-        'is_linux': 'Linux' in flask.request.headers['User-Agent']
+        'is_linux': 'Linux' in flask.request.headers['User-Agent'],
+        'uploaded': uploaded
     }
 
     return flask.render_template(


### PR DESCRIPTION
# Summary

Allow upload screenshots with already existing screenshots

Fixes #262 
Fixes #267 

# QA

- `./run`
- http://0.0.0.0:8004/account/snaps/SNAP/market
- Choose some screenshots to be added
- Apply
- Screenshots should be visible
- Add some more screenshots
- You should have the previous screenshots in the market page
- You can verify in dashboard page for same snap that screenshots are uploaded