### PR TITLE
Fixes dark hover on mobile navigation

### DIFF
--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -3,20 +3,22 @@
   $navigation-hover-color: darken($color-navigation-background, 8%); // from #252525 to #111
 
   .p-navigation {
-    .p-navigation__link {
-      a:hover,
-      .is-selected {
-        background: $navigation-hover-color;
-      }
-    }
-
-    .p-navigation__links {
+    @media (min-width: $breakpoint-navigation-threshold + 1) {
       .p-navigation__link {
-        border-left: 1px solid $navigation-border-color;
+        a:hover,
+        .is-selected {
+          background: $navigation-hover-color;
+        }
       }
 
-      &:last-of-type {
-        border-right: 1px solid $navigation-border-color;
+      .p-navigation__links {
+        .p-navigation__link {
+          border-left: 1px solid $navigation-border-color;
+        }
+
+        &:last-of-type {
+          border-right: 1px solid $navigation-border-color;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #406 

Removes dark hover from mobile navigation to make it readable.

### QA
- ./run
- make small screen (mobile navigation)
- open navigation
- hover any item, click on it (it should not have black hover background)