### PR TITLE
Fix width of empty screenshots box on market page

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -150,7 +150,7 @@
             </div>
           </div>
 
-          <div id="snap-screenshots">
+          <div class="row" id="snap-screenshots">
           </div>
 
           <div class="row">


### PR DESCRIPTION
### QA
- ./run
- go to snap market page that doesn't have screenshots
- 'Add images' grey field should have width of the page not whole screen