### PR TITLE
Adds basic Vanilla style validation to market input fields

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -50,7 +50,21 @@ function initFormNotification(formElId, notificationElId) {
 
 
 
-function initForm(config, initialState) {
+function initForm(config, initialState, errors) {
+  // if there are errors mark fields as invalid
+  if (errors && errors.length) {
+    errors.forEach((error) => {
+      if (error.code === 'invalid-field') {
+        const name = error.extra.name;
+        if (name) {
+          const input = document.querySelector(`[name=${name}]`);
+          input.closest('.p-form-validation').classList.add('is-error');
+        }
+      }
+    });
+  }
+
+  // setup form functionality
   const marketForm = document.getElementById(config.form);
   let state = JSON.parse(JSON.stringify(initialState));
 
@@ -75,8 +89,14 @@ function initForm(config, initialState) {
   );
 
   // when anything is changed update the state
-  marketForm.addEventListener('change', function() {
+  marketForm.addEventListener('change', function(event) {
     updateState(state, new FormData(marketForm));
+
+    // clear validation of field on change
+    const field = event.target.closest('.p-form-validation');
+    if (field) {
+      field.classList.remove('is-error');
+    }
   });
 
   document.querySelector('.js-market-submit').addEventListener('click', function(event) {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -28,7 +28,7 @@ $color-navigation-background: #252525;
 @include vf-p-heading-icon;
 @include vf-u-image-position;
 @include vf-p-code-snippet;
-
+@include vf-p-form-validation;
 
 // vanilla utilities
 @include vf-u-floats;

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -85,8 +85,10 @@
               </div>
             </div>
             <div class="col-8">
-              <label for="snap-title">Title:</label>
-              <input id="snap-title" type="text" name="title" value="{{ title }}"/>
+              <div class="p-form-validation u-no-margin">
+                <label for="snap-title">Title:</label>
+                <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}"/>
+              </div>
             </div>
           </div>
 
@@ -119,7 +121,9 @@
               <label class="p-label--grid-baseline">Summary: </label>
             </div>
             <div class="col-8">
-              <input type="text" name="summary" value="{{ summary }}"/>
+              <div class="p-form-validation u-no-margin">
+                <input class="p-form-validation__input" type="text" name="summary" value="{{ summary }}"/>
+              </div>
             </div>
           </div>
           <div class="row">
@@ -127,7 +131,9 @@
               <label class="p-label--grid-baseline">Description: </label>
             </div>
             <div class="col-8">
-              <textarea class="u-no-margin" name="description">{{ description }}</textarea>
+              <div class="p-form-validation u-no-margin">
+                <textarea class="p-form-validation__input u-no-margin" name="description">{{ description }}</textarea>
+              </div>
             </div>
           </div>
 
@@ -179,7 +185,9 @@
               <label class="p-label--grid-baseline">Developer website: </label>
             </div>
             <div class="col-8">
-            <input type="text" name="website" value="{{ website }}"/>
+              <div class="p-form-validation u-no-margin">
+                <input class="p-form-validation__input" type="text" name="website" value="{{ website }}"/>
+              </div>
             </div>
           </div>
 
@@ -188,7 +196,9 @@
               <label class="p-label--grid-baseline">Contact {{ publisher_name }}: </label>
             </div>
             <div class="col-8">
-              <input type="text" name="contact" value="{{ contact }}"/>
+              <div class="p-form-validation u-no-margin">
+                <input class="p-form-validation__input" type="text" name="contact" value="{{ contact }}"/>
+              </div>
             </div>
           </div>
         </form>
@@ -238,7 +248,13 @@
           { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
         {% endfor %}
       ]
-    })
+    },
+    {% if error_list %}
+      {{ error_list|tojson}}
+    {% else %}
+      null
+    {% endif %}
+    );
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
First pass of #399 

This PR adds basic marking of invalid fields with Vanilla styling.

Possible improvements for next PRs:
- showing error messages next to fields instead of top notification

### QA
- ./run
- go to market page
- update any of text fields to invalid value (make title or summary too long, make contact or website invalid URL)
- save the form (click `Apply`)
- Error notification should show up on top of the form, invalid field should be marked red
- Change the value in invalid field
- Field should be unmarked when you leave it

<img width="1028" alt="screen shot 2018-03-27 at 15 37 02" src="https://user-images.githubusercontent.com/83575/37971074-6121523a-31d5-11e8-8d67-604451cab2a0.png">
