### PR TITLE
Fixes typo on front page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -86,7 +86,7 @@
           <h2>Installable across Linux distributions</h2>
         </div>
         <div class="col-6">
-          <p class="p-heading--five">Snaps are available for any Linux OS running snapd, the service that runs and manage snaps.</p>
+          <p class="p-heading--five">Snaps are available for any Linux OS running snapd, the service that runs and manages snaps.</p>
           <p class="p-heading--five"><a href="https://docs.snapcraft.io/core/install">Enable snaps on your OS</a></p>
         </div>
       </div>


### PR DESCRIPTION
“runs and manage” > “runs and manages”