### PR TITLE
On hover, embolden the appropriate label

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevices.js
+++ b/static/js/publisher/metrics/graphs/activeDevices.js
@@ -86,7 +86,7 @@ export default function activeDevices(days, activeDevices, type) {
       contents: snapcraftGraphTooltip.bind(this, {
         colors: colors,
         showLabels: true
-      }),
+      }, el),
       position: positionTooltip.bind(this, el)
     },
     transition: {
@@ -144,6 +144,12 @@ export default function activeDevices(days, activeDevices, type) {
   });
 
   showGraph(el);
+
+  deviceData.forEach(device => {
+    const labelClass = device[0].replace(/\W+/g, '-');
+    const area = el.querySelector(`.bb-area-${labelClass}`);
+    area.dataset.label = device[0];
+  });
 
   // Extra events
   let elWidth = el.clientWidth;

--- a/static/sass/_snapcraft_graph-tooltip.scss
+++ b/static/sass/_snapcraft_graph-tooltip.scss
@@ -15,10 +15,14 @@
       font: 12px "Ubuntu";
       justify-content: center;
       margin-top: .25rem;
-      width: 176px;
+      width: 215px;
 
       &:last-child {
         margin-bottom: .25rem;
+      }
+
+      &.is-hovered {
+        font-weight: bold;
       }
 
       &-name {


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/321

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0/account/snaps/SNAP_NAME/measure
- Or visit http://snapcraft.io-pr-330.run.demo.haus/account/snaps/SNAP_NAME/measure
- Hover over the active devices graph and see the labels go bold, signifying which area you are over.

# Note

Sometimes the labels aren't bold - this, as far as I can tell is to do with the labels that will be removed as part of https://github.com/canonical-websites/snapcraft.io/pull/322

# Screenshot

![screenshot from 2018-02-22 15-02-57](https://user-images.githubusercontent.com/479384/36545767-98de4812-17e1-11e8-95f3-6480a7a88053.png)
