### PR TITLE
Market page - only save changed fields

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -36,8 +36,54 @@ function initFormNotification(formElId, notificationElId) {
 }
 
 
+// TODO: test
+function diffFormData(initialState, formData) {
+  const diff = {};
+
+  for (let key in initialState) {
+    if (key === 'images') {
+      let images = JSON.parse(formData.get('state'))['images'];
+
+      if (JSON.stringify(initialState[key]) !== JSON.stringify(images)) {
+        diff[key] = images;
+      }
+    } else {
+      if (initialState[key] !== formData.get(key)) {
+        diff[key] = formData.get(key);
+      }
+    }
+  }
+
+  return diff;
+}
+
+function initForm(config, initialState) {
+  // TODO: edit icon in images state
+  initSnapIconEdit(config.snapIconImage, config.snapIconInput);
+  initFormNotification(config.form, config.formNotification);
+  // TODO: move state out of screenshots (to share with icon and rest of the form?)
+  initSnapScreenshotsEdit(
+    config.screenshotsToolbar,
+    config.screenshotsWrapper,
+    {
+      images: JSON.parse(JSON.stringify(initialState.images))
+    }
+  );
+
+  // TODO: move to submit button, leave revert button as it is
+  document.querySelector('form').addEventListener('submit', function() {
+    const data = new FormData(this);
+
+    // TODO: only save changed data
+    // console.log('changed', diffFormData(initialState, data));
+    diffFormData(initialState, data);
+    // event.preventDefault();
+  });
+}
+
 export {
   initSnapIconEdit,
   initFormNotification,
-  initSnapScreenshotsEdit
+  initSnapScreenshotsEdit,
+  initForm
 };

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -54,7 +54,8 @@ function diffFormData(initialState, formData) {
     }
   }
 
-  return diff;
+  // only return diff when there are any changes
+  return Object.keys(diff).length > 0 ? diff : null;
 }
 
 function initForm(config, initialState) {
@@ -70,14 +71,17 @@ function initForm(config, initialState) {
     }
   );
 
