### PR TITLE
Better error handling when world map data fails to load

### DIFF
--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -104,6 +104,11 @@ export default function renderMap(el, snapData) {
   }
 
   function ready(error, world) {
+    if (error) {
+      // let sentry catch it, so we get notified why it fails
+      throw error;
+    }
+
     render(mapEl, snapData, world);
 
     let resizeTimeout;


### PR DESCRIPTION
To avoid unhelpful `world is undefined` errors in sentry we need to properly handle topojson loading error so we know why it happens and if we can do something about it.