### PR TITLE
Remove flask dependency api layer

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,7 @@ def page_not_found(error):
     """
 
     return flask.render_template(
-        '404.html', description=error.description
+        '404.html', error_list=error.description
     ), 404
 
 

--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -230,7 +230,16 @@ def snap_details(snap_name):
     today = datetime.datetime.utcnow().date()
     week_ago = today - relativedelta.relativedelta(weeks=1)
 
-    details = api.get_snap_details(snap_name)
+    try:
+        details = api.get_snap_details(snap_name)
+    except api.InvalidResponseContent as invalid_response_content:
+        message = str(invalid_response_content)
+        flask.abort(500, message)
+    except api.ApiErrorResponse as api_error_exception:
+        if api_error_exception.errors:
+            flask.abort(api_error_exception.status, api_error_exception.errors)
+        else:
+            flask.abort(api_error_exception.status, ["Unknown error"])
 
     metrics_query_json = [
         {

--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,11 @@
     </div>
     <div class="col-6">
       <h1>404: Page not found</h1>
-      <p>{{ description }}</p>
+      {% for error in error_list %}
+        <p class="p-notification__response">
+          {{ error.message }}
+        </p>
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/tests.py
+++ b/tests.py
@@ -81,7 +81,7 @@ class WebAppTestCase(unittest.TestCase):
         response = self._get_response('/non-existent-snap')
 
         assert response.status_code == 404
-        assert "Snap not found" in str(response.data)
+        assert "No snap named" in str(response.data)
 
     # Helper methods
     # ==


### PR DESCRIPTION
# Refactoto S02E01 - The first Endpoint

## Summary

* Remove flask dependency from api public layer.
* First draft for a better error handler in the api layer
* Work on public snap access

## QA

- `./run`
- `./run test`
- 0.0.0.0:8004/toto
- Should have a snap
- 0.0.0.0:8004/qsdfsqdfqsdf
- Should return 404 page