### PR TITLE
Further account updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,6 +39,12 @@ LOGIN_URL = os.getenv(
 )
 
 
+# Make LOGIN_URL available in all templates
+@app.context_processor
+def inject_login():
+    return dict(LOGIN_URL=LOGIN_URL)
+
+
 def login_required(func):
     """
     Decorator that checks if a user is logged in, and redirects

--- a/static/sass/_snapcraft_snap-list.scss
+++ b/static/sass/_snapcraft_snap-list.scss
@@ -1,0 +1,14 @@
+@mixin snapcraft-snap-list {
+  .p-snap-list {
+
+    &__image {
+      width: 32px;
+      height: 32px;
+    }
+
+    &__image,
+    &__name {
+      margin-right: $sp-medium;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -92,3 +92,6 @@ $color-accent: $color-brand;
 
 @import 'snapcraft_market_screenshots';
 @include snapcraft-market-screenshots;
+
+@import 'snapcraft_snap-list';
+@include snapcraft-snap-list;

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,69 +1,83 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-    Account page — Linux software in the Snap Store
+Account page — Linux software in the Snap Store
 {% endblock %}
 
 {% block content %}
-
   <section class="p-strip is-shallow">
-      <div class="row">
-          <div class="col-2">
-              {% if user.image %}
-                  <img class="p-media-object__image--large" src="{{ user.image }}" alt="{{ user.nickname }} account" />
-              {% else %}
-                  <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
-              {% endif %}
-          </div>
-          <div class="col-9">
-              <h1 class="u-no-margin">{{ user.nickname }}</h1>
-              <table class="p-table-key-value">
-                  <tr><th width="100">Full name</th><td>{{ user.fullname }}</td></tr>
-                  <tr><th>Username</th><td>{{ user.nickname }}</td></tr>
-                  <tr><th>Email</th><td>{{ user.email }}</td></tr>
-                  <tr><th>Namespace</th><td>{{ namespace }}</td></tr>
-              </table>
-          </div>
+    <div class="row">
+      <div class="col-2">
+        {% if user.image %}
+          <img class="p-media-object__image--large" src="{{ user.image }}" alt="{{ user.nickname }} account" />
+        {% else %}
+          <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
+        {% endif %}
       </div>
+      <div class="col-9">
+        <h1 class="u-no-margin">{{ user.nickname }}</h1>
+        <table class="p-table-key-value">
+          <tr><th width="100">Full name</th><td>{{ user.fullname }}</td></tr>
+          <tr>
+            <th>Username</th>
+            <td>
+              {{ user.nickname }} <a href="{{ LOGIN_URL }}" class="p-link--external">Edit</a>
+            </td>
+          </tr>
+          <tr><th>Email</th><td>{{ user.email }}</td></tr>
+          <tr><th>Namespace</th><td>{{ namespace }}</td></tr>
+        </table>
+      </div>
+    </div>
   </section>
 
   <section class="p-strip is-shallow">
-      <div class="row">
-          <div class="col-12">
-              <h3>My snaps</h3>
-              <table>
-                  <tr>
-                      <th>Name</th>
-                      <th>Status</th>
-                  </tr>
-                  {% if not user_snaps %}
-                  <tr>
-                      <td>You have uploaded no snap yet!</td>
-                  </tr>
-                  {% else %}
-                    {% for snap in user_snaps|sort %}
-                        <tr>
-                            <td class="u-vertically-center">
-                                {% if user_snaps[snap].icon_url %}
-                                    <img src="{{ user_snaps[snap].icon_url }}" width="32" height="32" />&nbsp;
-                                {% else %}
-                                    <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" width="32" height="32" />&nbsp;
-                                {% endif %}
-                                {% if user_snaps[snap].uploaded %}
-                                    <a href="/account/snaps/{{snap}}/market" class="u-no-margin--top">{{snap}}</a>
-                                {% else %}
-                                    {{snap}}
-                                {% endif %}
-                                {% if user_snaps[snap].private %}
-                                    &nbsp;<small class="u-no-margin--top">Private</small>
-                                {% endif %}
-                            </td>
-                            <td>{{ user_snaps[snap].status }}</td>
-                        </tr>
-                    {% endfor %}
+    <div class="row">
+      <div class="col-12">
+        <h3>My snaps</h3>
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Status</th>
+          </tr>
+          {% if not user_snaps %}
+            <tr>
+              <td>You have not uploaded or registered a snap yet!</td>
+            </tr>
+          {% else %}
+            {% for snap in user_snaps|sort %}
+              <tr>
+                <td class="u-vertically-center p-snap-list">
+                  {% if user_snaps[snap].uploaded %}
+                    <a href="/account/snaps/{{snap}}/market" class="u-no-margin--top u-vertically-center">
                   {% endif %}
-              </table>
-          </div>
+                  {% if user_snaps[snap].icon_url %}
+                    <img src="{{ user_snaps[snap].icon_url }}" class="p-snap-list__image" />
+                  {% else %}
+                    <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-snap-list__image" />
+                  {% endif %}
+                  <span class="p-snap-list__name u-no-margin--top">
+                    {{snap}}
+                  </span>
+                  {% if user_snaps[snap].uploaded %}
+                    </a>
+                  {% endif %}
+                  {% if user_snaps[snap].private %}
+                    <small class="u-no-margin--top">Private</small>
+                  {% endif %}
+                </td>
+                <td>
+                  {% if not user_snaps[snap].uploaded %}
+                    Name registered. No snap uploaded.
+                  {% else %}
+                    {{ user_snaps[snap].status }}
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          {% endif %}
+        </table>
       </div>
+    </div>
   </section>
 {% endblock %}


### PR DESCRIPTION
# Done

This pull request satisfies the remaining 'Phase 1' items in https://docs.google.com/document/d/1L6Dj77LGUJnbngyzceZcDrkf8iygx2HNAc471xjRaQE/edit#heading=h.q0rl1q8l4z1o:

1. User details (editable) - Links off to SSO (login.ubuntu.com)
2. Snap list - Registered names vs actual snaps

This should also satisfy https://github.com/CanonicalLtd/snappy-design-squad/issues/358 in it's current state (@Greggless to confirm).

# QA

- Pull this branch
- `./run`
- View your account page:
  - 'Username' should have an 'Edit' button that links to https://login.ubuntu.com
  - Spacing of icon, snap name and 'private' flag should be better
  - The 'Status' column should indicate whether a snap is a registered name.