### PR TITLE
Add integration tests for /account/agreement

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -75,7 +75,7 @@ def post_agreement():
         api.post_agreement(flask.session, True)
         return flask.redirect('/account')
     else:
-        return flask.render_template('developer_programme_agreement.html')
+        return flask.redirect('/account/agreement')
 
 
 def get_account_name():

--- a/tests_publisher.py
+++ b/tests_publisher.py
@@ -378,6 +378,67 @@ class PublisherPage(TestCase):
         self.assert_context('username', 'toto')
         self.assert_context('error_list', payload['error_list'])
 
+    # /account/agreement endpoint
+    # ===
+    @responses.activate
+    def test_agreement_logged_in(self):
+        self._log_in(self.client)
+        response = self.client.get("/account/agreement")
+
+        assert response.status_code == 200
+        self.assert_template_used('developer_programme_agreement.html')
+
+    @responses.activate
+    def test_post_agreement_logged_in(self):
+        responses.add(
+            responses.POST,
+            'https://dashboard.snapcraft.io/dev/api/agreement/',
+            json={}, status=200)
+
+        authorization = self._log_in(self.client)
+        response = self.client.post(
+            '/account/agreement',
+            data={
+                'i_agree': 'on'
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            'https://dashboard.snapcraft.io/dev/api/agreement/',
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            called.response.json(),
+            {},
+        )
+        self.assertEqual(
+            b'{"latest_tos_accepted": true}',
+            called.request.body
+            )
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/account',
+            response.location)
+
+    @responses.activate
+    def test_post_agreement_off_logged_in(self):
+        self._log_in(self.client)
+        response = self.client.post(
+            '/account/agreement',
+            data={
+                'i_agree': 'off'
+            },
+        )
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/account/agreement',
+            response.location)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Summary

- Add entire integration test suite for the /account/agreement page (POST, GET)

# QA

- `./run test`
The tests should pass!