### PR TITLE
Scoping public API calls to specific fields.

### DIFF
--- a/modules/public/api.py
+++ b/modules/public/api.py
@@ -15,6 +15,11 @@ SNAP_DETAILS_URL = ''.join([
     SNAPCRAFT_IO_API,
     'snaps/details/{snap_name}',
     '?channel=stable',
+    '&fields=snap_id,package_name,title,summary,description,license,contact,'
+    'website,publisher,prices,media,'
+    # Released (stable) revision fields will eventually be replaced by
+    # `channel_maps_list` contextual information.
+    'revision,version,binary_filesize,last_updated'
 ])
 DETAILS_QUERY_HEADERS = {
     'X-Ubuntu-Series': '16',
@@ -34,6 +39,7 @@ SNAP_SEARCH_URL = ''.join([
     'snaps/search',
     '?q={snap_name}&page={page}&size={size}',
     '&confinement=strict,classic',
+    '&fields=package_name,title,summary,icon_url'
 ])
 SEARCH_QUERY_HEADERS = {
     'X-Ubuntu-Frameworks': '*',
@@ -44,7 +50,8 @@ SEARCH_QUERY_HEADERS = {
 FEATURE_SNAPS_URL = ''.join([
     SNAPCRAFT_IO_API,
     'snaps/search',
-    '?confinement=strict,classic&q=&section=featured',
+    '?confinement=strict,classic&section=featured',
+    '&fields=package_name,title,icon_url'
 ])
 
 PROMOTED_QUERY_URL = ''.join([
@@ -52,6 +59,7 @@ PROMOTED_QUERY_URL = ''.join([
     'snaps/search',
     '?promoted=true',
     '&confinement=strict,classic',
+    '&fields=package_name,title,icon_url'
 ])
 PROMOTED_QUERY_HEADERS = {
     'X-Ubuntu-Series': '16'

--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -202,14 +202,16 @@ def snap_details(snap_name):
 
     # filter out banner and banner-icon images from screenshots
     screenshots = [
-        url for url in details['screenshot_urls'] if "banner" not in url
+        m['url'] for m in details['media']
+        if m['type'] == "screenshot" and "banner" not in m['url']
     ]
+    icons = [m['url'] for m in details['media'] if m['type'] == "icon"]
 
     context = {
         # Data direct from details API
         'snap_title': details['title'],
         'package_name': details['package_name'],
-        'icon_url': details['icon_url'],
+        'icon_url': icons[0] if icons else None,
         'version': details['version'],
         'revision': details['revision'],
         'license': details['license'],


### PR DESCRIPTION
Requesting explicit fields will make it easier to migrate to new APIs (similarly to what is already done in snapd).

Transitioning snap-details to `media` (instead of `icon_url` and `screenshot_urls`) which makes it ready for "banner" and "banner_icon" support. Search/promoted/featured-snaps remain using `icon_url` mostly for convenience, but eventually it should also be ported to `media`.