### PR TITLE
Delete screenshots

### DIFF
--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -198,14 +198,20 @@ def snap_screenshots(snap_id, data=None, files=None):
     headers = get_authorization_header()
     headers['Accept'] = 'application/json'
 
-    if data is not None:
+    if data:
         method = 'PUT'
+
         files_array = []
-        if files is not None:
+        if files:
             for f in files:
                 files_array.append(
                     (f.filename, (f.filename, f.stream, f.mimetype))
                 )
+        else:
+            # API requires a multipart request, but we have no files to push
+            # https://github.com/requests/requests/issues/1081
+            files_array = {'info': ('', data['info'])}
+            data = None
 
     screenshot_response = cache.get(
         SCREENSHOTS_QUERY_URL.format(snap_id=snap_id),

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -218,32 +218,35 @@ def post_market_snap(snap_name):
         images_json = None
 
         # Add existing screenshots
-        screenshots_uploaded = api.snap_screenshots(
+        current_screenshots = api.snap_screenshots(
             snap_id
         )
         state_screenshots = loads(flask.request.form['state'])['images']
-        for screenshot in state_screenshots:
-            for screenshot_uploaded in screenshots_uploaded:
-                if screenshot['url'] == screenshot_uploaded['url']:
-                    info.append(screenshot_uploaded)
+        for state_screenshot in state_screenshots:
+            for current_screenshot in current_screenshots:
+                if state_screenshot['url'] == current_screenshot['url']:
+                    info.append(current_screenshot)
 
+        # Add new icon
         icon = flask.request.files.get('icon')
         if icon is not None:
             info.append(build_image_info(icon, 'icon'))
             images_files.append(icon)
 
-        screenshots = flask.request.files.getlist('screenshots')
-        for screenshot in screenshots:
-            info.append(build_image_info(screenshot, 'screenshot'))
-            images_files.append(screenshot)
+        # Add new screenshots
+        new_screenshots = flask.request.files.getlist('screenshots')
+        for new_screenshot in new_screenshots:
+            for state_screenshot in state_screenshots:
+                is_same = (
+                    state_screenshot['status'] == 'new'
+                    and state_screenshot['name'] == new_screenshot.filename
+                )
 
-        if not images_files:
-            # API requires a multipart request, but we have no files to push
-            # https://github.com/requests/requests/issues/1081
-            images_files = {'info': ('', dumps(info))}
-        else:
-            images_json = {'info': dumps(info)}
+                if is_same:
+                    info.append(build_image_info(new_screenshot, 'screenshot'))
+                    images_files.append(new_screenshot)
 
+        images_json = {'info': dumps(info)}
         screenshots_response = api.snap_screenshots(
             snap_id,
             images_json,

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -21,10 +21,40 @@
     text-align: center;
   }
 
-  .p-screenshot {
-    &.selected {
-      outline: 1px solid $color-focus;
-      outline-offset: 2px;
+  .p-screenshot__holder {
+    .p-screenshot {
+      &.selected {
+        outline: 1px solid $color-focus;
+        outline-offset: 2px;
+      }
+    }
+
+    .p-screenshot[src^='blob'] {
+      & + .p-screenshot__delete,
+      & + .p-screenshot__revert {
+        display: none;
+      }
+    }
+
+    &:hover {
+      .p-screenshot__delete {
+        opacity: 1;
+      }
+    }
+
+    &.is-deleted {
+      .p-screenshot__delete {
+        display: none;
+      }
+
+      .p-screenshot__revert {
+        display: block;
+      }
+
+      .p-screenshot {
+        filter: grayscale(100%);
+        opacity: .6;
+      }
     }
   }
 }

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -132,10 +132,11 @@
           <div class="row">
             <div class="col-12">
               <div class="p-screenshots-toolbar" id="screenshots-toolbar">
-                <label>Screenshots:</label>
+                <label>Screenshots (up to 5):</label>
                 <div class="p-screenshots-toolbar__buttons">
-                  <button class="p-button-neutral js-fullscreen-screenshot"><i class="p-icon--fullscreen"></i></button>
-                  <button class="p-button-neutral js-add-screenshots u-no-margin--top"><i class="p-icon--plus"></i></button>
+                  <button class="p-button-neutral js-add-screenshots"><i class="p-icon--plus"></i></button>
+                  <button class="p-button-neutral js-delete-screenshot"><i class="p-icon--delete"></i></button>
+                  <button class="p-button-neutral js-fullscreen-screenshot  u-no-margin--top"><i class="p-icon--fullscreen"></i></button>
                 </div>
               </div>
             </div>
@@ -143,6 +144,7 @@
 
           <div class="row" id="snap-screenshots">
           </div>
+          <div class="row" id="screenshots-status"></div>
 
           <div class="row">
             <div class="col-12">
@@ -211,6 +213,7 @@
     snapcraft.publisher.market.initSnapScreenshotsEdit(
       "screenshots-toolbar",
       "snap-screenshots",
+      "screenshots-status",
       {
         images: [
           { url: {{ icon_url|tojson }}, type: "icon" },

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -216,8 +216,9 @@
       "screenshots-status",
       {
         images: [
-          { url: {{ icon_url|tojson }}, type: "icon" },
-
+          {% if icon_url %}
+            { url: {{ icon_url|tojson }}, type: "icon", status: "uploaded" },
+          {% endif %}
           {% for screenshot_url in screenshot_urls %}
             { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
           {% endfor %}


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/286
This is a temporary implementation, only previously uploaded images can be deleted - extra work needed to modify the `FileList` (I'm not even sure it's possible).

- Delete and revert buttons on individual screenshots
- A little status line when new items are being added or deleted
- When 5 images have been added, disable the add button

# QA

- Pull the branch
- `./run`
- Go to http://0.0.0.0:8004/account/snaps/SNAP_NAME/market
- Add screenshots, delete screenshots, revert deleting screenshots - generally use the screenshots
- Reload
- Make sure your changes are reflected.

# Screenshot

<img width="1029" alt="screen shot 2018-03-07 at 11 05 45" src="https://user-images.githubusercontent.com/83575/37086300-8584e594-21f7-11e8-9937-9e762b72edb8.png">
