### PR TITLE
Developer website > Developer contact

### DIFF
--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -45,7 +45,7 @@
         {% for paragraph in description_paragraphs %}
           <p>{{ paragraph | safe }}</p>
         {% endfor %}
-        {% if support_url %}<p><a href="{{ support_url }}">Developer website</a></p>{% endif %}
+        {% if support_url %}<p><a href="{{ support_url }}">Developer contact</a></p>{% endif %}
       </div>
       <div class="col-4">
         <table class="p-table-key-value">


### PR DESCRIPTION
# Done

- Changed the 'Developer website' link to 'Developer contact' as sometimes developers put their email address in. This is a short term solution until we implement the new fields.

# QA

- Pull this branch
- `./run`
- Go to a snap and ensure the 'Developer website' link now says 'Develop contact'
- Try a few more snaps