### PR TITLE
Market page client-side validation

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -433,7 +433,8 @@ def post_market_snap(snap_name):
             other_errors = []
 
             for error in error_list:
-                if error['code'] == 'invalid-field':
+                if (error['code'] == 'invalid-field' or
+                        error['code'] == 'required'):
                     field_errors[error['extra']['name']] = error['message']
                 else:
                     other_errors.append(error)
@@ -458,7 +459,7 @@ def post_market_snap(snap_name):
                 # errors
                 "error_list": error_list,
                 "field_errors": field_errors,
-                "other_erros": other_errors
+                "other_errors": other_errors
             }
 
             return flask.render_template(

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -2,6 +2,10 @@ import { initSnapScreenshotsEdit } from './screenshots';
 import { updateState, diffState } from './state';
 import { publicMetrics } from './publicMetrics';
 
+// https://gist.github.com/dperini/729294
+const URL_REGEXP = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
+const MAILTO_REGEXP = /^mailto:/;
+
 function initSnapIconEdit(iconElId, iconInputId, state) {
   const snapIconInput = document.getElementById(iconInputId);
   const snapIconEl = document.getElementById(iconElId);
@@ -140,6 +144,15 @@ function initForm(config, initialState, errors) {
       inputValidation.required = true;
     }
 
+    if (input.type === 'url') {
+      inputValidation.url = true;
+    }
+
+    // allow mailto: addresses for contact field
+    if (input.name === 'contact') {
+      inputValidation.mailto = true;
+    }
+
     validation[input.name] = inputValidation;
   });
 
@@ -176,6 +189,19 @@ function initForm(config, initialState, errors) {
         } else {
           inputValidation.counterEl.innerHTML = '';
           showCounter = false;
+        }
+      }
+
+      // only validate contents when there is any value
+      if (input.value.length > 0) {
+        if (inputValidation.mailto) {
+          if (!URL_REGEXP.test(input.value) && !MAILTO_REGEXP.test(input.value)) {
+            isValid = false;
+          }
+        } else if (inputValidation.url) {
+          if (!URL_REGEXP.test(input.value)) {
+            isValid = false;
+          }
         }
       }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -111,9 +111,8 @@ function initForm(config, initialState, errors) {
     }
   });
 
