### PR TITLE
Removes unnecessary spacing from footer links in Firefox

### DIFF
--- a/static/sass/_snapcraft_footer.scss
+++ b/static/sass/_snapcraft_footer.scss
@@ -12,6 +12,11 @@
     p {
       max-width: 100%;
     }
+
+    a,
+    br {
+      margin-top: 0; // get rid of Vanilla `* + *` margin
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #402

Removes unnecessary margins from links in footer in Firefox.

### QA

1. Use Firefox
2. Go to any page
3. Footer should not have unnecessary spacing (compare with Chrome)

<img width="946" alt="screen shot 2018-03-16 at 10 03 41" src="https://user-images.githubusercontent.com/83575/37512112-73d34fdc-2901-11e8-9676-87c3b7709823.png">
