### PR TITLE
Fix #310 "Incorrect country/region name"

### DIFF
--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -84,7 +84,7 @@ def build_country_info(users_by_country, display_number_users=False):
             color_rgb = country_info['color_rgb'] or [247, 247, 247]
 
         country_data[country.numeric] = {
-            'name': country.name,
+            'name': country.common_name,
             'code': country.alpha_2,
             'percentage_of_users': percentage_of_users,
             'color_rgb': color_rgb


### PR DESCRIPTION
Instead of discussing political issues, use `common_name` is the well known and well discussed solution, already agreed and implemented in LoCo Team Portal.
https://bugs.launchpad.net/loco-team-portal/+bug/614236