### PR TITLE
Market page screenshots lightbox

### DIFF
--- a/static/js/publisher/market/lightbox.js
+++ b/static/js/publisher/market/lightbox.js
@@ -1,0 +1,159 @@
+function openLightbox(url, images) {
+  const lightboxEl = initLightboxEl(images);
+
+  openLightboxEl(lightboxEl, url, images);
+}
+
+const lightboxTpl = `
+  <div class="vbox-preloader">Loading...</div>
+  <div class="vbox-container">
+    <div class="vbox-content">
+      <img class="figlio" >
+    </div>
+  </div>
+
+  <div class="vbox-title" style="display: none;"></div>
+  <div class="vbox-num" style="display: none;">0/0</div>
+  <div class="vbox-close">X</div>
+  <button class="vbox-next">next</button>
+  <button class="vbox-prev">prev</button>
+`;
+
+const initLightboxEl = () => {
+  const lightboxEl = document.createElement('div');
+  lightboxEl.className = 'vbox-overlay';
+  lightboxEl.style.display = 'none';
+  lightboxEl.style.display = '0';
+  lightboxEl.innerHTML = lightboxTpl;
+
+  // adjust positioning when image loads
+  const contentEl = lightboxEl.querySelector('.vbox-content');
+  const lightboxImgEl = lightboxEl.querySelector('.vbox-content img');
+
+  lightboxImgEl.addEventListener('load', () => {
+    contentEl.style.opacity = "1";
+  });
+
+  const closeLightbox = (event) => {
+    event.preventDefault();
+    closeLightboxEl(lightboxEl);
+  };
+
+  lightboxEl.querySelector('.vbox-close').addEventListener('click', closeLightbox);
+  lightboxEl.addEventListener('click', (event) => {
+    const ignore = [
+      'figlio',
+      'vbox-next',
+      'vbox-prev'
+    ];
+    // This assumes a single class on each item
+    if (ignore.indexOf(event.target.className) < 0){
+      closeLightbox(event);
+    }
+  });
+
+  return lightboxEl;
+};
+
+const loadLightboxImage = (lightboxEl, url, images) => {
+  // hide content before it loads
+  lightboxEl.querySelector('.vbox-content').style.opacity = "0";
+
+  // load image
+  lightboxEl.querySelector('.vbox-content img').src = url;
+
+  // update prev/next buttons
+  if (images && images.length) {
+    const imageIndex = images.indexOf(url);
+
+    if (imageIndex > 0) {
+      lightboxEl.querySelector('.vbox-prev').removeAttribute('disabled');
+      lightboxEl.querySelector('.vbox-prev').dataset.url = images[imageIndex - 1];
+    } else {
+      lightboxEl.querySelector('.vbox-prev').setAttribute('disabled', 'disabled');
+      lightboxEl.querySelector('.vbox-prev').dataset.url = null;
+    }
+
+    if (imageIndex < images.length-1) {
+      lightboxEl.querySelector('.vbox-next').removeAttribute('disabled');
+      lightboxEl.querySelector('.vbox-next').dataset.url = images[imageIndex + 1];
+    } else {
+      lightboxEl.querySelector('.vbox-next').setAttribute('disabled', 'disabled');
+      lightboxEl.querySelector('.vbox-next').dataset.url = null;
+    }
+  }
+};
+
+const openLightboxEl = (lightboxEl, url, images) => {
+  // prepare navigating to next/prev images
+  if (images && images.length) {
+    const handleNextPrevClick = (event) => {
+      event.preventDefault();
+      if (event.target.dataset.url) {
+        loadLightboxImage(lightboxEl, event.target.dataset.url, images);
+      }
+    };
+
+    const handleNextPrevKey = (event) => {
+      const KEYS = {
+        ESC: 27,
+        LEFT: 37,
+        RIGHT: 39
+      };
+      let image;
+      switch(event.keyCode) {
+        case KEYS.ESC:
+          closeLightboxEl(lightboxEl);
+          break;
+        case KEYS.LEFT:
+          image = lightboxEl.querySelector('.vbox-prev').dataset.url;
+          if (image !== 'null') {
+            loadLightboxImage(
+              lightboxEl,
+              image,
+              images
+            );
+          }
+          break;
+        case KEYS.RIGHT:
+          image = lightboxEl.querySelector('.vbox-next').dataset.url;
+          if (image !== 'null') {
+            loadLightboxImage(
+              lightboxEl,
+              image,
+              images
+            );
+          }
+          break;
+      }
+    };
+
+    lightboxEl.querySelector('.vbox-next').addEventListener('click', handleNextPrevClick);
+    lightboxEl.querySelector('.vbox-prev').addEventListener('click', handleNextPrevClick);
+    window.addEventListener('keyup', handleNextPrevKey);
+  }
+
+  // open lightbox
+  document.body.classList.add('vbox-open');
+  document.body.appendChild(lightboxEl);
+  lightboxEl.style.opacity = '1';
+  lightboxEl.style.display = 'block';
+
+  // load image
+  loadLightboxImage(lightboxEl, url, images);
+};
+
+const closeLightboxEl = (lightboxEl) => {
+  lightboxEl.style.opacity = '0';
+  lightboxEl.style.display = 'none';
+  if (lightboxEl.parentNode) {
+    lightboxEl.parentNode.removeChild(lightboxEl);
+  }
+  document.body.classList.remove('vbox-open');
+};
+
+const lightbox = {
+  openLightbox
+};
+
+export default lightbox;

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -1,3 +1,5 @@
+import lightbox from './lightbox';
+
 function initSnapIconEdit(iconElId, iconInputId) {
   const snapIconInput = document.getElementById(iconInputId);
   const snapIconEl = document.getElementById(iconElId);
@@ -100,8 +102,27 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
 
   // delegated click handlers
   document.addEventListener("click", function(event){
-    // unselect any screenshots when clicked outside of them
-    selectScreenshot();
+    if (event.target.classList.contains('js-fullscreen-screenshot')
+        || (event.target.parentNode && event.target.parentNode.classList.contains('js-fullscreen-screenshot'))
+      ) {
+      event.preventDefault();
+      let screenshot = state.images.filter(image => image.selected)[0];
+
+      // if none is selected pick first screenshot from list
+      if (!screenshot) {
+        screenshot = state.images.filter(image => image.type === 'screenshot')[0];
+      }
+
+      if (screenshot) {
+        lightbox.openLightbox(
+          screenshot.url,
+          state.images.filter(image => image.type === 'screenshot').map(image => image.url)
+        );
+      }
+    } else {
+      // unselect any screenshots when clicked outside of them
+      selectScreenshot();
+    }
 
     // clicking on [+] add screenshots button
     if (event.target.classList.contains('js-add-screenshots')
@@ -125,9 +146,27 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
     if (event.target.classList.contains('p-screenshot')) {
       event.preventDefault();
       selectScreenshot(event.target.src);
+      setTimeout(() => {
+        render();
+      }, 50);
+      return;
     }
 
     render();
+  });
+
+  document.addEventListener('dblclick', event => {
+    if (event.target.classList.contains('p-screenshot')) {
+      event.preventDefault();
+      let screenshot = state.images.filter(image => image.selected)[0];
+
+      if (screenshot) {
+        lightbox.openLightbox(
+          screenshot.url,
+          state.images.filter(image => image.type === 'screenshot').map(image => image.url)
+        );
+      }
+    }
   });
 }
 

--- a/static/sass/_patterns_maas_modal.scss
+++ b/static/sass/_patterns_maas_modal.scss
@@ -1,0 +1,255 @@
+// https://github.com/canonical-websites/maas.io/blob/master/static/sass/_settings_colors.scss
+$color-modal-overlay:  rgba($color-x-dark, .85);
+$color-modal-controls: rgba($color-x-dark, .2);
+
+// https://github.com/canonical-websites/maas.io/blob/master/static/sass/_patterns_modal.scss
+@mixin maas-p-modal {
+  .venobox {
+    width: auto;
+
+    &--expand {
+      margin: 0 auto 20px;
+      overflow: visible;
+      position: relative;
+
+      > img {
+        margin: 0 auto;
+      }
+
+      &::after {
+        background: {
+          color: $color-dark;
+          image: url('#{$assets-path}495995ef-fullscreen-white.svg');
+          position: center;
+          repeat: no-repeat;
+          size: 50%;
+        }
+        bottom: 15px;
+        box-shadow: 0 5px 10px 0 $color-modal-controls;
+        content: '';
+        display: block;
+        height: 20px;
+        position: absolute;
+        right: 15px;
+        width: 20px;
+      }
+    }
+  }
+
+  // venobox.css
+  .vbox-overlay *,
+  .vbox-overlay *::before,
+  .vbox-overlay *::after {
+    box-sizing: border-box;
+  }
+
+  // overlay: change here background color and opacity ----- */
+  .vbox-overlay {
+    background: $color-modal-overlay;
+    bottom: 0;
+    height: auto;
+    left: 0;
+    margin-top: 0;
+    opacity: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 9999;
+  }
+
+  // preloader - choose between CIRCLE, IOS, DOTS, QUADS
+
+  // circle preloader
+  .vbox-preloader {
+    background-image: url('preload-circle.png');
+    height: 32px;
+    left: 50%;
+    margin-left: -16px;
+    margin-top: -16px;
+    overflow: hidden;
+    position: fixed;
+    text-indent: -100px;
+    top: 50%;
+    width: 32px;
+  }
+
+  @keyframes playload {
+    from { background-position:    0; }
+    to { background-position: -576px; }
+  }
+
+  // navigation
+  .vbox-close {
+    background: url('#{$assets-path}345e40a0-close_16_white.svg') no-repeat;
+    background-position: center;
+    background-size: 1rem;
+    color: $color-x-light;
+    cursor: pointer;
+    display: block;
+    height: 2rem;
+    margin-top: 0;
+    overflow: hidden;
+    position: fixed;
+    right: 1rem;
+    text-indent: -100px;
+    top: 1rem;
+    width: 2rem;
+
+    @media screen and (max-width: $breakpoint-medium) {
+      background-position: top 20px right 20px;
+    }
+  }
+
+  .vbox-next,
+  .vbox-prev {
+    background-color: $color-x-light;
+    box-sizing: content-box;
+    cursor: pointer;
+    height: 3rem;
+    margin-top: -1.5rem;
+    overflow: hidden;
+    padding: 0;
+    position: fixed;
+    text-indent: -100px;
+    top: 50%;
+    width: 3rem;
+    border-radius: 3rem;
+    background: {
+      position: center;
+      repeat: no-repeat;
+      size: .25rem;
+    }
+  }
+
+  .vbox-next:disabled:hover,
+  .vbox-prev:disabled:hover {
+    background-color: $color-x-light;
+  }
+
+  .vbox-prev {
+    background-image: url('#{$assets-path}e8d2e45f-chevron-left.svg');
+    left: 1rem;
+  }
+
+  .vbox-next {
+    background-image: url('#{$assets-path}9716bbab-chevron.svg');
+    right: 1rem;
+  }
+
+  .vbox-title {
+    background: $color-dark;
+    bottom: 0;
+    color: $color-x-light;
+    display: none;
+    float: left;
+    font-size: 1rem;
+    height: auto;
+    left: 0;
+    line-height: 28px;
+    overflow: hidden;
+    padding: 40px;
+    position: fixed;
+    text-align: center;
+    width: 100%;
+
+    @media screen and (max-width: 1024px) {
+      bottom: 25px;
+    }
+  }
+
+  .vbox-num {
+    background: $color-dark;
+    color: $color-x-light;
+    cursor: pointer;
+    display: none;
+    font-size: 12px;
+    height: 40px;
+    left: 0;
+    line-height: 28px;
+    overflow: hidden;
+    padding: 6px 10px;
+    position: fixed;
+    top: -1px;
+  }
+
+  // inline window
+  .vbox-inline {
+    background: $color-x-light;
+    height: 315px;
+    margin: 0 auto;
+    overflow: auto;
+    padding: 10px;
+    text-align: left;
+    width: 420px;
+  }
+
+  // Video & iFrames window
+  .venoframe {
+    border: 0;
+    height: 100%;
+    min-height: 600px;
+    width: 100%;
+  }
+
+  @media (max-width: 992px) {
+    .venoframe {
+      height: 480px;
+      min-height: inherit;
+      width: 640px;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .venoframe {
+      height: 315px;
+      min-height: inherit;
+      width: 420px;
+    }
+  }
+
+  @media (max-width: 460px) {
+    .vbox-inline {
+      width: 100%;
+    }
+
+    .venoframe {
+      height: 260px;
+      min-height: inherit;
+      width: 100%;
+    }
+  }
+
+  // PLease do NOT edit this! (or do it at your own risk)
+  .vbox-open {
+    overflow: hidden;
+  }
+
+  .vbox-container {
+    margin: 0 auto;
+    max-width: 1200px;
+    padding: 0 15px;
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  .vbox-content {
+    float: left;
+    overflow: hidden;
+    position: relative;
+    text-align: center;
+    width: 100%;
+    height: 100%;
+    padding: 40px 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .vbox-container img {
+    max-height: 100%;
+    max-width: 100%;
+  }
+}

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -3,6 +3,15 @@
     align-items: baseline;
     display: flex;
     justify-content: space-between;
+
+    .p-screenshots-toolbar__buttons {
+      margin: 0;
+    }
+
+    .p-icon--fullscreen {
+      @extend %icon;
+      background-image: url('#{$assets-path}c566f22e-fullscreen-grey_16.svg');
+    }
   }
 
   .p-empty-add-screenshots {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -95,3 +95,6 @@ $color-accent: $color-brand;
 
 @import 'snapcraft_snap-list';
 @include snapcraft-snap-list;
+
+@import 'patterns_maas_modal';
+@include maas-p-modal;

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -133,7 +133,10 @@
             <div class="col-12">
               <div class="p-screenshots-toolbar" id="screenshots-toolbar">
                 <label>Screenshots:</label>
-                <button class="p-button-neutral js-add-screenshots" id="snap-add-screenshot"><i class="p-icon--plus"></i></button>
+                <div class="p-screenshots-toolbar__buttons">
+                  <button class="p-button-neutral js-fullscreen-screenshot"><i class="p-icon--fullscreen"></i></button>
+                  <button class="p-button-neutral js-add-screenshots u-no-margin--top"><i class="p-icon--plus"></i></button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #287 

Adds previewing screenshots in lightbox to market page

## QA

- ./run or http://snapcraft.io-pr-314.run.demo.haus/
- go to market page of a snap you own
- if it doesn't have screenshots add some (you don't have to upload them)
- click on a 'fullscreen' button next to screenshots
- screenshots should open in lightbox
- you should be able to navigate through screenshots (clicking next/prev buttons)

<img width="1027" alt="screen shot 2018-02-16 at 11 52 28" src="https://user-images.githubusercontent.com/83575/36304463-07ac67be-1310-11e8-8d02-4d98d80c8547.png">

<img width="1509" alt="screen shot 2018-02-16 at 11 53 03" src="https://user-images.githubusercontent.com/83575/36304462-07924492-1310-11e8-8c59-8827f42624de.png">

