### PR TITLE
Don't display map when 'NO DATA'

### DIFF
--- a/modules/public/logic.py
+++ b/modules/public/logic.py
@@ -126,6 +126,9 @@ def build_country_info(users_by_country, display_number_users=False):
 
     :returns: A dictionnary with the country information for every country
     """
+    if not users_by_country:
+        return {}
+
     country_data = {}
     for country in pycountry.countries:
         country_info = users_by_country.get(country.alpha_2)

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -95,7 +95,7 @@
       </div>
     </div>
     {% if countries %}
-      <div class="row" style="margin-top: 2rem">
+      <div class="row js-snap-map-holder" style="margin-top: 2rem;">
         <div class="col-12">
           <h4>Where people are using {{ snap_title }}</h4>
           <div id="js-snap-map" class="snapcraft-territories"></div>
@@ -133,7 +133,14 @@
     }).install();
     Raven.context(function () {
       snapcraft.public.screenshots('#js-snap-screenshots');
-      snapcraft.public.map('#js-snap-map', {{ countries|tojson }});
+      {% if countries %}
+        try {
+          snapcraft.public.map('#js-snap-map', {{ countries | tojson }});
+        } catch(e) {
+          Raven.captureException(e);
+          document.querySelector('.js-snap-map-holder').style.display = 'none';
+        }
+      {% endif %}
 
       var ctrlDown = false;
 


### PR DESCRIPTION
# Done
Fixes https://github.com/canonical-websites/snapcraft.io/issues/437

- Wrapped map initialiser with `try... catch` to stop displaying territories title if there's a JS error
- Made the backend return an empty object if there's `NO DATA` from the API

# QA

- Pull this branch
- `./run`
- Disable public metrics on a snap
- Visit the snap details
- The map will not be displayed
BONUS:
- If you have a snap without any users but public metrics turned on
- Visit the snap details and see no map or title

# Screenshots

## Public metrics on
![screenshot-2018-3-29 lukotron linux software in the snap store](https://user-images.githubusercontent.com/479384/38081983-4cbb0a2a-333d-11e8-8960-6b114c9d76f1.png)

## Public metrics off
![screenshot-2018-3-29 lukotron linux software in the snap store 1](https://user-images.githubusercontent.com/479384/38081989-52475d72-333d-11e8-9579-c7657e6ce5ef.png)
