### PR TITLE
Account dedupe and use of correct fields

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -26,12 +26,20 @@ def get_account():
     if '16' in account['snaps']:
         user_snaps = account['snaps']['16']
 
+    flask_user = flask.session['openid']
+
+    context = {
+        'image': flask_user['image'],
+        'username': account['username'],
+        'displayname': account['displayname'],
+        'email': account['email'],
+        'snaps': user_snaps,
+        'error_list': error_list
+    }
+
     return flask.render_template(
         'account.html',
-        namespace=account['namespace'],
-        user_snaps=user_snaps,
-        user=flask.session['openid'],
-        error_list=error_list
+        **context
     )
 
 

--- a/templates/account.html
+++ b/templates/account.html
@@ -8,24 +8,23 @@ Account page — Linux software in the Snap Store
   <section class="p-strip is-shallow">
     <div class="row">
       <div class="col-2">
-        {% if user.image %}
-          <img class="p-media-object__image--large" src="{{ user.image }}" alt="{{ user.nickname }} account" />
+        {% if image %}
+          <img class="p-media-object__image--large" src="{{ image }}" alt="{{ username }} account" />
         {% else %}
           <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
         {% endif %}
       </div>
       <div class="col-9">
-        <h1 class="u-no-margin">{{ user.nickname }}</h1>
+        <h1 class="u-no-margin">{{ username }}</h1>
         <table class="p-table-key-value">
-          <tr><th width="100">Full name</th><td>{{ user.fullname }}</td></tr>
+          <tr><th width="100">Full name</th><td>{{ displayname }}</td></tr>
           <tr>
             <th>Username</th>
             <td>
-              {{ user.nickname }} <a href="{{ LOGIN_URL }}" class="p-link--external">Edit</a>
+              {{ username }} <a href="{{ LOGIN_URL }}" class="p-link--external">Edit</a>
             </td>
           </tr>
-          <tr><th>Email</th><td>{{ user.email }}</td></tr>
-          <tr><th>Namespace</th><td>{{ namespace }}</td></tr>
+          <tr><th>Email</th><td>{{ email }}</td></tr>
         </table>
       </div>
     </div>
@@ -40,37 +39,37 @@ Account page — Linux software in the Snap Store
             <th>Name</th>
             <th>Status</th>
           </tr>
-          {% if not user_snaps %}
+          {% if not snaps %}
             <tr>
               <td>You have not uploaded or registered a snap yet!</td>
             </tr>
           {% else %}
-            {% for snap in user_snaps|sort %}
+            {% for snap in snaps|sort %}
               <tr>
                 <td class="u-vertically-center p-snap-list">
-                  {% if user_snaps[snap].uploaded %}
+                  {% if snaps[snap].uploaded %}
                     <a href="/account/snaps/{{snap}}/market" class="u-no-margin--top u-vertically-center">
                   {% endif %}
-                  {% if user_snaps[snap].icon_url %}
-                    <img src="{{ user_snaps[snap].icon_url }}" class="p-snap-list__image" />
+                  {% if snaps[snap].icon_url %}
+                    <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
                   {% else %}
                     <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-snap-list__image" />
                   {% endif %}
                   <span class="p-snap-list__name u-no-margin--top">
                     {{snap}}
                   </span>
-                  {% if user_snaps[snap].uploaded %}
+                  {% if snaps[snap].uploaded %}
                     </a>
                   {% endif %}
-                  {% if user_snaps[snap].private %}
+                  {% if snaps[snap].private %}
                     <small class="u-no-margin--top">Private</small>
                   {% endif %}
                 </td>
                 <td>
-                  {% if not user_snaps[snap].uploaded %}
+                  {% if not snaps[snap].uploaded %}
                     Name registered. No snap uploaded.
                   {% else %}
-                    {{ user_snaps[snap].status }}
+                    {{ snaps[snap].status }}
                   {% endif %}
                 </td>
               </tr>

--- a/tests.py
+++ b/tests.py
@@ -137,7 +137,9 @@ def _log_in(client):
     discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
 
     with client.session_transaction() as s:
-        s['openid'] = 'fake'
+        s['openid'] = {
+            'image': None
+            }
         s['macaroon_root'] = root.serialize()
         s['macaroon_discharge'] = discharge.serialize()
 
@@ -182,7 +184,9 @@ class PublisherPagesTestCase(unittest.TestCase):
     def test_account_logged_in(self):
         # Users logged-in can access they account page.
         payload = {
-            'namespace': 'testing',
+            'username': 'testing',
+            'displayname': 'testing',
+            'email': 'testing@testing.com',
             'snaps': {
                 '16': {
                     'foo': {
@@ -216,7 +220,9 @@ class PublisherPagesTestCase(unittest.TestCase):
         # Why verifying creds (`authentication.verify_response`) on a 500
         # from `account-info` that stil depend on a valid payload ?!?
         payload = {
-            'namespace': 'testing',
+            'username': 'testing',
+            'displayname': 'testing',
+            'email': 'testing@testing.com',
             'snaps': {
                 '16': {},
             }


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/348

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account or http://snapcraft.io-pr-395.run.demo.haus/account
- The page should look like the screenshot below (but with your details obviously)

# Screenshot

![image](https://user-images.githubusercontent.com/479384/37420257-42cb399e-27ae-11e8-8ae5-6dd4c63ecbd2.png)
