### PR TITLE
Extend timeout to 3 seconds

### DIFF
--- a/modules/cache.py
+++ b/modules/cache.py
@@ -32,11 +32,11 @@ def get(
             json=json,
             files=files,
             data=data,
-            timeout=2
+            timeout=3
         )
     except requests.exceptions.Timeout:
         api_error_exception = ApiTimeoutError(
-            'The request to {} took longer than 2 seconds'.format(url),
+            'The request to {} took longer than 3 seconds'.format(url),
         )
         raise api_error_exception
     except requests.exceptions.ConnectionError:


### PR DESCRIPTION
We've been getting a number of api timeout errors in production, intermittently.

This should hopefully help to reduce the chance of that happening, without allowing the API to bring down the site by waiting for too long.

QA
--

`./run`, check the site works