### PR TITLE
Show validation errors next to input fields

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -429,21 +429,36 @@ def post_market_snap(snap_name):
             details_metrics_enabled = snap_details['public_metrics_enabled']
             details_blacklist = snap_details['public_metrics_blacklist']
 
+            field_errors = {}
+            other_errors = []
+
+            for error in error_list:
+                if error['code'] == 'invalid-field':
+                    field_errors[error['extra']['name']] = error['message']
+                else:
+                    other_errors.append(error)
+
             context = {
+                # read-only values from details API
                 "snap_id": snap_details['snap_id'],
                 "snap_name": snap_details['snap_name'],
-                "title": snap_details['title'],
-                "summary": snap_details['summary'],
-                "description": snap_details['description'],
                 "license": snap_details['license'],
                 "icon_url": snap_details['icon_url'],
                 "publisher_name": snap_details['publisher_name'],
                 "screenshot_urls": snap_details['screenshot_urls'],
-                "contact": snap_details['contact'],
-                "website": snap_details['website'],
                 "public_metrics_enabled": details_metrics_enabled,
                 "public_metrics_blacklist": details_blacklist,
-                "error_list": error_list
+                "display_title": snap_details['title'],
+                # values posted by user
+                "title": flask.request.form['title'],
+                "summary": flask.request.form['summary'],
+                "description": flask.request.form['description'],
+                "contact": flask.request.form['contact'],
+                "website": flask.request.form['website'],
+                # errors
+                "error_list": error_list,
+                "field_errors": field_errors,
+                "other_erros": other_errors
             }
 
             return flask.render_template(

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -54,9 +54,12 @@ function initFormNotification(formElId, notificationElId) {
 function initForm(config, initialState, errors) {
   // if there are errors focus first error
   if (errors && errors.length) {
-    const errorInput = document.querySelector('.is-error input');
+    // find input with error or error notification and scroll it into view
+    const errorInput = document.querySelector('.is-error input')
+      || document.querySelector('.p-notification--negative');
+
     if (errorInput) {
-      errorInput.focus();
+      errorInput.scrollIntoView();
     }
   }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -59,7 +59,11 @@ function initForm(config, initialState, errors) {
       || document.querySelector('.p-notification--negative');
 
     if (errorInput) {
-      errorInput.scrollIntoView();
+      errorInput.focus();
+
+      if (errorInput.scrollIntoView) {
+        errorInput.scrollIntoView();
+      }
     }
   }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -52,17 +52,12 @@ function initFormNotification(formElId, notificationElId) {
 
 
 function initForm(config, initialState, errors) {
-  // if there are errors mark fields as invalid
+  // if there are errors focus first error
   if (errors && errors.length) {
-    errors.forEach((error) => {
-      if (error.code === 'invalid-field') {
-        const name = error.extra.name;
-        if (name) {
-          const input = document.querySelector(`[name=${name}]`);
-          input.closest('.p-form-validation').classList.add('is-error');
-        }
-      }
-    });
+    const errorInput = document.querySelector('.is-error input');
+    if (errorInput) {
+      errorInput.focus();
+    }
   }
 
   // setup form functionality
@@ -101,6 +96,11 @@ function initForm(config, initialState, errors) {
     const field = event.target.closest('.p-form-validation');
     if (field) {
       field.classList.remove('is-error');
+
+      const message = field.querySelector('.p-form-validation__message');
+      if (message) {
+        message.remove();
+      }
     }
   });
 

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,7 +1,7 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market details for {{ title }}
+  Market details for {% if display_title %}{{ display_title }}{% else %}{{ title }}{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -15,7 +15,7 @@
         <div class="row u-no-margin--top">
         <div class="row">
           <div class="col-6">
-            <h1 class="u-float--left p-heading--three">{{ title }}</h1>
+            <h1 class="u-float--left p-heading--three">{% if display_title %}{{ display_title }}{% else %}{{ title }}{% endif %}</h1>
           </div>
           <div class="col-6">
             <ul class="p-tabs__list u-float--right" role="tablist">
@@ -49,7 +49,7 @@
           </div>
 
           {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages or error_list %}
+            {% if messages %}
               <div class="row">
                 <div class="col-12">
                   {% for category, message in messages %}
@@ -59,8 +59,15 @@
                       </p>
                     </div>
                   {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+          {% endwith %}
 
-                  {% for error in error_list %}
+          {% if other_errors %}
+              <div class="row">
+                <div class="col-12">
+                  {% for error in other_errors %}
                     <div class="p-notification--negative">
                       <p class="p-notification__response">
                           {{ error.message }}
@@ -69,15 +76,25 @@
                   {% endfor %}
                 </div>
               </div>
-            {% endif %}
-          {% endwith %}
+          {% endif %}
 
-          <div class="row">
+          {% if field_errors and field_errors['icon'] %}
+            <div class="row">
+              <div class="col-12">
+                <div class="p-notification--negative">
+                  <p class="p-notification__response">
+                      <strong>Icon:</strong> {{ field_errors['icon'] }}
+                  </p>
+                </div>
+              </div>
+            </div>
+          {% endif %}
+          <div class="row" data-validation-name="icon">
             <div class="col-2">
               <div class="p-media-object__image--large p-editable-icon">
                 <img id="snap_icon_image"
                   {% if icon_url %}
-                    src="{{ icon_url }}" alt="{{ title }} snap"
+                    src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ title }}{% endif %} snap"
                   {% else %}
                     src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
                   {% endif %}
@@ -85,9 +102,14 @@
               </div>
             </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin">
+              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['title'] %}is-error{% endif %}">
                 <label for="snap-title">Title:</label>
                 <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}"/>
+                {% if field_errors and field_errors['title'] %}
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['title'] }}
+                  </p>
+                {% endif %}
               </div>
             </div>
           </div>
