### PR TITLE
Create username if user doesn't have one on snap store

### DIFF
--- a/app.py
+++ b/app.py
@@ -247,6 +247,18 @@ def post_agreement():
     return publisher_views.post_agreement()
 
 
+@app.route('/account/username')
+@login_required
+def get_account_name():
+    return publisher_views.get_account_name()
+
+
+@app.route('/account/username', methods=['POST'])
+@login_required
+def post_account_name():
+    return publisher_views.post_account_name()
+
+
 @app.route('/account/snaps/<snap_name>/measure')
 @login_required
 def publisher_snap_measure(snap_name):

--- a/modules/authentication.py
+++ b/modules/authentication.py
@@ -71,7 +71,13 @@ def request_macaroon():
     response = requests.request(
         url=url,
         method='POST',
-        json={'permissions': ['package_access', 'package_upload']},
+        json={
+            'permissions': [
+                'package_access',
+                'package_upload',
+                'edit_account'
+            ]
+        },
         headers={
             'Accept': 'application/json, application/hal+json',
             'Content-Type': 'application/json',

--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -137,6 +137,24 @@ def post_agreement(agreed):
     return agreement_response.json()
 
 
+def post_username(username):
+    headers = get_authorization_header()
+    json = {
+        'short_namespace': username
+    }
+    username_response = cache.get(
+        url=ACCOUNT_URL,
+        headers=headers,
+        json=json,
+        method='PATCH'
+    )
+
+    if username_response.status_code == 204:
+        return {}
+    else:
+        return username_response.json()
+
+
 def get_publisher_metrics(json):
     authed_metrics_headers = PUB_METRICS_QUERY_HEADERS.copy()
     auth_header = get_authorization_header()['Authorization']

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -19,6 +19,8 @@ def get_account():
             if error['code'] == 'user-not-ready':
                 if 'has not signed agreement' in error['message']:
                     return flask.redirect('/account/agreement')
+                elif 'missing namespace' in error['message']:
+                    return flask.redirect('/account/username')
             else:
                 error_list.append(error)
 
@@ -55,6 +57,27 @@ def post_agreement():
         return flask.redirect('/account')
     else:
         return flask.render_template('developer_programme_agreement.html')
+
+
+def get_account_name():
+    return flask.render_template('username.html')
+
+
+def post_account_name():
+    username = flask.request.form.get('username')
+
+    if username:
+        response = api.post_username(username)
+        if 'error_list' in response:
+            return flask.render_template(
+                'username.html',
+                username=username,
+                error_list=response['error_list']
+            )
+        else:
+            return flask.redirect('/account')
+    else:
+        return flask.render_template('username.html')
 
 
 def publisher_snap_measure(snap_name):

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -21,6 +21,7 @@ $color-accent: $color-brand;
 @include vf-p-footer;
 @include vf-p-tooltips;
 @include vf-p-forms;
+@include vf-p-form-help-text;
 @include vf-p-headings;
 @include vf-p-tabs;
 @include vf-p-matrix;

--- a/templates/developer_programme_agreement.html
+++ b/templates/developer_programme_agreement.html
@@ -1,7 +1,7 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-Developer Program Agreement — Linux software in the Snap Store
+    Developer Program Agreement — Linux software in the Snap Store
 {% endblock %}
 
 {% block content %}

--- a/templates/username.html
+++ b/templates/username.html
@@ -1,0 +1,49 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+Choose username — Linux software in the Snap Store
+{% endblock %}
+
+{% block content %}
+<section class="p-layout__main u-no-margin--top">
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <h3>Choose a snap store username</h3>
+      {% if error_list %}
+        {% for error in error_list %}
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            {{ error.message|safe }}
+          </p>
+        </div>
+      {% endfor %}
+    {% endif %}
+  </div>
+
+  <div class="row">
+    <form class="p-form p-form--stacked" method="POST" action="/account/username">
+      <div class="row">
+        <div class="col-7">
+          <label class="p-form__label" for="username">Username:</label>
+          <div class="p-form__control">
+            <input name="username" id="username" type="text" value="{{ username }}" required pattern="^[a-z0-9]+[a-z0-9-]*[a-z0-9]+$">
+            <p class="p-form-help-text">
+              <b>This name will appear as the owner of any snaps you create and cannot be changed.</b><br class="u-no-margin--top" />
+              Enter a value consisting of lower-case letters, numbers or hyphens.<br class="u-no-margin--top" />
+              Hyphens cannot occur at the start or end of the chosen value.
+            </p>
+          </div>
+        </div>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      </div>
+      <hr />
+      <div class="row u-no-margin--top">
+        <div class="u-float--right u-no-margin--top u-clear">
+          <a class="p-button--neutral" href="/">Cancel</a>
+          <button class="p-button--possitive u-no-margin--top" type="submit">Continue</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
# Summary
- Handle errors when a user is new:
  - Create a snap store username

# QA

- `./run`
- Create new account on login.ubuntu.com
- http://0.0.0.0:8004/account
- you should be redirected to the create username page
- http://0.0.0.0:8004/account/username
- Create username
- http://0.0.0.0:8004/account
- You should land on account page, Namespace should be the username choosen

# Screenshots

## New username
![screenshot-2018-3-15 choose username linux software in the snap store 1](https://user-images.githubusercontent.com/479384/37464911-adbdc066-2851-11e8-916a-e92532a27189.png)




