### PR TITLE
Adds selecting screenshots to market page

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -37,10 +37,39 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
 
   setState(initialState);
 
+  // actions on state
+  const addScreenshots = (files) => {
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      setState({
+        images: state.images.concat([{
+          file, url: URL.createObjectURL(file),
+          name: file.name,
+          type: "screenshot",
+          status: "new"
+        }])
+      });
+    }
+  };
+
+  const selectScreenshot = (url) => {
+    state.images.forEach(image => image.selected = false);
+
+    const screenshot = state.images.filter(image => image.url === url)[0];
+
+    if (url && screenshot) {
+      screenshot.selected = true;
+    }
+  };
+
   // templates
   const screenshotTpl = (screenshot) => `
     <div class="col-2">
-      <img src="${screenshot.url}" alt="" />
+      <img
+        class="p-screenshot ${screenshot.selected ? 'selected' : ''}"
+        src="${screenshot.url}"
+        alt=""
+      />
     </div>
   `;
 
@@ -65,24 +94,16 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   render();
 
   const onScreenshotsChange = function() {
-    const fileList = this.files;
-
-    for (let i = 0; i < fileList.length; i++) {
-      const file = fileList[i];
-      setState({
-        images: state.images.concat([{
-          file, url: URL.createObjectURL(file),
-          name: file.name,
-          type: "screenshot",
-          status: "new"
-        }])
-      });
-    }
-
+    addScreenshots(this.files);
     render();
   };
 
+  // delegated click handlers
   document.addEventListener("click", function(event){
+    // unselect any screenshots when clicked outside of them
+    selectScreenshot();
+
+    // clicking on [+] add screenshots button
     if (event.target.classList.contains('js-add-screenshots')
         || event.target.parentNode.classList.contains('js-add-screenshots')
       ) {
@@ -99,6 +120,14 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
       input.addEventListener("change", onScreenshotsChange);
       input.click();
     }
+
+    // clicking on screenshot to select it
+    if (event.target.classList.contains('p-screenshot')) {
+      event.preventDefault();
+      selectScreenshot(event.target.src);
+    }
+
+    render();
   });
 }
 

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -11,4 +11,11 @@
     padding: $sp-x-large;
     text-align: center;
   }
+
+  .p-screenshot {
+    &.selected {
+      outline: 1px solid $color-focus;
+      outline-offset: 2px;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #285 

## QA

- ./run or http://snapcraft.io-pr-301.run.demo.haus/
- go to market page of snap you own
- add some screenshots
- click on a screenshot - it should get selected
- click on other screenshot - it should get selected
- click anywhere else on the page - screenshots should not be selected anymore

<img width="1015" alt="screen shot 2018-02-13 at 12 41 21" src="https://user-images.githubusercontent.com/83575/36148375-17785b04-10bc-11e8-8b10-e56da90e5568.png">