@@ -121,8 +143,13 @@
               <label class="p-label--grid-baseline">Summary: </label>
             </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin">
+              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['summary'] %}is-error{% endif %}">
                 <input class="p-form-validation__input" type="text" name="summary" value="{{ summary }}"/>
+                {% if field_errors and field_errors['summary'] %}
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['summary'] }}
+                  </p>
+                {% endif %}
               </div>
             </div>
           </div>
@@ -131,8 +158,13 @@
               <label class="p-label--grid-baseline">Description: </label>
             </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin">
+              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['description'] %}is-error{% endif %}">
                 <textarea class="p-form-validation__input u-no-margin" name="description">{{ description }}</textarea>
+                {% if field_errors and field_errors['description'] %}
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['description'] }}
+                  </p>
+                {% endif %}
               </div>
             </div>
           </div>
@@ -143,7 +175,18 @@
             </div>
           </div>
 
-          <div class="row">
+          {% if field_errors and field_errors['screenshots'] %}
+            <div class="row">
+              <div class="col-12">
+                <div class="p-notification--negative">
+                  <p class="p-notification__response">
+                      <strong>Screenshots:</strong> {{ field_errors['screenshots'] }}
+                  </p>
+                </div>
+              </div>
+            </div>
+          {% endif %}
+          <div class="row" data-validation-name="screenshots">
             <div class="col-12">
               <div class="p-screenshots-toolbar" id="screenshots-toolbar">
                 <label>Screenshots (up to 5):</label>
@@ -185,8 +228,13 @@
               <label class="p-label--grid-baseline">Developer website: </label>
             </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin">
+              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['website'] %}is-error{% endif %}">
                 <input class="p-form-validation__input" type="text" name="website" value="{{ website }}"/>
+                {% if field_errors and field_errors['website'] %}
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['website'] }}
+                  </p>
+                {% endif %}
               </div>
             </div>
           </div>
@@ -196,8 +244,13 @@
               <label class="p-label--grid-baseline">Contact {{ publisher_name }}: </label>
             </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin">
+              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['contact'] %}is-error{% endif %}">
                 <input class="p-form-validation__input" type="text" name="contact" value="{{ contact }}"/>
+                {% if field_errors and field_errors['contact'] %}
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['contact'] }}
+                  </p>
+                {% endif %}
               </div>
             </div>
           </div>
@@ -249,19 +302,6 @@
           </div>
         </form>
     </div>
-
-    {% if api_error %}
-    <div class="row">
-      <div class="col-12">
-        <div class="p-notification--negative">
-          <p class="p-notification__response">
-            <span class="p-notification__status">Error:</span> API request failed
-          </p>
-        </div>
-      </div>
-    </div>
-    {% endif %}
-
   </div>
 {% endblock %}
 


### PR DESCRIPTION
Fixes #399 

- Shows validation errors next to input fields (or in notification in case of icon or screenshots)
- When there is validation error the invalid value is shown in the input, so user understands what caused the error
- Focuses first invalid input (so that the page scrolls down when error is in contact or website)

### QA
- ./run or http://snapcraft.io-pr-467.run.demo.haus/
- go to market page of any snap
- enter invalid title (longer then 64 letters) and Apply
- Title should be marked invalid with message under the input
- Invalid title should still be the value of the field
- Page title header should show old title (as from API), not invalid one
- Edit the title, when focus moves out of the field it should be not marked as error anymore
- Add invalid icon (bigger then 256px) or invalid screenshot (SVG), Apply
- Error should show in notification next to icon or screenshots
- Enter invalid website (invalid URL), Apply
- Website should be marked invalid, field should be focused and page scrolled so first error is visible
- Click `Revert`
- All changes should be reverted to values from the store

<img width="686" alt="screen shot 2018-03-29 at 11 11 57" src="https://user-images.githubusercontent.com/83575/38080633-50895134-3342-11e8-940e-12daae40e693.png">