-  // TODO: move to submit button, leave revert button as it is
-  document.querySelector('form').addEventListener('submit', function() {
-    const data = new FormData(this);
+  document.querySelector('.js-market-submit').addEventListener('click', function(event){
+    const marketForm = document.getElementById(config.form);
+    // const data = new FormData(marketForm);
+    // const diff = diffFormData(initialState, data);
+
+    event.preventDefault();
 
     // TODO: only save changed data
-    // console.log('changed', diffFormData(initialState, data));
-    diffFormData(initialState, data);
-    // event.preventDefault();
+    // if (diff) {
+    marketForm.submit();
+    //}
   });
 }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -1,4 +1,5 @@
 import { initSnapScreenshotsEdit } from './screenshots';
+import { updateState, diffState } from './state';
 
 function initSnapIconEdit(iconElId, iconInputId, state) {
   const snapIconInput = document.getElementById(iconInputId);
@@ -47,58 +48,7 @@ function initFormNotification(formElId, notificationElId) {
   }
 }
 
-const allowedKeys = ['title', 'summary', 'description', 'images', 'website', 'contact'];
 
-// TODO: test
-function diffFormData(initialState, state) {
-  const diff = {};
-
-  for (let key of allowedKeys) {
-    // images is an array of objects so compare stringified version
-    if (key === 'images') {
-      const images = state[key]
-        // remove images to delete from the diff
-        .filter(image => image.status !== 'delete')
-        // ignore selected status when comparing
-        .map(image => {
-          delete image.selected;
-          return image;
-        });
-
-      if (JSON.stringify(initialState[key]) !== JSON.stringify(images)) {
-        diff[key] = images;
-      }
-    } else {
-      if (initialState[key] !== state[key]) {
-        diff[key] = state[key];
-      }
-    }
-  }
-
-  // only return diff when there are any changes
-  return Object.keys(diff).length > 0 ? diff : null;
-}
-
-// TODO: test
-function updateState(state, values) {
-  if (values) {
-    // if values can be iterated on (like FormData)
-    if (values.forEach) {
-      values.forEach((value, key) => {
-        if (allowedKeys.includes(key)) {
-          state[key] = value;
-        }
-      });
-    // else if it's just a plain object
-    } else {
-      for (let key in values) {
-        if (allowedKeys.includes(key)) {
-          state[key] = values[key];
-        }
-      }
-    }
-  }
-}
 
 function initForm(config, initialState) {
   const marketForm = document.getElementById(config.form);
@@ -130,7 +80,7 @@ function initForm(config, initialState) {
   });
 
   document.querySelector('.js-market-submit').addEventListener('click', function(event) {
-    const diff = diffFormData(initialState, state);
+    const diff = diffState(initialState, state);
     event.preventDefault();
 
     // if anything was changed, update state inputs and submit

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -35,21 +35,24 @@ function initFormNotification(formElId, notificationElId) {
   }
 }
 
+const allowedKeys = ['title', 'summary', 'description', 'images', 'website', 'contact'];
 
 // TODO: test
-function diffFormData(initialState, formData) {
+function diffFormData(initialState, state) {
   const diff = {};
 
-  for (let key in initialState) {
+  for (let key of allowedKeys) {
+    // images is an array of objects so compare stringified version
     if (key === 'images') {
-      let images = JSON.parse(formData.get('state'))['images'];
+      // remove images to delete from the diff
+      const images = state[key].filter(image => image.status !== 'delete');
 
       if (JSON.stringify(initialState[key]) !== JSON.stringify(images)) {
         diff[key] = images;
       }
     } else {
-      if (initialState[key] !== formData.get(key)) {
-        diff[key] = formData.get(key);
+      if (initialState[key] !== state[key]) {
+        diff[key] = state[key];
       }
     }
   }
@@ -58,31 +61,73 @@ function diffFormData(initialState, formData) {
   return Object.keys(diff).length > 0 ? diff : null;
 }
 
+function updateState(state, values) {
+  if (values) {
+    // if values can be iterated on (like FormData)
+    if (values.forEach) {
+      values.forEach((value, key) => {
+        if (allowedKeys.includes(key)) {
+          state[key] = value;
+        }
+      });
+    // else if it's just a plain object
+    } else {
+      for (let key in values) {
+        if (allowedKeys.includes(key)) {
+          state[key] = values[key];
+        }
+      }
+    }
+  }
+}
+
 function initForm(config, initialState) {
+  const marketForm = document.getElementById(config.form);
+  let state = JSON.parse(JSON.stringify(initialState));
+
+  const stateInput = document.createElement('input');
+  stateInput.type = "hidden";
+  stateInput.name = "state";
+
+  marketForm.appendChild(stateInput);
+
+  const diffInput = document.createElement('input');
+  diffInput.type = "hidden";
+  diffInput.name = "changes";
+
+  marketForm.appendChild(diffInput);
+
   // TODO: edit icon in images state
   initSnapIconEdit(config.snapIconImage, config.snapIconInput);
   initFormNotification(config.form, config.formNotification);
-  // TODO: move state out of screenshots (to share with icon and rest of the form?)
   initSnapScreenshotsEdit(
     config.screenshotsToolbar,
     config.screenshotsWrapper,
-    {
-      images: JSON.parse(JSON.stringify(initialState.images))
-    }
+    state
   );
 
-  document.querySelector('.js-market-submit').addEventListener('click', function(event){
-    const marketForm = document.getElementById(config.form);
-    // const data = new FormData(marketForm);
-    // const diff = diffFormData(initialState, data);
+  // when anything is changed update the state
+  marketForm.addEventListener('change', function() {
+    updateState(state, new FormData(marketForm));
+  });
 
+  document.querySelector('.js-market-submit').addEventListener('click', function(event) {
+    const diff = diffFormData(initialState, state);
     event.preventDefault();
 
-    // TODO: only save changed data
-    // if (diff) {
-    marketForm.submit();
-    //}
+    // if anything was changed, update state inputs and submit
+    if (diff) {
+    // TODO: temporary soluton - save clean state in state input,
+    // so save still works until backend is update to understand diff
+      const cleanState = JSON.parse(JSON.stringify(state));
+      cleanState.images = cleanState.images.filter(image => image.status !== 'delete');
+      stateInput.value = JSON.stringify(cleanState);
+      diffInput.value = JSON.stringify(diff);
+
+      marketForm.submit();
+    }
   });
+
 }
 
 export {

--- a/static/js/publisher/market/market.test.js
+++ b/static/js/publisher/market/market.test.js
@@ -3,6 +3,7 @@ import * as market from './market';
 describe('initSnapIconEdit', () => {
   let input;
   let icon;
+  let state;
 
   beforeEach(() => {
     icon = document.createElement('a');
@@ -14,15 +15,19 @@ describe('initSnapIconEdit', () => {
     document.body.appendChild(input);
 
     URL.createObjectURL = jest.fn().mockReturnValue('test-url');
+
+    state = {
+      images: []
+    };
   });
 
   test('should set icon src on input change', () => {
-    market.initSnapIconEdit('test-icon-id', 'test-id');
+    market.initSnapIconEdit('test-icon-id', 'test-id', state);
 
     let event = new Event('change');
     // mock list of files on input
     Object.defineProperty(input, 'files', {
-      value: []
+      value: [ { name: 'test.png' } ]
     });
     input.dispatchEvent(event);
 

--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -1,15 +1,5 @@
 import lightbox from './lightbox';
-
-// STATE HELPER FUNCTIONS
-function updateState(state, values) {
-  if (values) {
-    for (let key in values) {
-      if (values.hasOwnProperty(key)) {
-        state[key] = values[key];
-      }
-    }
-  }
-}
+import { updateState } from './state';
 
 // TEMPLATES
 const templates = {
@@ -57,8 +47,6 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   const setState = function(nextState) {
     updateState(state, nextState);
   };
-
-  setState();
 
   // actions on state
   const addScreenshots = (files) => {

--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -11,14 +11,6 @@ function updateState(state, values) {
   }
 }
 
-function serializeState(state) {
-  let cleanedState = Object.assign({}, state);
-  if (cleanedState.images && cleanedState.images.length) {
-    cleanedState.images = cleanedState.images.filter(image => image.status !== 'delete');
-  }
-  return cleanedState;
-}
-
 // TEMPLATES
 const templates = {
   row: (content) => `
@@ -57,28 +49,16 @@ const templates = {
 };
 
 // INIT SCREENSHOTS
-function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, initialState) {
+function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, state) {
   // DOM elements
   const screenshotsToolbarEl = document.getElementById(screenshotsToolbarElId);
   const screenshotsWrapper = document.getElementById(screenshotsWrapperElId);
 
-  // simple state handling (and serializing as JSON in hidden input)
-  const state = {};
-  const stateInput = document.createElement('input');
-  stateInput.type = "hidden";
-  stateInput.name = "state";
-
-  screenshotsToolbarEl.parentNode.appendChild(stateInput);
-
   const setState = function(nextState) {
     updateState(state, nextState);
-
-    let newState = Object.assign({}, state);
-    newState.images = newState.images.filter(image => image.status !== 'delete');
-    stateInput.value = JSON.stringify(serializeState(state));
   };
 
-  setState(initialState);
+  setState();
 
   // actions on state
   const addScreenshots = (files) => {
@@ -244,6 +224,5 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
 export {
   initSnapScreenshotsEdit,
   // for testing
-  templates,
-  serializeState
+  templates
 };

--- a/static/js/publisher/market/screenshots.test.js
+++ b/static/js/publisher/market/screenshots.test.js
@@ -1,6 +1,5 @@
 import {
-  templates,
-  serializeState
+  templates
 } from './screenshots';
 
 describe('templates', () => {
@@ -90,22 +89,5 @@ describe('templates', () => {
       expect(result).toContain('3 images to upload');
       expect(result).toContain('2 images to delete');
     });
-  });
-});
-
-describe('serializeState', () => {
-  it('should remove images marked from deletion', () => {
-    const state = {
-      images: [
-        { url: 'image1' },
-        { url: 'image2', status: 'delete' },
-        { url: 'image3' }
-      ]
-    };
-
-    const result = serializeState(state);
-
-    expect(result.images.length).toBe(2);
-    expect(result.images.filter(image => image.status === 'delete').length).toBe(0);
   });
 });

--- a/static/js/publisher/market/state.js
+++ b/static/js/publisher/market/state.js
@@ -1,0 +1,55 @@
+const allowedKeys = ['title', 'summary', 'description', 'images', 'website', 'contact'];
+
+function updateState(state, values) {
+  if (values) {
+    // if values can be iterated on (like FormData)
+    if (values.forEach) {
+      values.forEach((value, key) => {
+        if (allowedKeys.includes(key)) {
+          state[key] = value;
+        }
+      });
+    // else if it's just a plain object
+    } else {
+      for (let key in values) {
+        if (allowedKeys.includes(key)) {
+          state[key] = values[key];
+        }
+      }
+    }
+  }
+}
+
+function diffState(initialState, state) {
+  const diff = {};
+
+  for (let key of allowedKeys) {
+    // images is an array of objects so compare stringified version
+    if (key === 'images' && state[key]) {
+      const images = state[key]
+        // remove images to delete from the diff
+        .filter(image => image.status !== 'delete')
+        // ignore selected status when comparing
+        .map(image => {
+          delete image.selected;
+          return image;
+        });
+
+      if (JSON.stringify(initialState[key]) !== JSON.stringify(images)) {
+        diff[key] = images;
+      }
+    } else {
+      if (initialState[key] !== state[key]) {
+        diff[key] = state[key];
+      }
+    }
+  }
+
+  // only return diff when there are any changes
+  return Object.keys(diff).length > 0 ? diff : null;
+}
+
+export {
+  updateState,
+  diffState
+};

--- a/static/js/publisher/market/state.test.js
+++ b/static/js/publisher/market/state.test.js
@@ -1,0 +1,129 @@
+import { updateState, diffState } from './state';
+
+describe('updateState', () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      title: 'Default test title'
+    };
+  });
+
+  describe('when passing FormData values', () => {
+    let formData;
+
+    beforeEach(() => {
+      formData = new FormData();
+    });
+
+    test('should add value from allowed keys', () => {
+      formData.set('summary', 'Test summary');
+      updateState(state, formData);
+
+      expect(state.summary).toBe('Test summary');
+    });
+
+    test('should update value from allowed keys', () => {
+      formData.set('title', 'Test title');
+      updateState(state, formData);
+
+      expect(state.title).toBe('Test title');
+    });
+
+    test('should not add value not from allowed keys', () => {
+      formData.set('something', 'Test something');
+      updateState(state, formData);
+
+      expect(state.something).toBeUndefined();
+    });
+  });
+
+  describe('when passing object with values', () => {
+    test('should add value from allowed keys', () => {
+      updateState(state, {
+        summary: 'Test summary'
+      });
+
+      expect(state.summary).toBe('Test summary');
+    });
+
+    test('should update value from allowed keys', () => {
+      updateState(state, {
+        title: 'Test title'
+      });
+
+      expect(state.title).toBe('Test title');
+    });
+
+    test('should not add value not from allowed keys', () => {
+      updateState(state, {
+        something: 'Test something'
+      });
+
+      expect(state.something).toBeUndefined();
+    });
+  });
+});
+
+
+describe('diffState', () => {
+
+  test('should return null if states are equal is empty', () => {
+    expect(diffState({
+      title: 'Test title'
+    }, {
+      title: 'Test title'
+    })).toBeNull();
+  });
+
+  test('should return diff containing only changed fields', () => {
+    expect(diffState({
+      title: 'Test title',
+      summary: 'Test summary',
+    }, {
+      title: 'Test title',
+      summary: 'Test summary changed',
+      something: 'Test something'
+    })).toEqual({
+      summary: 'Test summary changed'
+    });
+  });
+
+  // when comparing images
+  describe('when comparing images in state', () => {
+    test('should remove images marked for deletion', () => {
+      expect(diffState({
+        images: [
+          { url: 'test1.png', status: 'uploaded' },
+          { url: 'test2.png', status: 'uploaded' }
+        ]
+      }, {
+        images: [
+          { url: 'test1.png', status: 'uploaded' },
+          { url: 'test2.png', status: 'delete' },
+          { url: 'test3.png', status: 'new' }
+        ]
+      })).toEqual({
+        images: [
+          { url: 'test1.png', status: 'uploaded' },
+          { url: 'test3.png', status: 'new' }
+        ]
+      });
+    });
+
+    test('should ignore selected status', () => {
+      expect(diffState({
+        images: [
+          { url: 'test1.png', status: 'uploaded' },
+          { url: 'test2.png', status: 'uploaded' }
+        ]
+      }, {
+        images: [
+          { url: 'test1.png', status: 'uploaded', selected: false },
+          { url: 'test2.png', status: 'uploaded', selected: true }
+        ]
+      })).toBeNull();
+    });
+  });
+
+});

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -209,22 +209,28 @@
     whitelistUrls: ['snapcraft.io']
   }).install();
   Raven.context(function () {
-    snapcraft.publisher.market.initSnapIconEdit("snap_icon_image", "snap_icon");
-    snapcraft.publisher.market.initFormNotification("market-form", "market-form-status");
-    snapcraft.publisher.market.initSnapScreenshotsEdit(
-      "screenshots-toolbar",
-      "snap-screenshots",
-      {
-        images: [
-          {% if icon_url %}
-            { url: {{ icon_url|tojson }}, type: "icon", status: "uploaded" },
-          {% endif %}
-          {% for screenshot_url in screenshot_urls %}
-            { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
-          {% endfor %}
-        ]
-      }
-    );
+    snapcraft.publisher.market.initForm({
+      snapIconImage: "snap_icon_image",
+      snapIconInput: "snap_icon",
+      form: "market-form",
+      formNotification: "market-form-status",
+      screenshotsToolbar: "screenshots-toolbar",
+      screenshotsWrapper: "snap-screenshots"
+    }, {
+      title: {{ title|tojson }},
+      summary: {{ summary|tojson }},
+      description: {{ description|tojson }},
+      website: {{ website|tojson }},
+      contact: {{ contact|tojson }},
+      images: [
+        {% if icon_url %}
+          { url: {{ icon_url|tojson }}, type: "icon", status: "uploaded" },
+        {% endif %}
+        {% for screenshot_url in screenshot_urls %}
+          { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
+        {% endfor %}
+      ]
+    })
   });
 </script>
 {% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -34,8 +34,8 @@
 
           <div class="row">
             <div class="col-12 u-align--right">
-                <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert"/>
-                <input type="submit" class="p-button--positive" name="submit_apply" value="Apply"/>
+                <input type="submit" class="p-button--neutral js-market-revert" name="submit_revert" value="Revert"/>
+                <input type="submit" class="p-button--positive js-market-submit" name="submit_apply" value="Apply"/>
                 <hr />
             </div>
           </div>


### PR DESCRIPTION
Refactors market page front-end logic to allow saving only data changed by user.

Adds `changes` field to the form which contains JSON with only values changed by the user.

### NOTE:
Needs backend update to use diff instead of form input values, but can be merged for front-end changes only, as is backwards compatible (only adds new hidden data field to the form)

### QA

- ./run
- go to market page
- change some values, save
- market page should be saved as before
- additional `changes` field is sent to backend 