### PR TITLE
Add COMMIT_ID as env var in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip install -r requirements.txt
 ARG COMMIT_ID
 RUN test -n "${COMMIT_ID}"
 RUN echo "${COMMIT_ID}" > version-info.txt
+ENV COMMIT_ID "${COMMIT_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["talisker.gunicorn", "app:app", "--access-logfile", "-", "--error-logfile", "-", "--bind"]


### PR DESCRIPTION
# Summary

- Add COMMIT_ID as an environment var to the docker image on build
- This will allow s.io to catch use this var for sentry, the headers and the css cache problem

# QA

- `docker build --build-arg COMMIT_ID=test --tag test-sio .`
- `docker run --rm -p 80:80 -it -e SECRET_KEY=adsf test-sio`
- in another terminal : docker ps
- get the container ID
- `docker exec -it CONTAINER_ID /bin/bash`
- `echo $COMMIT_ID`
- Should display `test`

