### PR TITLE
Add both Developer contact and website fields

### DIFF
--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -279,7 +279,8 @@ def snap_details(snap_name):
         'publisher': details['publisher'],
         'screenshot_urls': details['screenshot_urls'],
         'prices': details['prices'],
-        'support_url': details.get('support_url'),
+        'contact': details.get('contact'),
+        'website': details.get('website'),
         'summary': details['summary'],
         'description_paragraphs': formatted_paragraphs,
 

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -167,7 +167,9 @@ def get_market_snap(snap_name):
         "license": snap_details['license'],
         "icon_url": snap_details['icon_url'],
         "publisher_name": snap_details['publisher_name'],
-        "screenshot_urls": snap_details['screenshot_urls']
+        "screenshot_urls": snap_details['screenshot_urls'],
+        "contact": snap_details['contact'],
+        "website": snap_details['website']
     }
 
     return flask.render_template(
@@ -256,6 +258,7 @@ def post_market_snap(snap_name):
             'summary',
             'description',
             'contact',
+            'website',
             'keywords',
             'license',
             'price',

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -42,4 +42,8 @@
     }
   }
 
+  // workaround for label placement in grid
+  .p-label--grid-baseline {
+    margin-top: .55rem;
+  }
 }

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -167,10 +167,19 @@
 
           <div class="row">
             <div class="col-2">
-              <label>Developer website: </label>
+              <label>Developer contact: </label>
             </div>
             <div class="col-8">
               <input type="text" name="contact" value="{{ contact }}"/>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+            <label>Developer website: </label>
+            </div>
+            <div class="col-8">
+            <input type="text" name="website" value="{{ website }}"/>
             </div>
           </div>
         </form>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -108,7 +108,7 @@
 
           <div class="row">
             <div class="col-2">
-              <label>Summary: </label>
+              <label class="p-label--grid-baseline">Summary: </label>
             </div>
             <div class="col-8">
               <input type="text" name="summary" value="{{ summary }}"/>
@@ -116,10 +116,10 @@
           </div>
           <div class="row">
             <div class="col-2">
-              <label>Description: </label>
+              <label class="p-label--grid-baseline">Description: </label>
             </div>
             <div class="col-8">
-              <textarea name="description">{{ description }}</textarea>
+              <textarea class="u-no-margin" name="description">{{ description }}</textarea>
             </div>
           </div>
 
@@ -167,7 +167,7 @@
 
           <div class="row">
             <div class="col-2">
-              <label>Developer website: </label>
+              <label class="p-label--grid-baseline">Developer website: </label>
             </div>
             <div class="col-8">
             <input type="text" name="website" value="{{ website }}"/>
@@ -176,7 +176,7 @@
 
           <div class="row">
             <div class="col-2">
-              <label>Contact {{ publisher_name }}: </label>
+              <label class="p-label--grid-baseline">Contact {{ publisher_name }}: </label>
             </div>
             <div class="col-8">
               <input type="text" name="contact" value="{{ contact }}"/>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -167,19 +167,19 @@
 
           <div class="row">
             <div class="col-2">
-              <label>Developer contact: </label>
+              <label>Developer website: </label>
             </div>
             <div class="col-8">
-              <input type="text" name="contact" value="{{ contact }}"/>
+            <input type="text" name="website" value="{{ website }}"/>
             </div>
           </div>
 
           <div class="row">
             <div class="col-2">
-            <label>Developer website: </label>
+              <label>Contact {{ publisher_name }}: </label>
             </div>
             <div class="col-8">
-            <input type="text" name="website" value="{{ website }}"/>
+              <input type="text" name="contact" value="{{ contact }}"/>
             </div>
           </div>
         </form>

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -50,7 +50,7 @@
           <p>{{ paragraph | safe }}</p>
         {% endfor %}
         {% if website %}<p><a href="{{ website }}">Developer website</a></p>{% endif %}
-        {% if contact %}<p class="u-no-margin--top"><a href="{{ contact }}">Developer contact</a></p>{% endif %}
+        {% if contact %}<p class="u-no-margin--top"><a href="{{ contact }}">Contact {{ publisher }}</a></p>{% endif %}
       </div>
       <div class="col-4">
         <table class="p-table-key-value">

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -49,7 +49,8 @@
         {% for paragraph in description_paragraphs %}
           <p>{{ paragraph | safe }}</p>
         {% endfor %}
-        {% if support_url %}<p><a href="{{ support_url }}">Developer contact</a></p>{% endif %}
+        {% if website %}<p><a href="{{ website }}">Developer website</a></p>{% endif %}
+        {% if contact %}<p class="u-no-margin--top"><a href="{{ contact }}">Developer contact</a></p>{% endif %}
       </div>
       <div class="col-4">
         <table class="p-table-key-value">


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/317
- Added both contact and website fields to market page
- Added both fields (if present) to snap details page

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/SNAP_NAME/market
- Update the Developer contact and Developer website fields.
- Save your changes and ensure the change have persisted
- Go to http://0.0.0.0:8004/SNAP_NAME
- Make sure the Developer website and Developer contact link go to the correct places
- Repeat if you fancy it

# Note

Apologies if there are designs/ wireframes for any of this that I've ignored - point me in the right direction and I'll update the PR thanks!

# Screenshots

Snap market page:
<img width="1015" alt="screen shot 2018-02-27 at 13 38 01" src="https://user-images.githubusercontent.com/83575/36729166-8d9cdb40-1bc3-11e8-8709-53070091fa2f.png">

Snap details page:
<img width="1030" alt="screen shot 2018-02-27 at 13 38 21" src="https://user-images.githubusercontent.com/83575/36729163-8d83c81c-1bc3-11e8-9399-3dd56dfeac7d.png">
