### PR TITLE
Test username endpoint

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -96,7 +96,7 @@ def post_account_name():
         else:
             return flask.redirect('/account')
     else:
-        return flask.render_template('username.html')
+        return flask.redirect('/account/username')
 
 
 def publisher_snap_measure(snap_name):


### PR DESCRIPTION
# Summary

Fixes https://github.com/canonical-websites/snapcraft.io/issues/445

- I disabled CSRF for testing, not useful to test a library :)
- Add entire integration test suite for the /account/username page (POST, GET)

# QA

- `./run test`
The tests should pass!