### PR TITLE
Remove flask dependency from validation

### DIFF
--- a/modules/authentication.py
+++ b/modules/authentication.py
@@ -88,36 +88,6 @@ def request_macaroon():
     return response.json()['macaroon']
 
 
-def verify_macaroon(root, discharge, url):
-    """
-    Submit a request to verify a macaroon used for authorization.
-    Returns the response.
-    """
-    authorization = get_authorization_header(root, discharge)
-    url = ''.join([
-        DASHBOARD_API,
-        'acl/verify/',
-    ])
-    response = requests.request(
-        url=url,
-        method='POST',
-        json={
-            'auth_data': {
-                'authorization': authorization,
-                'http_uri': url,
-                'http_method': 'GET'
-            }
-        },
-        headers={
-            'Accept': 'application/json, application/hal+json',
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-cache',
-        }
-    )
-
-    return response.json()
-
-
 def get_refreshed_discharge(discharge):
     """
     Get a refresh macaroon if the macaroon is not valid anymore.
@@ -141,68 +111,10 @@ def get_refreshed_discharge(discharge):
     return response.json()['discharge_macaroon']
 
 
-def verify_headers(headers):
+def is_macaroon_expired(headers):
     """
     Returns True if the macaroon needs to be refreshed from
     the header response.
     """
     return headers.get('WWW-Authenticate') == (
             'Macaroon needs_refresh=1')
-
-
-def verify_response(
-        response,
-        session,
-        url_requested,
-        url_calling,
-        url_login,
-        url_account
-):
-    """
-    Verify if the response from the server has errors.
-    Returns an JSON Object with the status_code error,
-    the redirection url and the reason of the redirection.
-    """
-    # Redirection to same url if my macaroon needs to be refreshed
-    if verify_headers(response.headers):
-        session['macaroon_discharge'] = get_refreshed_discharge(
-            session['macaroon_discharge']
-        )
-
-        return {
-            'status_code': 307,
-            'redirect': url_calling,
-            'reason': 'Macaroon discharge refreshed'
-        }
-
-    if response.status_code > 400:
-        verified = verify_macaroon(
-            session['macaroon_root'],
-            session['macaroon_discharge'],
-            url_calling
-        )
-
-        # Macaroon not valid anymore, needs refresh
-        if verified['account'] is None:
-            empty_session(session)
-            return {
-                'status_code': 307,
-                'redirect': url_login,
-                'reason': 'Need login'
-            }
-
-        # Not authorized content
-        if response.status_code == 401 and not verified['allowed']:
-            return {
-                'status_code': 401,
-                'redirect': url_account,
-                'reason': 'Not authorized'
-            }
-
-        # The package doesn't exist
-        if verified['account'] is not None and response.status_code == 404:
-            return {
-                'status_code': 404,
-                'redirect': url_account,
-                'reason': 'Not found'
-            }

--- a/modules/exceptions.py
+++ b/modules/exceptions.py
@@ -49,3 +49,8 @@ class ApiResponseErrorList(ApiResponseError):
     def __init__(self, message, status_code, errors):
         self.errors = errors
         return super().__init__(message, status_code)
+
+
+class MacaroonRefreshRequired(ApiError):
+    def __init__(self):
+        return super().__init__('The Macaroon needs to be refreshed')

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 
-import json
 import unittest
 
 import pymacaroons
@@ -230,33 +229,18 @@ class PublisherPagesTestCase(unittest.TestCase):
         responses.add(
             responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
             json=payload, status=500)
-        responses.add(
-            responses.POST,
-            'https://dashboard.snapcraft.io/dev/api/acl/verify/',
-            json={'account': 'test', 'allowed': True}, status=200)
 
         authorization = _log_in(self.client)
         response = self.client.get('/account')
         self.assertEqual(200, response.status_code)
 
-        self.assertEqual(2, len(responses.calls))
-        [account_call, verify_call] = responses.calls
+        self.assertEqual(1, len(responses.calls))
+        [account_call] = responses.calls
         self.assertEqual(
             'https://dashboard.snapcraft.io/dev/api/account',
             account_call.request.url)
         self.assertEqual(
             authorization, account_call.request.headers.get('Authorization'))
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/acl/verify/',
-            verify_call.request.url)
-        self.assertEqual({
-            'auth_data': {
-                'authorization': authorization,
-                'http_uri': (
-                    'https://dashboard.snapcraft.io/dev/api/acl/verify/'),
-                'http_method': 'GET'
-            },
-        }, json.loads(verify_call.request.body.decode('utf-8')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Refactoto S02E06 - The validation

~~This PR should be merged before: https://github.com/canonical-websites/snapcraft.io/pull/431~~

## Summary

- Remove last flask dependency from publisher API module
- Remove useless validation checks for the frontend. Only check if the macaroon needs to be refreshed in the headers. If yes raise an exception to handle it.

## QA

- `./run`
- http://0.0.0.0:8004/account/
- Should work as usual

Hard to QA because the macaroon is valid for 1 year...