### PR TITLE
Return 404 on invalid snap name

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from werkzeug.contrib.fixers import ProxyFix
 import prometheus_flask_exporter
 
 import modules.authentication as authentication
+import modules.helpers as helpers
 import modules.public.views as public_views
 import modules.publisher.views as publisher_views
 from modules.macaroon import (
@@ -34,6 +35,7 @@ talisker.flask.register(app)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 app.secret_key = os.environ['SECRET_KEY']
 app.url_map.strict_slashes = False
+app.url_map.converters['regex'] = helpers.RegexConverter
 sentry = Sentry(app)
 
 metrics = prometheus_flask_exporter.PrometheusMetrics(
@@ -251,7 +253,7 @@ def search_snap():
     return public_views.search_snap()
 
 
-@app.route('/<snap_name>')
+@app.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
 def snap_details(snap_name):
     return public_views.snap_details(snap_name)
 

--- a/app.py
+++ b/app.py
@@ -177,6 +177,11 @@ def create_redirect():
     return flask.redirect('https://docs.snapcraft.io/build-snaps')
 
 
+@app.route('/favicon.ico')
+def favicon():
+    return flask.redirect('https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png')
+
+
 # Login handler
 # ===
 @app.route('/login', methods=['GET', 'POST'])

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1,0 +1,7 @@
+from werkzeug.routing import BaseConverter
+
+
+class RegexConverter(BaseConverter):
+    def __init__(self, url_map, *items):
+        super(RegexConverter, self).__init__(url_map)
+        self.regex = items[0]


### PR DESCRIPTION
# Summary 

- When requesting invalid snap name return 404
- Add /favicon.ico endpoint

# QA

- `./run`
- http://0.0.0.0:8004/robots.txt
- Should return 404 with message: Invalid snap name
- http://0.0.0.0:8004/toto
- Should work as usual
- http://0.0.0.0:8004/favicon.ico
- Should redirect to https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png