### PR TITLE
Revert "Add DEVEL to .env variables"

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
 PORT=8004
-DEVEL=true
 FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key


### PR DESCRIPTION
Reverts canonical-websites/snapcraft.io#434

This is just too ugly in my terminal I'm afraid. Could we not enable this until talisker has fixed the colours?

![bad-colours](https://user-images.githubusercontent.com/519935/37800865-35e18cd2-2e1c-11e8-8c68-4437dff3f69d.png)