### PR TITLE
Fix error no HTTP-AGENT in header

### DIFF
--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -297,8 +297,8 @@ def snap_details(snap_name):
 
         # Context info
         'is_linux': (
-            'Linux' in flask.request.headers['User-Agent'] and
-            'Android' not in flask.request.headers['User-Agent']
+            'Linux' in flask.request.headers.get('User-Agent', '') and
+            'Android' not in flask.request.headers.get('User-Agent', '')
         )
     }
 


### PR DESCRIPTION
# Summary
When user agent not defined in header the detail page should be accessible

# QA
- `./run`
-  curl -H "User-Agent:" http://0.0.0.0:8004/skype