### PR TITLE
New consistent header

### DIFF
--- a/static/sass/_snapcraft_banner.scss
+++ b/static/sass/_snapcraft_banner.scss
@@ -1,6 +1,9 @@
 @mixin snapcraft-banner {
+  $snapcraft-banner-color: #e5eeee;
+
   .snapcraft-banner-background {
-    background-image: url('#{$assets-path}0a575390-hero-background--edgeless.png');
+    background-color: $snapcraft-banner-color;
+    background-image: url('#{$assets-path}9689339a-snapcraft-hero-background--light.png');
     background-position: 50% 0;
     background-size: 1440px 1440px;
   }

--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -1,10 +1,24 @@
 @mixin snapcraft-p-navigation {
+  $navigation-border-color: lighten($color-navigation-background, 20%);
+  $navigation-hover-color: darken($color-navigation-background, 8%); // from #252525 to #111
+
   .p-navigation {
     .p-navigation__link {
       a:hover,
       .is-selected {
-        background: darken($color-x-light, 10%);
+        background: $navigation-hover-color;
+      }
+    }
+
+    .p-navigation__links {
+      .p-navigation__link {
+        border-left: 1px solid $navigation-border-color;
+      }
+
+      &:last-of-type {
+        border-right: 1px solid $navigation-border-color;
       }
     }
   }
+
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,6 +1,7 @@
 // colour definitions
 $color-brand: #00302f; // TODO: this is a temprary brand colour
 $color-accent: $color-brand;
+$color-navigation-background: #252525;
 
 // vanilla patterns
 @import 'vanilla-framework/scss/vanilla';

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -21,6 +21,7 @@
           </a>
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
+        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://dashboard.snapcraft.io/snaps">My snaps</a></li>
         <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
         <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
       </ul>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -3,7 +3,7 @@
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/2964e9eb-snapcraft-logo--web.svg" alt="Snapcraft" />
+          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft" />
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
@@ -21,9 +21,9 @@
           </a>
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
-        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://docs.snapcraft.io">Docs</a></li>
-        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
-        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
       </ul>
     </nav>
   </div>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -22,7 +22,6 @@
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
         <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
-        <li class="p-navigation__link" role="menuitem"><a href="https://tutorials.ubuntu.com/?q=snap">Tutorials</a></li>
         <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
       </ul>
     </nav>

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,7 +68,7 @@
 
     {% include "_header.html" %}
 
-    <div id="main-content" class="p-strip--accent p-strip--image is-dark is-deep snapcraft-banner-background">
+    <div id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
       <h1 class="u-off-screen">Snapcraft</h1>
       <div class="row">
         <div class="col-12">

--- a/templates/search.html
+++ b/templates/search.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 
-  <section id="main-content" class="p-strip--accent p-strip--image is-dark is-deep snapcraft-banner-background">
+  <section id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
     <div class="row">
       <div class="col-10">
         {% if query %}

--- a/templates/store.html
+++ b/templates/store.html
@@ -3,7 +3,7 @@
 {% block title %}Find snaps for Linux — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
-  <section id="main-content" class="p-strip--accent p-strip--image is-dark is-deep snapcraft-banner-background">
+  <section id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
     <div class="row">
       <div class="col-10">
         <h2>Find snaps for Linux</h2>


### PR DESCRIPTION
Fixes #273 

Adds new dark header to snapcraft.io, removed Tutorial link, added My snaps (linking to dashboard).

Designs:
https://github.com/canonicalltd/snappy-design-squad/issues/387 (header)
https://github.com/canonicalltd/snapcraft-design/issues/287 (footer)

### QA

- ./run
- Go to home page
- It should have new dark navigation
- Go to snap details page
- It should have new dark navigation


<img width="1061" alt="screen shot 2018-03-15 at 13 56 41" src="https://user-images.githubusercontent.com/83575/37464493-d4145458-2858-11e8-907e-b0fc4f4b0157.png">
