### PR TITLE
Display 404 page when snap not found for market page

### DIFF
--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -125,6 +125,10 @@ def get_snap_info(snap_name):
         headers=get_authorization_header()
     )
 
+    if response.status_code == 404:
+        message = 'Snap not found: {snap_name}'.format(**locals())
+        flask.abort(404, message)
+
     return response.json()
 
 
@@ -180,8 +184,3 @@ def snap_screenshots(snap_id, data=None, files=None):
     )
 
     return screenshot_response.json()
-
-
-def is_snap_uploaded(snap_name):
-    user_snaps = get_account()
-    return user_snaps['snaps']['16'][snap_name]['uploaded']

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -33,20 +33,7 @@ def publisher_snap_measure(snap_name):
     some of the data through to the publisher/measure.html template,
     with appropriate sanitation.
     """
-    uploaded = api.is_snap_uploaded(snap_name)
-
-    if not uploaded:
-        context = {
-            'snap_title': snap_name,
-            'snap_name': snap_name,
-            'uploaded': uploaded
-        }
-
-        return flask.render_template(
-            'publisher/measure.html',
-            **context
-        )
-
+    details = api.get_snap_info(snap_name)
     metric_period = flask.request.args.get('period', default='30d', type=str)
     metric_bucket = ''.join([i for i in metric_period if not i.isdigit()])
     metric_period_int = int(metric_period[:-1])
@@ -56,8 +43,6 @@ def publisher_snap_measure(snap_name):
         default='version',
         type=str
     )
-
-    details = api.get_snap_info(snap_name)
 
     today = datetime.datetime.utcnow().date()
     end = today - relativedelta.relativedelta(days=1)
@@ -139,8 +124,7 @@ def publisher_snap_measure(snap_name):
         'territories': country_data,
 
         # Context info
-        'is_linux': 'Linux' in flask.request.headers['User-Agent'],
-        'uploaded': uploaded
+        'is_linux': 'Linux' in flask.request.headers['User-Agent']
     }
 
     return flask.render_template(
@@ -150,31 +134,19 @@ def publisher_snap_measure(snap_name):
 
 
 def get_market_snap(snap_name):
-    uploaded = api.is_snap_uploaded(snap_name)
+    snap_details = api.get_snap_info(snap_name)
 
-    if not uploaded:
-        context = {
-            "snap_name": snap_name,
-            "title": snap_name,
-
-            # Check if snap is uploaded or not
-            "uploaded": uploaded
-        }
-    else:
-        snap_details = api.get_snap_info(snap_name)
-        context = {
-            "snap_id": snap_details['snap_id'],
-            "snap_name": snap_details['snap_name'],
-            "title": snap_details['title'],
-            "summary": snap_details['summary'],
-            "description": snap_details['description'],
-            "license": snap_details['license'],
-            "icon_url": snap_details['icon_url'],
-            "publisher_name": snap_details['publisher_name'],
-            "screenshot_urls": snap_details['screenshot_urls'],
-            # Check if snap is uploaded or not
-            "uploaded": uploaded
-        }
+    context = {
+        "snap_id": snap_details['snap_id'],
+        "snap_name": snap_details['snap_name'],
+        "title": snap_details['title'],
+        "summary": snap_details['summary'],
+        "description": snap_details['description'],
+        "license": snap_details['license'],
+        "icon_url": snap_details['icon_url'],
+        "publisher_name": snap_details['publisher_name'],
+        "screenshot_urls": snap_details['screenshot_urls']
+    }
 
     return flask.render_template(
         'publisher/market.html',
@@ -211,14 +183,7 @@ def build_image_info(image, image_type):
 
 
 def post_market_snap(snap_name):
-    uploaded = api.is_snap_uploaded(snap_name)
-
-    if not uploaded:
-        return flask.redirect(
-            "/account/snaps/{snap_name}/market".format(
-                snap_name=snap_name
-            )
-        )
+    snap_id = api.get_snap_id(snap_name)
 
     if 'submit_revert' in flask.request.form:
         flask.flash("All changes reverted.", 'information')
@@ -230,7 +195,7 @@ def post_market_snap(snap_name):
 
         # Add existing screenshots
         screenshots_uploaded = api.snap_screenshots(
-            flask.request.form['snap_id']
+            snap_id
         )
         state_screenshots = loads(flask.request.form['state'])['images']
         for screenshot in state_screenshots:
@@ -256,7 +221,7 @@ def post_market_snap(snap_name):
             images_json = {'info': dumps(info)}
 
         screenshots_response = api.snap_screenshots(
-            flask.request.form['snap_id'],
+            snap_id,
             images_json,
             images_files
         )
@@ -300,8 +265,7 @@ def post_market_snap(snap_name):
                 "icon_url": snap_details['icon_url'],
                 "publisher_name": snap_details['publisher_name'],
                 "screenshot_urls": snap_details['screenshot_urls'],
-                "error_list": error_list,
-                "uploaded": uploaded
+                "error_list": error_list
             }
 
             return flask.render_template(

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -27,17 +27,6 @@
     </section>
 
     <div class="p-strip is-shallow">
-      {% if not uploaded %}
-          <div class="row">
-            <div class="col-12">
-                <div class="p-notification--negative">
-                  <p class="p-notification__response">
-                      You need to upload your snap before updating snap metadata.
-                  </p>
-                </div>
-            </div>
-          </div>
-      {% else %}
         <form id="market-form" method="POST" enctype='multipart/form-data'>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <input type="hidden" name="snap_id" value="{{ snap_id }}" />
@@ -45,8 +34,8 @@
 
           <div class="row">
             <div class="col-12 u-align--right">
-                <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert" {% if not uploaded %}disabled{% endif %}/>
-                <input type="submit" class="p-button--positive" name="submit_apply" value="Apply" {% if not uploaded %}disabled{% endif %}/>
+                <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert"/>
+                <input type="submit" class="p-button--positive" name="submit_apply" value="Apply"/>
                 <hr />
             </div>
           </div>
@@ -89,7 +78,7 @@
             </div>
             <div class="col-8">
               <label for="snap-title">Title:</label>
-              <input id="snap-title" type="text" name="title" value="{{ title }}" {% if not uploaded %}readonly{% endif %}/>
+              <input id="snap-title" type="text" name="title" value="{{ title }}"/>
             </div>
           </div>
 
@@ -122,7 +111,7 @@
               <label>Summary: </label>
             </div>
             <div class="col-8">
-              <input type="text" name="summary" value="{{ summary }}" {% if not uploaded %}readonly{% endif %}/>
+              <input type="text" name="summary" value="{{ summary }}"/>
             </div>
           </div>
           <div class="row">
@@ -130,7 +119,7 @@
               <label>Description: </label>
             </div>
             <div class="col-8">
-              <textarea name="description" {% if not uploaded %}readonly{% endif %}>{{ description }}</textarea>
+              <textarea name="description">{{ description }}</textarea>
             </div>
           </div>
 
@@ -178,11 +167,10 @@
               <label>Developer website: </label>
             </div>
             <div class="col-8">
-              <input type="text" name="contact" value="{{ contact }}" {% if not uploaded %}readonly{% endif %}/>
+              <input type="text" name="contact" value="{{ contact }}"/>
             </div>
           </div>
         </form>
-      {% endif %}
     </div>
 
     {% if api_error %}
@@ -201,7 +189,6 @@
 {% endblock %}
 
 {% block scripts %}
-{% if uploaded %}
 <script src="/static/js/dist/publisher.js"></script>
 <script>
   snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
@@ -220,5 +207,4 @@
     }
   );
 </script>
-{% endif %}
 {% endblock %}

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -26,17 +26,6 @@
       </nav>
     </section>
     <section class="p-strip is-shallow">
-      {% if not uploaded %}
-        <div class="row">
-          <div class="col-12">
-              <div class="p-notification--negative">
-                <p class="p-notification__response">
-                    You need to upload your snap before accessing measures.
-                </p>
-              </div>
-          </div>
-        </div>
-      {% else %}
         <div class="row">
           <div class="grid">
             {#<div class="col-3">
@@ -103,7 +92,6 @@
             #}
           {#</div>
         </div>#}
-      {% endif %}
     </section>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Summary

When user tries to acces market page for a snap he doesn't own, redirection to 404 page

# QA

- `./run`
- http://0.0.0.0:8004/account/snaps/toto0/market
- Should display a 404 page
- Try to acces the same page but for a non uploaded snap
- Should diplay the same message: upload needed...