### PR TITLE
Fixes JS error when removing non-existent nofitication.

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -175,7 +175,8 @@ function initFormNotification(formElId, notificationElId) {
 
   form.addEventListener("change", function() {
     var notification = document.getElementById(notificationElId);
-    if (notification) {
+
+    if (notification && notification.parentNode) {
       notification.parentNode.removeChild(notification);
     }
   });
@@ -183,7 +184,9 @@ function initFormNotification(formElId, notificationElId) {
 
   if (notification) {
     setTimeout(function(){
-      notification.parentNode.removeChild(notification);
+      if (notification && notification.parentNode) {
+        notification.parentNode.removeChild(notification);
+      }
     }, 20000);
   }
 }


### PR DESCRIPTION
In some cases there were JavaScript errors thrown about `removeNode` being called on `null`.
Possibly `setTimeout` script was trying to remove the notification that is not showing anymore.

This fix makes sure notification node is still available before trying to remove it from DOM.

### QA
1. Go to market page of some snap
2. Change some values
3. 'Apply' notification should show
4. Make some changes again and 'Apply'
5. Repeat couple of times

There should be no error in JS console.