### PR TITLE
Add custom User-Agent headers for the storefront

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PORT=8004
 FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
+ENVIRONMENT=devel

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -1,7 +1,18 @@
+import os
 import requests
 from modules.exceptions import (
     ApiTimeoutError,
     ApiConnectionError
+)
+
+ENVIRONMENT = os.getenv(
+    'ENVIRONMENT',
+    'devel'
+)
+
+COMMIT_ID = os.getenv(
+    'COMMIT_ID',
+    'commit_id'
 )
 
 
@@ -23,6 +34,12 @@ def get(
 
     if method is None:
         method = "POST" if json else "GET"
+
+    storefront_header = 'storefront ({commit_hash};{environment})'.format(
+        commit_hash=COMMIT_ID,
+        environment=ENVIRONMENT
+    )
+    headers.update({'User-Agent': storefront_header})
 
     try:
         return requests.request(


### PR DESCRIPTION
# Summary

- Add custom UserAgent request to the storefront for every request.

**Format**
  - development: `storefront (commit_id; devel)`
 - staging: `storefront (fc78bfaa6f36bff9e09450b88441701ad8600740; staging)`
 - production: `storefront (fc78bfaa6f36bff9e09450b88441701ad8600740; production)`

# QA

 - `./run`
- Browse s.io make sure it still works
(- you can print the header in cache.py to make sure the header has all the information :sweat_smile: )