-  document.querySelector('.js-market-submit').addEventListener('click', function(event) {
+  marketForm.addEventListener('submit', function(event) {
     const diff = diffState(initialState, state);
-    event.preventDefault();
 
     // if anything was changed, update state inputs and submit
     if (diff) {
@@ -123,8 +122,8 @@ function initForm(config, initialState, errors) {
       cleanState.images = cleanState.images.filter(image => image.status !== 'delete');
       stateInput.value = JSON.stringify(cleanState);
       diffInput.value = JSON.stringify(diff);
-
-      marketForm.submit();
+    } else {
+      event.preventDefault();
     }
   });
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -97,11 +97,18 @@ function initForm(config, initialState, errors) {
 
   // when anything is changed update the state
   marketForm.addEventListener('change', function() {
+    // Some extra modifications need to happen for the checkboxes
+    publicMetrics(marketForm);
+
     let formData = new FormData(marketForm);
 
-    // Some extra modifications need to happen for the checkboxes
-    publicMetrics(marketForm, formData);
+    // update state based on data of all inputs
     updateState(state, formData);
+    // checkboxes are tricky,
+    // make sure to update state based on their 'checked' status
+    updateState(state, {
+      'public_metrics_enabled': marketForm['public_metrics_enabled'].checked
+    });
   });
 
   marketForm.addEventListener('submit', function(event) {

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -73,6 +73,19 @@ function initForm(config, initialState, errors) {
 
   // setup form functionality
   const marketForm = document.getElementById(config.form);
+  const submitButton = marketForm.querySelector('.js-market-submit');
+
+  function disableSubmit() {
+    submitButton.disabled = 'disabled';
+  }
+
+  function enableSubmit() {
+    submitButton.disabled = false;
+  }
+
+  // disable submit by default, it will be enabled on valid change
+  disableSubmit();
+
   let state = JSON.parse(JSON.stringify(initialState));
 
   const stateInput = document.createElement('input');
@@ -95,6 +108,22 @@ function initForm(config, initialState, errors) {
     state
   );
 
+  function checkForm() {
+    let enabled = false;
+
+    const diff = diffState(initialState, state);
+
+    if (diff) {
+      enabled = true;
+    }
+
+    if (enabled) {
+      enableSubmit();
+    } else {
+      disableSubmit();
+    }
+  }
+
   // when anything is changed update the state
   marketForm.addEventListener('change', function() {
     // Some extra modifications need to happen for the checkboxes
@@ -109,6 +138,8 @@ function initForm(config, initialState, errors) {
     updateState(state, {
       'public_metrics_enabled': marketForm['public_metrics_enabled'].checked
     });
+
+    checkForm();
   });
 
   marketForm.addEventListener('submit', function(event) {

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -98,17 +98,6 @@ function initForm(config, initialState, errors) {
     // Some extra modifications need to happen for the checkboxes
     publicMetrics(marketForm, formData);
     updateState(state, formData);
-
-    // clear validation of field on change
-    const field = event.target.closest('.p-form-validation');
-    if (field) {
-      field.classList.remove('is-error');
-
-      const message = field.querySelector('.p-form-validation__message');
-      if (message) {
-        message.remove();
-      }
-    }
   });
 
   marketForm.addEventListener('submit', function(event) {
@@ -127,6 +116,50 @@ function initForm(config, initialState, errors) {
     }
   });
 
+  // client side validation
+
+  const validation = {};
+  const maxLengthInputs = Array.from(marketForm.querySelectorAll('.p-form-validation__field [maxlength]'));
+
+  maxLengthInputs.forEach(input => {
+    validation[input.name] = {
+      maxLength: input.maxLength
+    };
+    input.removeAttribute('maxlength');
+
+    const counter = document.createElement('span');
+    counter.className = 'p-form-validation__counter';
+    validation[input.name].counterEl = counter;
+    input.parentNode.appendChild(counter);
+  });
+
+  // validate inputs on change
+  marketForm.addEventListener('input', function (event) {
+    const input = event.target;
+    const field = input.closest('.p-form-validation');
+
+    if (field) {
+      const message = field.querySelector('.p-form-validation__message');
+      if (message) {
+        message.remove();
+      }
+
+      if (validation[input.name] && validation[input.name].maxLength) {
+        const count = validation[input.name].maxLength - input.value.length;
+
+        if (count < 0) {
+          validation[input.name].counterEl.innerHTML = count;
+          field.classList.add('is-error');
+          field.classList.add('has-counter');
+        } else {
+          validation[input.name].counterEl.innerHTML = '';
+          field.classList.remove('is-error');
+          field.classList.remove('has-counter');
+        }
+      }
+    }
+
+  });
 }
 
 export {

--- a/static/js/publisher/market/publicMetrics.js
+++ b/static/js/publisher/market/publicMetrics.js
@@ -2,14 +2,8 @@ const NAMES = {
   'public_metrics_territories': 'installed_base_by_country_percent'
 };
 
-function publicMetrics(form, formData) {
+function publicMetrics(form) {
   const publicMetricsEnabled = form['public_metrics_enabled'].checked;
-
-  if (publicMetricsEnabled) {
-    formData.set('public_metrics_enabled', publicMetricsEnabled);
-  } else {
-    formData.set('public_metrics_enabled', false);
-  }
 
   let blackList = [];
 

--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -1,5 +1,4 @@
 import lightbox from './lightbox';
-import { updateState } from './state';
 
 // TEMPLATES
 const templates = {
@@ -39,14 +38,10 @@ const templates = {
 };
 
 // INIT SCREENSHOTS
-function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, state) {
+function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId, state, setState) {
   // DOM elements
   const screenshotsToolbarEl = document.getElementById(screenshotsToolbarElId);
   const screenshotsWrapper = document.getElementById(screenshotsWrapperElId);
-
-  const setState = function(nextState) {
-    updateState(state, nextState);
-  };
 
   // actions on state
   const addScreenshots = (files) => {

--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -172,7 +172,7 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
 
       const input = document.createElement('input');
       input.type = "file";
-      input.accept = "image/*";
+      input.accept = "image/x-png,image/gif,image/jpeg";
       input.name="screenshots";
       input.hidden = "hidden";
 

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -46,4 +46,27 @@
   .p-label--grid-baseline {
     margin-top: .55rem;
   }
+
+  .p-form-validation__field {
+    position: relative;
+
+    // workaround for Vanilla added spacing
+    * + & {
+      margin-top: .75rem;
+    }
+
+    .p-form-validation__counter {
+      color: $color-negative;
+      line-height: 42px;
+      margin: 0;
+      position: absolute;
+      right: 6px;
+      top: 0;
+    }
+  }
+
+  // hide validation icon when counter is visible
+  .has-counter .p-form-validation__input {
+    background-image: none;
+  }
 }

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -42,7 +42,7 @@
 
           <div class="row">
             <div class="col-12 u-align--right">
-                <a class="p-button--neutral js-market-revert" name="submit_revert" href="/account/snaps/{{ snap_name }}/market">Revert</a>
+                <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/market">Revert</a>
                 <input type="submit" class="p-button--positive js-market-submit" name="submit_apply" value="Apply"/>
                 <hr />
             </div>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -233,7 +233,9 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['website'] %}is-error{% endif %}">
-                <input class="p-form-validation__input" type="url" name="website" value="{{ website }}" maxlength="256"/>
+                <div class="p-form-validation__field">
+                  <input class="p-form-validation__input" type="url" name="website" value="{{ website }}" maxlength="256"/>
+                </div>
                 {% if field_errors and field_errors['website'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['website'] }}
@@ -249,7 +251,9 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['contact'] %}is-error{% endif %}">
-                <input class="p-form-validation__input" type="url" name="contact" value="{{ contact }}" maxlength="256"/>
+                <div class="p-form-validation__field">
+                  <input class="p-form-validation__input" type="url" name="contact" value="{{ contact }}" maxlength="256"/>
+                </div>
                 {% if field_errors and field_errors['contact'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['contact'] }}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -104,7 +104,9 @@
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['title'] %}is-error{% endif %}">
                 <label for="snap-title">Title:</label>
-                <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}" required maxlength="64"/>
+                <div class="p-form-validation__field">
+                  <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}" required maxlength="64"/>
+                </div>
                 {% if field_errors and field_errors['title'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['title'] }}
@@ -144,7 +146,9 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['summary'] %}is-error{% endif %}">
-                <input class="p-form-validation__input" type="text" name="summary" value="{{ summary }}" required maxlength="128"/>
+                <div class="p-form-validation__field">
+                  <input class="p-form-validation__input" type="text" name="summary" value="{{ summary }}" required maxlength="128"/>
+                </div>
                 {% if field_errors and field_errors['summary'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['summary'] }}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -42,7 +42,7 @@
 
           <div class="row">
             <div class="col-12 u-align--right">
-                <input type="submit" class="p-button--neutral js-market-revert" name="submit_revert" value="Revert"/>
+                <a class="p-button--neutral js-market-revert" name="submit_revert" href="/account/snaps/{{ snap_name }}/market">Revert</a>
                 <input type="submit" class="p-button--positive js-market-submit" name="submit_apply" value="Apply"/>
                 <hr />
             </div>
@@ -104,7 +104,7 @@
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['title'] %}is-error{% endif %}">
                 <label for="snap-title">Title:</label>
-                <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}"/>
+                <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}" required maxlength="64"/>
                 {% if field_errors and field_errors['title'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['title'] }}
@@ -144,7 +144,7 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['summary'] %}is-error{% endif %}">
-                <input class="p-form-validation__input" type="text" name="summary" value="{{ summary }}"/>
+                <input class="p-form-validation__input" type="text" name="summary" value="{{ summary }}" required maxlength="128"/>
                 {% if field_errors and field_errors['summary'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['summary'] }}
@@ -229,7 +229,7 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['website'] %}is-error{% endif %}">
-                <input class="p-form-validation__input" type="text" name="website" value="{{ website }}"/>
+                <input class="p-form-validation__input" type="url" name="website" value="{{ website }}" maxlength="256"/>
                 {% if field_errors and field_errors['website'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['website'] }}
@@ -245,7 +245,7 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['contact'] %}is-error{% endif %}">
-                <input class="p-form-validation__input" type="text" name="contact" value="{{ contact }}"/>
+                <input class="p-form-validation__input" type="url" name="contact" value="{{ contact }}" maxlength="256"/>
                 {% if field_errors and field_errors['contact'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['contact'] }}


### PR DESCRIPTION
Fixes #391 
Fixes #469

Adds basic HTML level restrictions/validation of market page fields and client-side validation to mark invalid fields and allow submitting only when form is valid.

- adds required fields (title and summary)
- adds max length limits (title, summary, website, contact) - if user types too long text field is marked as error and number of characters over the limit is shown
- adds URL type for website and contact
- removes SVG from accepted image formats for screenshots

### QA

- ./run
- go to market page
- try to enter too long title
- field should be marked red and number of characters to remove should be shown
- remove title
- field should be marked invalid as title is required
- try to enter and submit invalid URL (website or contact)
- try to add SVG screenshots - SVG files should not be allowed to be added
- if any field is invalid `Apply` button should be disabled

<img width="1007" alt="screen shot 2018-03-30 at 18 48 22" src="https://user-images.githubusercontent.com/83575/38145721-0f5910aa-344b-11e8-9239-2ec4bb5a718f.png">

<img width="1017" alt="screen shot 2018-03-30 at 18 48 54" src="https://user-images.githubusercontent.com/83575/38145720-0f36c3f6-344b-11e8-9d8c-9bdf218b80ff.png">
