### PR TITLE
Updates footer design

### DIFF
--- a/static/sass/_snapcraft_custom-typography.scss
+++ b/static/sass/_snapcraft_custom-typography.scss
@@ -41,7 +41,6 @@
   .p-heading--five,
   .p-heading--six {
     @extend %paragraph-copy;
-    max-width: 100%;
   }
 
   // update to p-list is-ticked style

--- a/static/sass/_snapcraft_footer.scss
+++ b/static/sass/_snapcraft_footer.scss
@@ -1,0 +1,17 @@
+@mixin snapcraft-footer {
+  .p-icon--top {
+    @extend %icon;
+    background-image: url('#{$assets-path}9ec2c354-icon-arrow-up.svg');
+    background-size: 12px 12px;
+    margin-left: $sp-x-small;
+  }
+
+  .p-footer {
+    padding-bottom: $sp-xx-large;
+
+    p {
+      max-width: 100%;
+    }
+  }
+
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -98,3 +98,6 @@ $color-accent: $color-brand;
 
 @import 'patterns_maas_modal';
 @include maas-p-modal;
+
+@import 'snapcraft_footer';
+@include snapcraft-footer;

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -1,0 +1,50 @@
+<footer class="p-footer p-strip--light p-sticky-footer">
+  <div class="row">
+    <div class="col-8">
+      <nav class="p-footer__nav">
+        <ul class="p-footer__links">
+          <li class="p-footer__item">
+            <a class="p-footer__link" href="#">Back to top<i class="p-icon--top"></i></a>
+          </li>
+        </ul>
+      </nav>
+      <p>&copy; 2018 Canonical Ltd. <br/> Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+      <p>
+        You can contribute to, or report problems with,
+        <a
+          class="p-link--external"
+          href="https://bugs.launchpad.net/snappy"
+        >snapd</a>,
+        <a
+          class="p-link--external"
+          href="https://github.com/snapcore/snapcraft/issues"
+        >Snapcraft</a>,
+        or
+        <a
+          class="p-link--external"
+          href="https://github.com/canonical-websites/snapcraft.io/issues"
+        >this site</a>.
+        <br />
+        Powered by <a href="https://www.ubuntu.com/kubernetes">the Canonical Distribution of Kubernetes</a>
+        &#183;
+        <a href="https://status.snapcraft.io/">Service status</a>
+      </p>
+    </div>
+    <div class="col-4">
+       <ul class="p-inline-list--compact">
+         <li class="p-inline-list__item">
+           <a href="https://twitter.com/snapcraftio" class="p-social-icon--twitter">Share on Twitter</a>
+         </li>
+         <li class="p-inline-list__item">
+           <a href="https://plus.google.com/+SnapcraftIo" class="p-social-icon--google">Share on Google plus</a>
+         </li>
+         <li class="p-inline-list__item">
+           <a href="https://www.facebook.com/snapcraftio" class="p-social-icon--facebook">Share on Facebook</a>
+         </li>
+         <li class="p-inline-list__item">
+           <a href="https://www.youtube.com/snapcraftio" class="p-social-icon--youtube">Share on YouTube</a>
+         </li>
+       </ul>
+     </div>
+  </div>
+</footer>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -39,42 +39,8 @@
 
     {% block content %}{% endblock %}
 
-    <div class="p-strip--light u-no-padding p-sticky-footer">
-      <footer class="p-footer u-no-margin--top">
-        <div class="row">
-          <div class="col-6">
-            <p>&copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-            <p>
-              You can contribute to, or report problems with,
-              <a
-                class="p-link--external"
-                href="https://bugs.launchpad.net/snapd"
-              >snapd</a>,
-              <a
-                class="p-link--external"
-                href="https://github.com/snapcore/snapcraft/issues"
-              >Snapcraft</a>,
-              or
-              <a
-                class="p-link--external"
-                href="https://github.com/canonical-websites/snapcraft.io/issues"
-              >this site</a>.
-            </p>
-            <nav class="u-no-margin">
-              <ul class="p-footer__links">
-                  <li class="p-footer__item"><a class="p-footer__link" href="http://www.ubuntu.com/legal">Legal information</a></li>
-              </ul>
-              <span class="u-off-screen u-no-margin">
-                <a href="#">Go to the top of the page</a>
-              </span>
-            </nav>
-          </div>
-          <div class="col-6">
-            <p class="u-align--right">Powered by <a href="https://www.ubuntu.com/kubernetes">the Canonical Distribution of Kubernetes</a></p>
-          </div>
-        </div>
-      </footer>
-    </div>
+    {% include "_footer.html" %}
+
     {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -354,61 +354,7 @@
       </div>
     </div>
 
-    <footer class="p-footer p-strip--light">
-      <div class="row">
-        <div class="col-8">
-          <p>&copy; 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-          <p>Powered by <a href="https://www.ubuntu.com/kubernetes">the Canonical Distribution of Kubernetes</a></p>
-          <p>
-            You can contribute to, or report problems with,
-            <a
-              class="p-link--external"
-              href="https://bugs.launchpad.net/snappy"
-            >snapd</a>,
-            <a
-              class="p-link--external"
-              href="https://github.com/snapcore/snapcraft/issues"
-            >Snapcraft</a>,
-            or
-            <a
-              class="p-link--external"
-              href="https://github.com/canonical-websites/snapcraft.io/issues"
-            >this site</a>.
-          </p>
-          <nav class="p-footer__nav">
-            <ul class="p-footer__links">
-              <li class="p-footer__item">
-                <a class="p-footer__link" href="https://www.ubuntu.com/legal">Legal information</a>
-              </li>
-              <li class="p-footer__item">
-                <a class="p-footer__link" href="https://status.snapcraft.io/">Service status</a>
-              </li>
-            </ul>
-            <p>Yocto Project and all related marks and logos are trademarks of The Linux Foundation. This website is not, in any way, endorsed by the Yocto Project or The Linux Foundation.</p>
-            <span class="u-off-screen u-no-margin">
-              <a href="#">Go to the top of the page</a>
-            </span>
-          </nav>
-        </div>
-        <div class="col-4">
-           <h3 class="p-muted-heading">Follow us</h3>
-           <ul class="p-inline-list--compact">
-             <li class="p-inline-list__item">
-               <a href="https://twitter.com/snapcraftio" class="p-social-icon--twitter">Share on Twitter</a>
-             </li>
-             <li class="p-inline-list__item">
-               <a href="https://plus.google.com/+SnapcraftIo" class="p-social-icon--google">Share on Google plus</a>
-             </li>
-             <li class="p-inline-list__item">
-               <a href="https://www.facebook.com/snapcraftio" class="p-social-icon--facebook">Share on Facebook</a>
-             </li>
-             <li class="p-inline-list__item">
-               <a href="https://www.youtube.com/snapcraftio" class="p-social-icon--youtube">Share on YouTube</a>
-             </li>
-           </ul>
-         </div>
-      </div>
-    </footer>
+    {% include "_footer.html" %}
 
   </body>
 </html>


### PR DESCRIPTION
Update footer on snapcraft.io to new design.

Part of https://github.com/CanonicalLtd/snapcraft-design/issues/273

Because we need additional discussion on headers, footer can be merged separately.

### QA

- ./run
- go to home page - footer should have a new design
- go to store page or snap details page - footer should have new design

<img width="1271" alt="screen shot 2018-03-02 at 10 15 21" src="https://user-images.githubusercontent.com/83575/36891652-a58891cc-1e02-11e8-967e-2eaef5abad68.png">
