### PR TITLE
Change search API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ To use staging APIs locally you can add the following lines to an`.env.local` fi
 ```bash
 SNAPCRAFT_IO_API=https://api.staging.snapcraft.io/api/v1/
 DASHBOARD_API=https://dashboard.staging.snapcraft.io/dev/api/
-SEARCH_API=https://search.apps.staging.ubuntu.com/api/v1/
 LOGIN_URL=https://login.staging.ubuntu.com
 ```
 

--- a/modules/public/api.py
+++ b/modules/public/api.py
@@ -6,10 +6,6 @@ SNAPCRAFT_IO_API = os.getenv(
     'SNAPCRAFT_IO_API',
     'https://api.snapcraft.io/api/v1/',
 )
-SEARCH_API = os.getenv(
-    'SEARCH_API',
-    'https://search.apps.ubuntu.com/api/v1/',
-)
 
 SNAP_DETAILS_URL = ''.join([
     SNAPCRAFT_IO_API,
@@ -30,7 +26,7 @@ METRICS_QUERY_HEADERS = {
 }
 
 SNAP_SEARCH_URL = ''.join([
-    SEARCH_API,
+    SNAPCRAFT_IO_API,
     'snaps/search',
     '?q={snap_name}&page={page}&size={size}',
     '&confinement=strict,classic',


### PR DESCRIPTION
search.apps.ubuntu.com is deprecated; the endpoint we use is now provided by api.snapcraft.io.

(same modification that is in b.s.io https://github.com/canonical-websites/build.snapcraft.io/pull/1061 )