### PR TITLE
public sentry

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,11 +29,15 @@ from modules.macaroon import (
 
 
 app = flask.Flask(__name__)
-sentry = Sentry(app)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 app.secret_key = os.environ['SECRET_KEY']
 app.wtf_csrf_secret_key = os.environ['WTF_CSRF_SECRET_KEY']
 app.url_map.strict_slashes = False
+app.sentry_public_dsn = os.getenv(
+    'SENTRY_PUBLIC_DSN',
+    ''
+)
+sentry = Sentry(app)
 
 open_id = OpenID(
     app=app,
@@ -52,8 +56,11 @@ LOGIN_URL = os.getenv(
 
 # Make LOGIN_URL available in all templates
 @app.context_processor
-def inject_login():
-    return dict(LOGIN_URL=LOGIN_URL)
+def inject_template_variables():
+    return {
+        'LOGIN_URL': LOGIN_URL,
+        'SENTRY_PUBLIC_DSN': app.sentry_public_dsn
+    }
 
 
 def login_required(func):

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -201,22 +201,26 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
 <script src="/static/js/dist/publisher.js"></script>
 <script>
-  snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
-  snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");
-  snapcraft.publisher.market.initSnapScreenshotsEdit(
-    "screenshots-toolbar",
-    "snap-screenshots",
-    {
-      images: [
-        { url: {{ icon_url|tojson }}, type: "icon" },
+  Raven.config('{{ SENTRY_PUBLIC_DSN }}').install();
+  Raven.context(function () {
+    snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
+    snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");
+    snapcraft.publisher.market.initSnapScreenshotsEdit(
+      "screenshots-toolbar",
+      "snap-screenshots",
+      {
+        images: [
+          { url: {{ icon_url|tojson }}, type: "icon" },
 
-        {% for screenshot_url in screenshot_urls %}
-          { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
-        {% endfor %}
-      ]
-    }
-  );
+          {% for screenshot_url in screenshot_urls %}
+            { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
+          {% endfor %}
+        ]
+      }
+    );
+  });
 </script>
 {% endblock %}

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -102,16 +102,20 @@
 <script src="/static/js/modules/topojson-client.min.js"></script>
 <script src="/static/js/modules/billboard.min.js"></script>
 
+<script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
 <script src="/static/js/dist/publisher.js"></script>
 <script>
-  snapcraft.publisher.selector('.metrics-period', 'period');
-  snapcraft.publisher.selector('.active-devices', 'active-devices');
-  snapcraft.publisher.metrics({
-    activeDevices: {
-      metrics: {{ active_devices|safe }},
-      type: '{{ active_device_metric }}'
-    },
-    territories: {{ territories|safe }}
+  Raven.config('{{ SENTRY_PUBLIC_DSN }}').install();
+  Raven.context(function () {
+    snapcraft.publisher.selector('.metrics-period', 'period');
+    snapcraft.publisher.selector('.active-devices', 'active-devices');
+    snapcraft.publisher.metrics({
+      activeDevices: {
+        metrics: {{ active_devices|safe }},
+        type: '{{ active_device_metric }}'
+      },
+      territories: {{ territories|safe }}
+    });
   });
 </script>
 {% endblock %}

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -88,8 +88,12 @@
   <script src="/static/js/modules/topojson-client.min.js"></script>
 
   <!-- Illustration of country data -->
+  <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
   <script src="/static/js/dist/public.js"></script>
   <script>
-    snapcraft.public.map('#js-snap-map', {{ countries|tojson }});
+    Raven.config('{{ SENTRY_PUBLIC_DSN }}').install();
+    Raven.context(function () {
+      snapcraft.public.map('#js-snap-map', {{ countries|tojson }});
+    });
   </script>
 {% endblock %}


### PR DESCRIPTION
# Done

- Added Raven from the sentry CDN
- Checks for `SENTRY_PUBLIC_DSN` in `.env.local`

# QA

- Pull the branch
- Setup an account on https://sentry.io and get a public DSN
- Add the public dsn to your `.env.local` (or create one):`SENTRY_PUBLIC_DSN=<public_dsn>`
- Change the name of a variable in the JS
- `./run`
- Visit the page with the bad JS
- Check your sentry dashboard, you should see the error immediately
- Rejoice

# Screenshot

![screenshot from 2018-02-22 17-20-58](https://user-images.githubusercontent.com/479384/36553668-d57d0412-17f4-11e8-9b71-d61b396ccba3.png)
