### PR TITLE
Smaller headings

### DIFF
--- a/static/sass/_snapcraft_metrics.scss
+++ b/static/sass/_snapcraft_metrics.scss
@@ -1,13 +1,4 @@
 @mixin snapcraft-metrics {
-
-  // Remove this when we have a coloured header background
-  // It hackily hides the top drop shadow.
-  .metrics__nav-wrap {
-    .p-tabs {
-      box-shadow: 0 2px 2.5px 1px transparentize($color-dark, .85);
-    }
-  }
-
   .snapcraft-metrics__graph {
     opacity: 0;
     transition: opacity .333s;

--- a/static/sass/_snapcraft_p-tabs.scss
+++ b/static/sass/_snapcraft_p-tabs.scss
@@ -1,0 +1,13 @@
+@mixin snapcraft-p-tabs {
+  @include vf-p-tabs;
+
+  .p-tabs {
+    @extend .p-tabs; // sass-lint:disable-line placeholder-in-extend
+    box-shadow: none;
+
+    &__list {
+      padding-right: 0;
+      width: auto;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -23,7 +23,6 @@ $color-navigation-background: #252525;
 @include vf-p-forms;
 @include vf-p-form-help-text;
 @include vf-p-headings;
-@include vf-p-tabs;
 @include vf-p-matrix;
 @include vf-p-icons;
 @include vf-p-heading-icon;
@@ -67,6 +66,9 @@ $color-navigation-background: #252525;
 
 @import 'snapcraft_p-navigation';
 @include snapcraft-p-navigation;
+
+@import 'snapcraft_p-tabs';
+@include snapcraft-p-tabs;
 
 @import 'snapcraft_custom-typography';
 @include snapcraft-custom-typography;

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -6,23 +6,31 @@
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    <section class="p-strip is-shallow">
-      <div class="row">
-        <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-        <h1 class="u-no-margin--top">{{ title }}</h1>
-      </div>
-    </section>
-
-    <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+    <section class="p-strip is-shallow u-no-padding--bottom">
       <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Market</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab">Measure</a>
-          </li>
-        </ul>
+        {# This row and it's contents needs to be removed before going live #}
+        <div class="row">
+          <a href="/account" class="u-float--left p-muted-heading">&lsaquo; Snap list</a>
+        </div>
+        <div class="row u-no-margin--top">
+        <div class="row">
+          <div class="col-6">
+            <h1 class="u-float--left p-heading--three">{{ title }}</h1>
+          </div>
+          <div class="col-6">
+            <ul class="p-tabs__list u-float--right" role="tablist">
+              <li class="p-tabs__item" role="presentation">
+                <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Market</a>
+              </li>
+              <li class="p-tabs__item" role="presentation">
+                <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab">Measure</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="row u-no-margin--top">
+          <hr class="u-no-margin" />
+        </div>
       </nav>
     </section>
 
@@ -35,7 +43,7 @@
           <div class="row">
             <div class="col-12 u-align--right">
                 <input type="submit" class="p-button--neutral" name="submit_revert" value="Revert"/>
-                <input type="submit" class="p-button--positive" name="submit_apply" value="Apply"/>
+                <input type="submit" class="p-button--positive u-no-margin--top" name="submit_apply" value="Apply"/>
                 <hr />
             </div>
           </div>

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -6,30 +6,38 @@ Publisher metrics for {{ snap_name }}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    <section class="p-strip is-shallow">
-      <div class="row">
-        <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-        <h1 class="u-no-margin--top">{{ snap_title }}</h1>
-      </div>
-    </section>
-
-    <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+    <section class="p-strip is-shallow u-no-padding--bottom">
       <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab">Market</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Measure</a>
-          </li>
-        </ul>
+        {# This row and it's contents needs to be removed before going live #}
+        <div class="row">
+          <a href="/account" class="u-float--left p-muted-heading">&lsaquo; Snap list</a>
+        </div>
+        <div class="row u-no-margin--top">
+          <div class="col-6">
+            <h1 class="u-float--left p-heading--three">{{ snap_title }}</h1>
+          </div>
+          <div class="col-6">
+            <ul class="p-tabs__list u-float--right" role="tablist">
+              <li class="p-tabs__item" role="presentation">
+                <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab">Market</a>
+              </li>
+              <li class="p-tabs__item" role="presentation">
+                <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Measure</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="row u-no-margin--top">
+          <hr class="u-no-margin" />
+        </div>
       </nav>
     </section>
+
     {% if nodata %}
       <section class="p-strip--light is-shallow">
         <div class="row">
           <div class="col-6">
-            <h4>Measure your snap's performance</h4>
+            <h2 class="p-heading--four">Measure your snap's performance</h2>
           </div>
           <div class="col-6">
             <p>You'll be able to see active devices and territories when people start using your snap.</p>
@@ -40,8 +48,8 @@ Publisher metrics for {{ snap_name }}
     <section class="p-strip is-shallow{% if nodata %} is-empty{% endif %}">
       <div class="row">
         <div class="u-clearfix">
-          <h3 class="u-float--left">Weekly active devices</h3>
-          <div class="p-heading--three u-float--right u-no-margin--top">
+          <h4 class="u-float--left">Weekly active devices</h4>
+          <div class="p-heading--four u-float--right u-no-margin--top">
             <strong>{{ latest_active_devices }}</strong>
           </div>
         </div>
@@ -67,8 +75,8 @@ Publisher metrics for {{ snap_name }}
       </div>
       <div class="row">
         <div class="u-clearfix">
-          <h3 class="u-float--left">Territories</h3>
-          <div class="p-heading--three u-float--right u-no-margin--top">
+          <h1 class="u-float--left p-heading--four">Territories</h1>
+          <div class="p-heading--four u-float--right u-no-margin--top">
             <strong>{{ territories_total }}</strong>
           </div>
         </div>


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/432

# QA

- Pull the branch
- `./run`
- Visit the publisher pages
- Check them against the prototype
- Note the '< Snap list' link - this is for convenience while developing, it will be removed on release as 'My snaps' in the header will link to the snap list.

# Screenshots

## Market page
![screenshot-2018-3-22 market details for lukotron test](https://user-images.githubusercontent.com/479384/37765549-5a822a48-2dbc-11e8-8a85-f2f5b06a2c48.png)

## Measure page
![screenshot-2018-3-22 publisher metrics for lukewh-test](https://user-images.githubusercontent.com/479384/37765555-5e189ef8-2dbc-11e8-9a47-bdc1e8816619.png)
