### PR TITLE
Adds missing market fields when there are post errors

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -409,6 +409,8 @@ def post_market_snap(snap_name):
                 "icon_url": snap_details['icon_url'],
                 "publisher_name": snap_details['publisher_name'],
                 "screenshot_urls": snap_details['screenshot_urls'],
+                "contact": snap_details['contact'],
+                "website": snap_details['website'],
                 "error_list": error_list
             }
 


### PR DESCRIPTION
`website` and `contact` fields are missing in context when posting market page has errors.
Because of that when you post market page with errors you get 500 internal server error.

This PR fixes that.

### QA
- ./run
- go to market page of any snap
- change something that will cause error (make title longer then 64 chars or icon that is not 256x256)
- post
- page should render correctly with error message on the top