### PR TITLE
Testing publisher pages (with authentication).

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ def login_required(func):
 
 
 def redirect_to_login():
-    return flask.redirect('login?next=' + flask.request.url_rule.rule)
+    return flask.redirect('login?next=' + flask.request.path)
 
 
 # Error handlers

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pymacaroons==0.12.0
 python-dateutil==2.6.1
 requests==2.18.4
 requests-cache==0.4.13
+responses==0.8.1

--- a/run
+++ b/run
@@ -443,7 +443,7 @@ case $run_command in
         # Generic python tests
         if [ -f tests.py ]; then
             echo "- Running python tests from tests.py"
-            python_run "" python3 tests.py || test_error=true
+            python_run "" python3  -m unittest -vvv tests.py || test_error=true
         fi
 
         # Run flake8 (python syntax) checks

--- a/run
+++ b/run
@@ -443,7 +443,7 @@ case $run_command in
         # Generic python tests
         if [ -f tests.py ]; then
             echo "- Running python tests from tests.py"
-            python_run "" python3  -m unittest -vvv tests.py || test_error=true
+            python_run "" python3 tests.py || test_error=true
         fi
 
         # Run flake8 (python syntax) checks

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,18 @@
 #! /usr/bin/env python3
 
-import app
+import json
 import unittest
-from urllib.parse import urlparse, urlunparse
+
+import pymacaroons
+import responses
+import urllib
+
+import app
+from modules.authentication import get_authorization_header
+
+
+# Make sure tests fail on stray responses.
+responses.mock.assert_all_requests_are_fired = True
 
 
 class WebAppTestCase(unittest.TestCase):
@@ -84,8 +94,9 @@ class WebAppTestCase(unittest.TestCase):
         """
 
         # Check trailing slashes trigger redirect
-        parsed_uri = urlparse(uri)
-        slash_uri = urlunparse(parsed_uri._replace(path=parsed_uri.path + '/'))
+        parsed_uri = urllib.parse.urlparse(uri)
+        slash_uri = urllib.parse.urlunparse(
+            parsed_uri._replace(path=parsed_uri.path + '/'))
         redirect_response = self.app.get(slash_uri)
         assert redirect_response.status_code == 302
 
@@ -109,6 +120,137 @@ class WebAppTestCase(unittest.TestCase):
         assert "Ubuntu and Canonical are registered" in str(response.data)
 
         return response
+
+
+def _log_in(client):
+    """Emulates test client login in the store.
+
+    Fill current session with `openid`, `macaroon_root` and
+    `macaroon_discharge`.
+
+    Return the expected `Authorization` header for further verification in API
+    requests.
+    """
+    # Basic root/discharge macaroons pair.
+    root = pymacaroons.Macaroon('test', 'testing', 'a_key')
+    root.add_third_party_caveat('3rd', 'a_caveat-key', 'a_ident')
+    discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
+
+    with client.session_transaction() as s:
+        s['openid'] = 'fake'
+        s['macaroon_root'] = root.serialize()
+        s['macaroon_discharge'] = discharge.serialize()
+
+    return get_authorization_header(root.serialize(), discharge.serialize())
+
+
+class PublisherPagesTestCase(unittest.TestCase):
+    """Integration tests for the publisher pages."""
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.app.test_client()
+
+    def test_account_not_logged_in(self):
+        # `account` page redirects unauthenticated access to `login`
+        # with the appropriate `next` path.
+        response = self.client.get('/account')
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/login?next=/account',
+            response.location)
+
+    def test_snap_market_not_logged_in(self):
+        # `snap-market` page redirects unauthenticated access to `login`
+        # with the appropriate `next` path.
+        response = self.client.get('/account/snaps/lxd/market')
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/login?next=/account/snaps/lxd/market',
+            response.location)
+
+    def test_snap_measure_not_logged_in(self):
+        # `snap-measure` page redirects unauthenticated access to `login`
+        # with the appropriate `next` path.
+        response = self.client.get('/account/snaps/lxd/measure')
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/login?next=/account/snaps/lxd/measure',
+            response.location)
+
+    @responses.activate
+    def test_account_logged_in(self):
+        # Users logged-in can access they account page.
+        payload = {
+            'namespace': 'testing',
+            'snaps': {
+                '16': {
+                    'foo': {
+                        'icon_url': None,
+                        'snap_id': 'snap-id',
+                        'private': False,
+                        'uploaded': False,
+                    }
+                }
+            }
+        }
+        responses.add(
+            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            json=payload, status=200)
+
+        authorization = _log_in(self.client)
+        response = self.client.get('/account')
+        self.assertEqual(200, response.status_code)
+        # Add pyQuery basic context checks
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            'https://dashboard.snapcraft.io/dev/api/account',
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+    @responses.activate
+    def test_account_api_failure(self):
+        # Why verifying creds (`authentication.verify_response`) on a 500
+        # from `account-info` that stil depend on a valid payload ?!?
+        payload = {
+            'namespace': 'testing',
+            'snaps': {
+                '16': {},
+            }
+        }
+        responses.add(
+            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            json=payload, status=500)
+        responses.add(
+            responses.POST,
+            'https://dashboard.snapcraft.io/dev/api/acl/verify/',
+            json={'account': 'test', 'allowed': True}, status=200)
+
+        authorization = _log_in(self.client)
+        response = self.client.get('/account')
+        self.assertEqual(200, response.status_code)
+
+        self.assertEqual(2, len(responses.calls))
+        [account_call, verify_call] = responses.calls
+        self.assertEqual(
+            'https://dashboard.snapcraft.io/dev/api/account',
+            account_call.request.url)
+        self.assertEqual(
+            authorization, account_call.request.headers.get('Authorization'))
+        self.assertEqual(
+            'https://dashboard.snapcraft.io/dev/api/acl/verify/',
+            verify_call.request.url)
+        self.assertEqual({
+            'auth_data': {
+                'authorization': authorization,
+                'http_uri': (
+                    'https://dashboard.snapcraft.io/dev/api/acl/verify/'),
+                'http_method': 'GET'
+            },
+        }, json.loads(verify_call.request.body.decode('utf-8')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tentative proposal for testing publisher pages using response doubles.

Minor fix included for login redirects (previously pointing to non-evaluated route, e.g `.../<snap_name>/market` and ending up on `/account` because of the redirect in `verify_response()` ... kinda crazy) 