### PR TITLE
Small fixes 

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,7 +150,7 @@ def after_login(resp):
     }
 
     flask.session['macaroon_discharge'] = resp.extensions['macaroon'].discharge
-    return flask.redirect('/account')
+    return flask.redirect(open_id.get_next_url())
 
 
 @app.route('/logout')

--- a/modules/authentication.py
+++ b/modules/authentication.py
@@ -149,7 +149,8 @@ def verify_response(
         session,
         url_requested,
         url_calling,
-        url_login
+        url_login,
+        url_account
 ):
     """
     Verify if the response from the server has errors.
@@ -188,6 +189,7 @@ def verify_response(
         if response.status_code == 401 and not verified['allowed']:
             return {
                 'status_code': 401,
+                'redirect': url_account,
                 'reason': 'Not authorized'
             }
 
@@ -195,5 +197,6 @@ def verify_response(
         if verified['account'] is not None and response.status_code == 404:
             return {
                 'status_code': 404,
+                'redirect': url_account,
                 'reason': 'Not found'
             }

--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -7,7 +7,7 @@ import pycountry
 import re
 from dateutil import parser, relativedelta
 from math import floor
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, quote_plus
 
 
 def calculate_colors(countries, max_users):
@@ -193,7 +193,11 @@ def search_snap():
 
     page = floor(offset / size) + 1
 
-    searched_results = api.get_searched_snaps(snap_searched, size, page)
+    searched_results = api.get_searched_snaps(
+        quote_plus(snap_searched),
+        size,
+        page
+    )
 
     context = {
         "query": snap_searched,

--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -60,7 +60,8 @@ def verify_response(response, url, endpoint, login_endpoint):
         flask.session,
         url,
         endpoint,
-        login_endpoint
+        login_endpoint,
+        '/account'
     )
 
     if verified_response is not None:


### PR DESCRIPTION
# Summary

This PR fixes small problems on s.io:
- We requesting page behind auth, login redirects to page and not to the /account page
- On bad verification (40* http code) redirect to account page
- Fix https://github.com/canonical-websites/snapcraft.io/issues/315 search problem with special charcaters 

# QA

- `./run`
- http://0.0.0.0:8004/search?q=test%23test
- http://0.0.0.0:8004/logout
- http://0.0.0.0:8004/account/snaps/YOUR_SNAP/market
- should ask for login and then redirect to the page you requested