### PR TITLE
Adds snap name to market page (and fixes page title)

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,7 +1,7 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market details for {{ snap_title }}
+  Market details for {{ title }}
 {% endblock %}
 
 {% block content %}
@@ -90,6 +90,15 @@
             <div class="col-8">
               <label for="snap-title">Title:</label>
               <input id="snap-title" type="text" name="title" value="{{ title }}" {% if not uploaded %}readonly{% endif %}/>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+              <label>Snap name: </label>
+            </div>
+            <div class="col-8">
+                {{ snap_name }}
             </div>
           </div>
 


### PR DESCRIPTION
Fixes showing snap name in page title and adds read only snap name to market page (below editable snap title).

## QA

- ./run or http://snapcraft.io-pr-297.run.demo.haus/
- go to market page of snap you own
- browser page title (tab), page header and editable title should show same value (snap title)
- read-only snap package name should be shown below snap title

<img width="1182" alt="screen shot 2018-02-12 at 11 16 28" src="https://user-images.githubusercontent.com/83575/36092203-d514cffc-0fe6-11e8-9438-1336edff398d.png">
