### PR TITLE
Public metrics toggles

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,6 +69,21 @@ def inject_template_variables():
     }
 
 
+# Template helpers
+@app.context_processor
+def utility_processor():
+    def contains(arr, str):
+        return str in arr
+
+    def join(arr, str):
+        return str.join(arr)
+
+    return {
+        'contains': contains,
+        'join': join
+    }
+
+
 def login_required(func):
     """
     Decorator that checks if a user is logged in, and redirects

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -260,7 +260,9 @@ def get_market_snap(snap_name):
         "publisher_name": snap_details['publisher_name'],
         "screenshot_urls": snap_details['screenshot_urls'],
         "contact": snap_details['contact'],
-        "website": snap_details['website']
+        "website": snap_details['website'],
+        "public_metrics_enabled": snap_details['public_metrics_enabled'],
+        "public_metrics_blacklist": snap_details['public_metrics_blacklist'],
     }
 
     return flask.render_template(
@@ -375,13 +377,26 @@ def post_market_snap(snap_name):
             'license',
             'price',
             'blacklist_countries',
-            'whitelist_countries'
+            'whitelist_countries',
+            'public_metrics_enabled',
+            'public_metrics_blacklist'
         ]
 
         body_json = {
             key: flask.request.form[key]
             for key in whitelist if key in flask.request.form
         }
+
+        metrics_enabled = flask.request.form.get('public_metrics_enabled')
+        body_json['public_metrics_enabled'] = metrics_enabled == 'on'
+        metrics_blacklist = flask.request.form.get('public_metrics_blacklist')
+
+        if len(metrics_blacklist) > 0:
+            metrics_blacklist = metrics_blacklist.split(',')
+        else:
+            metrics_blacklist = []
+
+        body_json['public_metrics_blacklist'] = metrics_blacklist
 
         metadata = api.snap_metadata(
             flask.request.form['snap_id'],
@@ -411,6 +426,9 @@ def post_market_snap(snap_name):
             except ApiError as api_error:
                 flask.abort(502, str(api_error))
 
+            details_metrics_enabled = snap_details['public_metrics_enabled']
+            details_blacklist = snap_details['public_metrics_blacklist']
+
             context = {
                 "snap_id": snap_details['snap_id'],
                 "snap_name": snap_details['snap_name'],
@@ -423,6 +441,8 @@ def post_market_snap(snap_name):
                 "screenshot_urls": snap_details['screenshot_urls'],
                 "contact": snap_details['contact'],
                 "website": snap_details['website'],
+                "public_metrics_enabled": details_metrics_enabled,
+                "public_metrics_blacklist": details_blacklist,
                 "error_list": error_list
             }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -1,5 +1,6 @@
 import { initSnapScreenshotsEdit } from './screenshots';
 import { updateState, diffState } from './state';
+import { publicMetrics } from './publicMetrics';
 
 function initSnapIconEdit(iconElId, iconInputId, state) {
   const snapIconInput = document.getElementById(iconInputId);
@@ -90,7 +91,11 @@ function initForm(config, initialState, errors) {
 
   // when anything is changed update the state
   marketForm.addEventListener('change', function(event) {
-    updateState(state, new FormData(marketForm));
+    let formData = new FormData(marketForm);
+
+    // Some extra modifications need to happen for the checkboxes
+    publicMetrics(marketForm, formData);
+    updateState(state, formData);
 
     // clear validation of field on change
     const field = event.target.closest('.p-form-validation');

--- a/static/js/publisher/market/publicMetrics.js
+++ b/static/js/publisher/market/publicMetrics.js
@@ -1,0 +1,37 @@
+const NAMES = {
+  'public_metrics_territories': 'installed_base_by_country_percent'
+};
+
+function publicMetrics(form, formData) {
+  const publicMetricsEnabled = form['public_metrics_enabled'].checked;
+
+  if (publicMetricsEnabled) {
+    formData.set('public_metrics_enabled', publicMetricsEnabled);
+  } else {
+    formData.set('public_metrics_enabled', false);
+  }
+
+  let blackList = [];
+
+  Object.keys(NAMES).forEach(name => {
+    const checked = form[name].checked;
+
+    if (!checked) {
+      blackList.push(NAMES[name]);
+    }
+
+    if (!publicMetricsEnabled) {
+      form[name].setAttribute('disabled', 'disabled');
+    } else {
+      form[name].removeAttribute('disabled');
+    }
+  });
+
+  if (blackList.length > 0) {
+    form['public_metrics_blacklist'].setAttribute('value', blackList.join(','));
+  } else {
+    form['public_metrics_blacklist'].removeAttribute('value');
+  }
+}
+
+export { NAMES, publicMetrics };

--- a/static/js/publisher/market/state.js
+++ b/static/js/publisher/market/state.js
@@ -1,4 +1,13 @@
-const allowedKeys = ['title', 'summary', 'description', 'images', 'website', 'contact'];
+const allowedKeys = [
+  'title',
+  'summary',
+  'description',
+  'images',
+  'website',
+  'contact',
+  'public_metrics_enabled',
+  'public_metrics_blacklist'
+];
 
 function updateState(state, values) {
   if (values) {

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -201,6 +201,52 @@
               </div>
             </div>
           </div>
+
+          <div class="row">
+            <div class="col-12">
+              <hr />
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-8">
+              <input
+                type="checkbox"
+                name="public_metrics_enabled"
+                id="public-metrics-enabled"
+                {% if public_metrics_enabled %}
+                  checked="checked"
+                {% endif %}
+                />
+              <label class="u-no-margin--top" for="public-metrics-enabled">Display public metric charts</label>
+              <p class="p-form-help-text">Does not disclose any usage numbers for your application</p>
+              <input
+                type="hidden"
+                name="public_metrics_blacklist"
+                {% if public_metrics_blacklist|length > 0 %}
+                  value="{{ join(public_metrics_blacklist, ',')}}"
+                {% endif %}
+                />
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-4">
+              <input
+                type="checkbox"
+                name="public_metrics_territories"
+                id="public-metrics-territories"
+                {% if not contains(public_metrics_blacklist, 'installed_base_by_country_percent') %}
+                  checked="checked"
+                {% endif %}
+                {% if not public_metrics_enabled %}
+                  disabled="disabled"
+                {% endif %}
+                />
+              <label class="u-no-margin--top" for="public-metrics-territories">Territories</label>
+              <p class="p-form-help-text">Shows usage percentage by country on a map</p>
+            </div>
+          </div>
         </form>
     </div>
 
@@ -247,7 +293,9 @@
         {% for screenshot_url in screenshot_urls %}
           { url: {{ screenshot_url|tojson }}, type: "screenshot", status: "uploaded" },
         {% endfor %}
-      ]
+      ],
+      'public_metrics_enabled': {{ public_metrics_enabled|tojson }},
+      'public_metrics_blacklist': {{ join(public_metrics_blacklist, ',')|tojson }}
     },
     {% if error_list %}
       {{ error_list|tojson}}


### PR DESCRIPTION
# Done
Fixes https://github.com/canonical-websites/snapcraft.io/issues/436 and https://github.com/canonical-websites/snapcraft.io/issues/443

- Added Public Metrics global checkbox and Territories specific checkbox to the Market page
- Made the backend pass the data through

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/<snapname>/market
- Scroll down to the bottom and see the checkboxes
- When toggling the public metrics checkbox the items below should be disabled
- If you disable all metrics but have a specific metric checked, the specific metric should still be checked, but disabled
- Save changes and check the state when the page reloads

# Screenshots

## Nothing selected
![screenshot-2018-3-28 market details for lukotron](https://user-images.githubusercontent.com/479384/38040912-7554d956-32a8-11e8-8177-f1cdf566041c.png)

## Global selected
![screenshot-2018-3-28 market details for lukotron 1](https://user-images.githubusercontent.com/479384/38040923-7bb9336e-32a8-11e8-90e2-96a35da388b0.png)

## Global and individual selected
![screenshot-2018-3-28 market details for lukotron 2](https://user-images.githubusercontent.com/479384/38040935-7f6933c4-32a8-11e8-8997-623028005d40.png)

## Global not selected and individual selected
![screenshot-2018-3-28 market details for lukotron 3](https://user-images.githubusercontent.com/479384/38040951-83176c3e-32a8-11e8-99cf-596de813ef67.png)

## Potential future when distro graph is implemented
![screenshot-2018-3-28 market details for lukotron 4](https://user-images.githubusercontent.com/479384/38040961-86d01fd8-32a8-11e8-803d-d63d58e5e5b9.png)
