### PR TITLE
Fixes typo in install instructions HTML

### DIFF
--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -36,7 +36,7 @@
                     class="p-code-snippet__input"
                     id="snap-install"
                     value="sudo snap install {{ package_name }}"
-                    readonly="readonly">
+                    readonly="readonly"
                   />
                   <button
                     class="p-code-snippet__action"


### PR DESCRIPTION
### QA

- ./run
- go to snap details page
- install instructions should be correctly displayed
- all tags should be correctly closed