### PR TITLE
Sentry whitelist

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -206,7 +206,9 @@
 <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
 <script src="/static/js/dist/publisher.js"></script>
 <script>
-  Raven.config('{{ SENTRY_PUBLIC_DSN }}').install();
+  Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
+    whitelistUrls: ['snapcraft.io']
+  }).install();
   Raven.context(function () {
     snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
     snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -105,7 +105,9 @@
 <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
 <script src="/static/js/dist/publisher.js"></script>
 <script>
-  Raven.config('{{ SENTRY_PUBLIC_DSN }}').install();
+  Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
+    whitelistUrls: ['snapcraft.io']
+  }).install();
   Raven.context(function () {
     snapcraft.publisher.selector('.metrics-period', 'period');
     snapcraft.publisher.selector('.active-devices', 'active-devices');

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -91,7 +91,9 @@
   <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
   <script src="/static/js/dist/public.js"></script>
   <script>
-    Raven.config('{{ SENTRY_PUBLIC_DSN }}').install();
+    Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
+      whitelistUrls: ['snapcraft.io']
+    }).install();
     Raven.context(function () {
       snapcraft.public.map('#js-snap-map', {{ countries|tojson }});
     });


### PR DESCRIPTION
# Done

Added snapcraft.io and run.demo.haus as white listed urls for error reporting.

# QA

- Wait for the demo to start.
- Go to a measure page.
- See an error in the page - d4 is not defined.
- See an error in sentry - d4 is not defined.
- Check the count of NS_ERROR_UNKNOWN_PROTOCOL errors in sentry
- Go to http://snapcraft.io-pr-364.run.demo.haus/slack
- Click the install button (on an OS that doesn't support snap urls)
- Make sure the NS_ERROR_UNKNOWN_PROTOCOL error count doesn't increase.
