### PR TITLE
Fixes screenshots JS errors from sentry

### DIFF
--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -3,6 +3,10 @@ import lightbox from './../../publisher/market/lightbox';
 export default function initScreenshots(screenshotsId) {
   const screenshotsEl = document.querySelector(screenshotsId);
 
+  if (!screenshotsEl) {
+    return;
+  }
+
   const images = Array.from(screenshotsEl.querySelectorAll('img')).map(image => image.src);
 
   screenshotsEl.addEventListener('click', (event) => {
@@ -35,14 +39,14 @@ export default function initScreenshots(screenshotsId) {
 
 
   // get table of offsets for all screenshots
-  let offsets = Array.from(screenshotsEl.querySelectorAll('.p-screenshot'))
+  let offsets = [].slice.call(screenshotsEl.querySelectorAll('.p-screenshot'))
     .map(screenshot => screenshot.offsetLeft);
 
   let current = 0;
 
   function setCurrent(n) {
     // update offsets in case images finished loading after init
-    offsets = Array.from(screenshotsEl.querySelectorAll('.p-screenshot'))
+    offsets = [].slice.call(screenshotsEl.querySelectorAll('.p-screenshot'))
       .map(screenshot => screenshot.offsetLeft);
 
     current = n;


### PR DESCRIPTION
There was a 'bunch' of errors in Sentry cased by recent public screenshots release.

Most common are 2 types:

- `screenshotsEl` is null - very common case because it happens when snap doesn't have any screenshots, in such case we should not try to run screenshots related code...

- `Array.from` is not a function - it seems that we still have quite a lot of people with older or not mainstream browsers that don't yet support this function, so we need to get back to older solutions

This PR addresses both of issues listed above.

### QA

- ./run
- go to a public snap page with screenshots (everything should work as expected, no errors in console)
- go to a public span page without screenshots (everything should work, no errors in console)