### PR TITLE
Adds JS files to watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/d3-geo/build/d3-geo.min.js static/js/modules && cp node_modules/topojson-client/dist/topojson-client.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/moment/min/moment.min.js static/js/modules",
     "build-js-transpile": "rollup -c",
-    "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
+    "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
+    "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
+    "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle"
   },
   "author": "Canonical webteam",


### PR DESCRIPTION
Adds JS files to watcher.

## QA

Watch all:

1. ./run watch
2. change any SCSS file - CSS files should be rebuilt
3. change any JS file - JS files should be rebuilt

Watch JS only

1. ./run exec yarn run watch-js
2. change any JS file - JS files should be rebuilt

Watch SCSS only

1. ./run exec yarn run watch-scss
2. change any SCSS file - CSS files should be rebuilt
