### PR TITLE
Adds snapcraft logo to social share meta data

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -10,6 +10,7 @@
       <meta property="og:site_name" content="Snapcraft"/>
       <meta property="og:type" content="website"/>
       <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
+      <meta property="og:image" content="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png" />
       <meta property="twitter:site" content="@snapcraftio" />
     {% endblock %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <meta property="og:type" content="website"/>
     <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
     <meta property="twitter:site" content="@snapcraftio" />
+    <meta property="og:image" content="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png" />
 
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -9,7 +9,11 @@
   <meta property="og:type" content="product"/>
 
   {% if summary %}<meta property="og:description" content="{{ summary }}"/>{% endif %}
-  {% if icon_url %}<meta property="og:image" content="{{ icon_url }}"/>{% endif %}
+  {% if icon_url %}
+    <meta property="og:image" content="{{ icon_url }}"/>
+  {% else %}
+    <meta property="og:image" content="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png" />
+  {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/284

Fixes showing ubuntu image when sharing snapcraft.io

### QA

- Try sharing http://snapcraft.io-pr-302.run.demo.haus/ on Facebook or use https://developers.facebook.com/tools/debug/sharing/
- Preview should show snapcraft logo (not Ubuntu logo)
- Same result should be for store page: http://snapcraft.io-pr-302.run.demo.haus/store
- Snap page should show given snap icon: http://snapcraft.io-pr-302.run.demo.haus/spotify

<img width="1008" alt="screen shot 2018-02-14 at 12 44 53" src="https://user-images.githubusercontent.com/83575/36203024-539525f2-1186-11e8-823c-fdca35ea45c6.png">

