### PR TITLE
Ensure br's don't have the * + * spacing applied

### DIFF
--- a/static/sass/_snapcraft_custom-typography.scss
+++ b/static/sass/_snapcraft_custom-typography.scss
@@ -48,4 +48,11 @@
   .is-ticked {
     background-position: 0 .3em;
   }
+
+  // This can be removed when
+  // https://github.com/vanilla-framework/vanilla-framework/issues/1627
+  // is resolved.
+  br {
+    margin-top: 0;
+  }
 }

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -50,7 +50,11 @@
           <p>{{ paragraph | safe }}</p>
         {% endfor %}
         {% if website %}<p><a href="{{ website }}">Developer website</a></p>{% endif %}
-        {% if contact %}<p class="u-no-margin--top"><a href="{{ contact }}">Contact {{ publisher }}</a></p>{% endif %}
+        {% if contact %}
+          <p{% if website %} class="u-no-margin--top"{% endif %}>
+            <a href="{{ contact }}">Contact {{ publisher }}</a>
+          </p>
+        {% endif %}
       </div>
       <div class="col-4">
         <table class="p-table-key-value">


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/405

- Overrides the `*+*` style from vanilla, specifically for `<br />` elements.
- Fixes a spacing issue caused if the contact field is defined, but the website isn't.

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/spotify or http://snapcraft.io-pr-408.run.demo.haus/spotify in Firefox
- Ensure the error reported is fixed

# Screenshot

![screenshot-2018-3-16 spotify linux software in the snap store](https://user-images.githubusercontent.com/479384/37522968-69e322ce-291d-11e8-8f4d-427cfdd1dde8.png)
