### PR TITLE
Cache-busting URLs for static files

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from urllib.parse import (
     urlparse,
     urlunparse,
 )
+from hashlib import md5
 
 import flask
 import talisker.flask
@@ -73,18 +74,6 @@ app.config['SENTRY_CONFIG'] = {
 }
 
 
-# Make LOGIN_URL available in all templates
-@app.context_processor
-def inject_template_variables():
-    return {
-        'LOGIN_URL': LOGIN_URL,
-        'SENTRY_PUBLIC_DSN': SENTRY_PUBLIC_DSN,
-        'COMMIT_ID': COMMIT_ID,
-        'ENVIRONMENT': ENVIRONMENT
-    }
-
-
-# Template helpers
 @app.context_processor
 def utility_processor():
     def contains(arr, str):
@@ -93,9 +82,39 @@ def utility_processor():
     def join(arr, str):
         return str.join(arr)
 
+    def static_url(filename):
+        """
+        Given the path for a static file
+        Output a url path with a hex has query string for versioning
+        """
+
+        filepath = os.path.join('static', filename)
+        url = '/' + filepath
+
+        if not os.path.isfile(filepath):
+            print('Could not find static file: ' + filepath)
+            return url
+
+        # Use MD5 as we care about speed a lot
+        # and not security in this case
+        file_hash = md5()
+        with open(filepath, "rb") as file_contents:
+            for chunk in iter(lambda: file_contents.read(4096), b""):
+                file_hash.update(chunk)
+
+        return url + '?v=' + file_hash.hexdigest()[:7]
+
     return {
+        # Variables
+        'LOGIN_URL': LOGIN_URL,
+        'SENTRY_PUBLIC_DSN': SENTRY_PUBLIC_DSN,
+        'COMMIT_ID': COMMIT_ID,
+        'ENVIRONMENT': ENVIRONMENT,
+
+        # Functions
         'contains': contains,
-        'join': join
+        'join': join,
+        'static_url': static_url,
     }
 
 

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -117,7 +117,8 @@ def publisher_snap_measure(snap_name):
         if api_response_error_list.status_code == 404:
             flask.abort(404, 'No snap named {}'.format(snap_name))
         else:
-            error_messages = ', '.join(api_response_error_list.errors.key())
+            codes = [error['code'] for error in api_response_error_list.errors]
+            error_messages = ', '.join(codes)
             flask.abort(502, error_messages)
     except ApiResponseError as api_response_error:
         flask.abort(502, str(api_response_error))
@@ -242,7 +243,8 @@ def get_market_snap(snap_name):
         if api_response_error_list.status_code == 404:
             flask.abort(404, 'No snap named {}'.format(snap_name))
         else:
-            error_messages = ', '.join(api_response_error_list.errors.key())
+            codes = [error['code'] for error in api_response_error_list.errors]
+            error_messages = ', '.join(codes)
             flask.abort(502, error_messages)
     except ApiResponseError as api_response_error:
         flask.abort(502, str(api_response_error))
@@ -282,7 +284,8 @@ def snap_release(snap_name):
         if api_response_error_list.status_code == 404:
             flask.abort(404, 'No snap named {}'.format(snap_name))
         else:
-            error_messages = ', '.join(api_response_error_list.errors.key())
+            codes = [error['code'] for error in api_response_error_list.errors]
+            error_messages = ', '.join(codes)
             flask.abort(502, error_messages)
     except ApiResponseError as api_response_error:
         flask.abort(502, str(api_response_error))
@@ -417,9 +420,9 @@ def post_market_snap(snap_name):
                 if api_response_error_list.status_code == 404:
                     flask.abort(404, 'No snap named {}'.format(snap_name))
                 else:
-                    error_messages = ', '.join(
-                        api_response_error_list.errors.key()
-                    )
+                    errors = api_response_error_list.errors
+                    codes = [error['code'] for error in errors]
+                    error_messages = ', '.join(codes)
                     flask.abort(502, error_messages)
             except ApiResponseError as api_response_error:
                 flask.abort(502, str(api_response_error))

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -5,11 +5,15 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{% block description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
+
+    <title>{% block title %}Snapcraft - Snaps are universal Linux packages{% endblock %}</title>
+
     {% block meta %}
       <meta property="og:title" content="{{ self.title() }}"/>
       <meta property="og:site_name" content="Snapcraft"/>
       <meta property="og:type" content="website"/>
-      <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
+      <meta property="og:description" content="{{ self.description() }}"/>
       <meta property="og:image" content="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png" />
       <meta property="twitter:site" content="@snapcraftio" />
     {% endblock %}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -21,8 +21,7 @@
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
 
-    <title>{% block title %}{% endblock %}</title>
-    <link rel="stylesheet" href="/static/minified/styles.css" />
+    <link rel="stylesheet" href="{{ static_url('minified/styles.css') }}" />
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,342 +1,271 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+{% extends "_layout.html" %}
 
-    <meta property="og:title" content="Snapcraft - Snaps are universal Linux packages"/>
-    <meta property="og:site_name" content="Snapcraft"/>
-    <meta property="og:type" content="website"/>
-    <meta property="og:description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification."/>
-    <meta property="twitter:site" content="@snapcraftio" />
-    <meta property="og:image" content="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png" />
+{% block content %}
+<div id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
+  <h1 class="u-off-screen">Snapcraft</h1>
+  <div class="row">
+    <div class="col-12">
+      <p class="p-heading--two">Package, distribute, and update any app for Linux and IoT</p>
+      <p class="p-heading--five">Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.</p>
+      <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Build your first snap</a>
+      <a href="https://build.snapcraft.io" class="p-button--neutral">Get started using GitHub</a>
+    </div>
+  </div>
+</div>
 
-    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
-    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2>Installable across Linux distributions</h2>
+    </div>
+    <div class="col-6">
+      <p class="p-heading--five">Snaps are available for any Linux OS running snapd, the service that runs and manages snaps.</p>
+      <p class="p-heading--five"><a href="https://docs.snapcraft.io/core/install">Enable snaps on your OS</a></p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-logo-links">
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-ubuntu">
+        <img src="https://assets.ubuntu.com/v1/4e18e57c-logo-ubuntu--in-card.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-debian">
+        <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-linux-mint">
+        <img src="https://assets.ubuntu.com/v1/2ce868d9-mint.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-gentoo">
+        <img src="https://assets.ubuntu.com/v1/439fa9d5-gentuu.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-arch-linux">
+        <img src="https://assets.ubuntu.com/v1/44789cf1-arch.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-fedora">
+        <img src="https://assets.ubuntu.com/v1/f24733d2-fedora.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-openwrt">
+        <img src="https://assets.ubuntu.com/v1/0dd4809d-openwrit.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-oe-yocto">
+        <img src="https://assets.ubuntu.com/v1/f131a86c-yocto.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-oe-yocto">
+        <img src="https://assets.ubuntu.com/v1/38659979-openembed.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-opensuse">
+        <img src="https://assets.ubuntu.com/v1/c4c720c6-suse.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-manjaro">
+        <img src="https://assets.ubuntu.com/v1/02d49758-manjaro.png" alt="" />
+      </a>
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-solus">
+        <img src="https://assets.ubuntu.com/v1/4ea80b29-solus.png" alt="" />
+      </a>
+    </div>
+  </div>
+</div>
 
-    <title>Snapcraft - Snaps are universal Linux packages</title>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2>What is Snapcraft?</h2>
+      <p class="p-heading--five">Snapcraft is the command line tool for writing and publishing your software as a snap.</p>
+      <p class="p-heading--five">Snapcraft is available on <a href="https://docs.snapcraft.io/core/install">most popular Linux systems</a>.</p>
+    </div>
+    <div class="col-6">
+      <ul class="p-list u-no-margin">
+        <li class="p-list__item is-ticked p-heading--five">Simple to package leveraging your existing tools</li>
+        <li class="p-list__item is-ticked p-heading--five">Automatic updates for everyone</li>
+        <li class="p-list__item is-ticked p-heading--five">Reach tens of millions of Linux systems</li>
+        <li class="p-list__item is-ticked p-heading--five">Roll back versions effortlessly</li>
+        <li class="p-list__item is-ticked p-heading--five">Integrate easily with build and CI infrastructure</li>
+        <li class="p-list__item is-ticked p-heading--five">Free for open and closed source projects</li>
+      </ul>
+    </div>
+  </div>
+</div>
 
-    <!-- Google Optimize page-hiding -->
-    <style>.async-hide { opacity: 0 !important} </style>
-    <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-    })(window,document.documentElement,'async-hide','dataLayer',4000,
-    {'GTM-MJJ7C2K':true});</script>
-    <!-- End Google Optimize page-hiding -->
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Snapcraft integrates with your tools</h2>
+      <p class="p-heading--five">See how Snapcraft works with your language or framework to make packaging and installing your software easy.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 p-logo-links">
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/pre-built">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/4890ee03-icon-prepackaged-apps.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Pre-built apps</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/c">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/ae5902bf-logo-cpp.png" alt=""/>
+        </header>
+        <p class="u-no-margin">C/C++</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/go">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/53990c77-logo-go.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Go</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/java">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/4fb34568-logo-java.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Java</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/node">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/81c3c76e-logo-node.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Node.js</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/electron">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/6ee78042-logo-electron.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Electron</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/python">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/27e2a770-logo-python.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Python</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ruby">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/1ce42763-logo-ruby.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Ruby</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/rust">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/387bfca8-logo-rust.png" alt=""/>
+        </header>
+        <p class="u-no-margin">Rust</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/moos">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/b24fda67-logo-moos.png" alt=""/>
+        </header>
+        <p class="u-no-margin">MOOS</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/b7079097-logo-ros.png" alt=""/>
+        </header>
+        <p class="u-no-margin">ROS</p>
+      </a>
+      <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros2">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/788b4b66-logo-ros2.png" alt=""/>
+        </header>
+        <p class="u-no-margin">ROS 2</p>
+      </a>
+    </div>
+  </div>
+</div>
 
-    <!-- Google Analytics and Google Optimize -->
-    <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true});
-    ga('require', 'GTM-MJJ7C2K');
-    ga('require', 'linker');
-    ga('linker:autoLink', ['snapcraft.io', 'build.snapcraft.io',
-    'dashboard.snapcraft.io', 'conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',
-    'ubuntu.com', 'insights.ubuntu.com', 'developer.ubuntu.com', 'cn.ubuntu.com',
-    'design.ubuntu.com', 'maas.io', 'canonical.com', 'landscape.canonical.com',
-    'pages.ubuntu.com', 'tutorials.ubuntu.com', 'docs.ubuntu.com']);
-    </script>
-    <!-- End Google Analytics and Google Optimize -->
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>What people are saying about Snapcraft</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <blockquote class="p-testimonial">
+        <h4>The auto-updating feature is huge</h4>
+        <p>We had been facing issues with packaging problems for years...snaps seemed it would make my life a lot easier. The auto-updating feature is huge and one that we haven’t seen elsewhere. Due to the nature of our platform, we release updates more than daily which admittedly can be annoying for our users to constantly update. Therefore, having them done seamlessly in the background makes life for our users so much easier. It’s great to see snaps as the first serious attempt to try and unify the community.</p>
+        <cite class="p-testimonial--citation">Jeff Hickey, CLI engineer, <a href="https://www.heroku.com/" class="p-link--external">Heroku</a></cite>
+      </blockquote>
+    </div>
+    <div class="col-4">
+      <blockquote class="p-testimonial">
+        <h4>Starting with snaps is easy</h4>
+        <p>We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts artefacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication. The modular containments is what appealed about snaps and can see it will be a lot more flexible. Starting with snaps is easy and the resources that are provided are clean and structured which aids adoption.</p>
+        <cite class="p-testimonial--citation">Lee Coward and Rakesh Singh,<br/> <a href="https://www.microsoft.com/net/" class="p-link--external">.NET (Microsoft)</a></cite>
+      </blockquote>
+    </div>
+    <div class="col-4">
+      <blockquote class="p-testimonial">
+        <h4>Snaps will help the robotic community take a step forward in their development</h4>
+        <p>The use of snaps as a middleware and the automatic updates work seamlessly.  Most roboticists, robotic labs and companies use Ubuntu and I see that snaps are the best way forward to keep software up-to-date. Think about the automatic updates provided by snaps for example, if one customer finds a bug, an update can be issued to all previously sold units and there’s no need to send engineers to install the patches.</p>
+        <cite class="p-testimonial--citation">Mohamed Saad Ibn Seddik,<br/> Chief Scientist,<br/> <a href="http://www.sea-machines.com/" class="p-link--external">Sea Machines</a></cite>
+      </blockquote>
+    </div>
+  </div>
+</div>
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-KCGXHQS');</script>
-    <!-- End Google Tag Manager -->
+<div class="p-strip is-deep is-bordered u-image-position">
+  <div class="row u-vertically-center">
+    <div class="col-6">
+      <h2>Auto-build from GitHub</h2>
+      <p class="p-heading--five">Automate your build process and publish software straight from your GitHub repos.</p>
+    <p><a class="p-button--neutral" href="https://build.snapcraft.io/auth/authenticate"><i class="p-icon--github"></i> Connect a GitHub repo</a></p>
+    </div>
+    <div class="col-6">
+      <img class="u-image-position--bottom" src="https://assets.ubuntu.com/v1/006db1f4-build-snapcraft-heroku.png" alt="" style="max-height: 95%;" />
+    </div>
+  </div>
+</div>
 
-    <script>
-    /* HTML5 element support */
-    for(var e,l='article aside footer header nav section time'.split(' ');e=l.pop();document.createElement(e));
-    </script>
-
-    <meta name="description" content="Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.">
-
-    <link rel="stylesheet" href="/static/minified/styles.css">
-  </head>
-
-  <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KCGXHQS"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-
-    {% include "_header.html" %}
-
-    <div id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
-      <h1 class="u-off-screen">Snapcraft</h1>
-      <div class="row">
-        <div class="col-12">
-          <p class="p-heading--two">Package, distribute, and update any app for Linux and IoT</p>
-          <p class="p-heading--five">Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.</p>
-          <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Build your first snap</a>
-          <a href="https://build.snapcraft.io" class="p-button--neutral">Get started using GitHub</a>
-        </div>
+<div class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h2>The Snap Store</h2>
+    </div>
+    <div class="col-6">
+      <p class="p-heading--five">The Snap Store is enabled by default on tens of millions of Linux systems. It allows developers to release free or paid apps for multiple architectures, on multiple release channels from daily builds to stable releases.</p>
+    </div>
+  </div>
+  {% if featured_snaps %}
+    <div class="row">
+      <div class="col-12">
+        <h3>Featured snaps</h3>
       </div>
     </div>
-
-    <div class="p-strip is-deep is-bordered">
-      <div class="row">
-        <div class="col-6">
-          <h2>Installable across Linux distributions</h2>
-        </div>
-        <div class="col-6">
-          <p class="p-heading--five">Snaps are available for any Linux OS running snapd, the service that runs and manages snaps.</p>
-          <p class="p-heading--five"><a href="https://docs.snapcraft.io/core/install">Enable snaps on your OS</a></p>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12 p-logo-links">
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-ubuntu">
-            <img src="https://assets.ubuntu.com/v1/4e18e57c-logo-ubuntu--in-card.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-debian">
-            <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-linux-mint">
-            <img src="https://assets.ubuntu.com/v1/2ce868d9-mint.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-gentoo">
-            <img src="https://assets.ubuntu.com/v1/439fa9d5-gentuu.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-arch-linux">
-            <img src="https://assets.ubuntu.com/v1/44789cf1-arch.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-fedora">
-            <img src="https://assets.ubuntu.com/v1/f24733d2-fedora.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-openwrt">
-            <img src="https://assets.ubuntu.com/v1/0dd4809d-openwrit.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-oe-yocto">
-            <img src="https://assets.ubuntu.com/v1/f131a86c-yocto.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-oe-yocto">
-            <img src="https://assets.ubuntu.com/v1/38659979-openembed.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-opensuse">
-            <img src="https://assets.ubuntu.com/v1/c4c720c6-suse.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-manjaro">
-            <img src="https://assets.ubuntu.com/v1/02d49758-manjaro.png" alt="" />
-          </a>
-          <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-solus">
-            <img src="https://assets.ubuntu.com/v1/4ea80b29-solus.png" alt="" />
-          </a>
-        </div>
-      </div>
-    </div>
-
-    <div class="p-strip is-deep is-bordered">
-      <div class="row">
-        <div class="col-6">
-          <h2>What is Snapcraft?</h2>
-          <p class="p-heading--five">Snapcraft is the command line tool for writing and publishing your software as a snap.</p>
-          <p class="p-heading--five">Snapcraft is available on <a href="https://docs.snapcraft.io/core/install">most popular Linux systems</a>.</p>
-        </div>
-        <div class="col-6">
-          <ul class="p-list u-no-margin">
-            <li class="p-list__item is-ticked p-heading--five">Simple to package leveraging your existing tools</li>
-            <li class="p-list__item is-ticked p-heading--five">Automatic updates for everyone</li>
-            <li class="p-list__item is-ticked p-heading--five">Reach tens of millions of Linux systems</li>
-            <li class="p-list__item is-ticked p-heading--five">Roll back versions effortlessly</li>
-            <li class="p-list__item is-ticked p-heading--five">Integrate easily with build and CI infrastructure</li>
-            <li class="p-list__item is-ticked p-heading--five">Free for open and closed source projects</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-
-    <div class="p-strip is-deep is-bordered">
-      <div class="row">
-        <div class="col-12">
-          <h2>Snapcraft integrates with your tools</h2>
-          <p class="p-heading--five">See how Snapcraft works with your language or framework to make packaging and installing your software easy.</p>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12 p-logo-links">
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/pre-built">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/4890ee03-icon-prepackaged-apps.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Pre-built apps</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/c">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/ae5902bf-logo-cpp.png" alt=""/>
-            </header>
-            <p class="u-no-margin">C/C++</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/go">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/53990c77-logo-go.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Go</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/java">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/4fb34568-logo-java.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Java</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/node">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/81c3c76e-logo-node.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Node.js</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/electron">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/6ee78042-logo-electron.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Electron</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/python">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/27e2a770-logo-python.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Python</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ruby">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/1ce42763-logo-ruby.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Ruby</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/rust">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/387bfca8-logo-rust.png" alt=""/>
-            </header>
-            <p class="u-no-margin">Rust</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/moos">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/b24fda67-logo-moos.png" alt=""/>
-            </header>
-            <p class="u-no-margin">MOOS</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/b7079097-logo-ros.png" alt=""/>
-            </header>
-            <p class="u-no-margin">ROS</p>
-          </a>
-          <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros2">
-            <header class="p-card__header">
-              <img src="https://assets.ubuntu.com/v1/788b4b66-logo-ros2.png" alt=""/>
-            </header>
-            <p class="u-no-margin">ROS 2</p>
-          </a>
-        </div>
-      </div>
-    </div>
-
-    <div class="p-strip is-deep is-bordered">
-      <div class="row">
-        <div class="col-12">
-          <h2>What people are saying about Snapcraft</h2>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-4">
-          <blockquote class="p-testimonial">
-            <h4>The auto-updating feature is huge</h4>
-            <p>We had been facing issues with packaging problems for years...snaps seemed it would make my life a lot easier. The auto-updating feature is huge and one that we haven’t seen elsewhere. Due to the nature of our platform, we release updates more than daily which admittedly can be annoying for our users to constantly update. Therefore, having them done seamlessly in the background makes life for our users so much easier. It’s great to see snaps as the first serious attempt to try and unify the community.</p>
-            <cite class="p-testimonial--citation">Jeff Hickey, CLI engineer, <a href="https://www.heroku.com/" class="p-link--external">Heroku</a></cite>
-          </blockquote>
-        </div>
-        <div class="col-4">
-          <blockquote class="p-testimonial">
-            <h4>Starting with snaps is easy</h4>
-            <p>We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts artefacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication. The modular containments is what appealed about snaps and can see it will be a lot more flexible. Starting with snaps is easy and the resources that are provided are clean and structured which aids adoption.</p>
-            <cite class="p-testimonial--citation">Lee Coward and Rakesh Singh,<br/> <a href="https://www.microsoft.com/net/" class="p-link--external">.NET (Microsoft)</a></cite>
-          </blockquote>
-        </div>
-        <div class="col-4">
-          <blockquote class="p-testimonial">
-            <h4>Snaps will help the robotic community take a step forward in their development</h4>
-            <p>The use of snaps as a middleware and the automatic updates work seamlessly.  Most roboticists, robotic labs and companies use Ubuntu and I see that snaps are the best way forward to keep software up-to-date. Think about the automatic updates provided by snaps for example, if one customer finds a bug, an update can be issued to all previously sold units and there’s no need to send engineers to install the patches.</p>
-            <cite class="p-testimonial--citation">Mohamed Saad Ibn Seddik,<br/> Chief Scientist,<br/> <a href="http://www.sea-machines.com/" class="p-link--external">Sea Machines</a></cite>
-          </blockquote>
-        </div>
-      </div>
-    </div>
-
-    <div class="p-strip is-deep is-bordered u-image-position">
-      <div class="row u-vertically-center">
-        <div class="col-6">
-          <h2>Auto-build from GitHub</h2>
-          <p class="p-heading--five">Automate your build process and publish software straight from your GitHub repos.</p>
-        <p><a class="p-button--neutral" href="https://build.snapcraft.io/auth/authenticate"><i class="p-icon--github"></i> Connect a GitHub repo</a></p>
-        </div>
-        <div class="col-6">
-          <img class="u-image-position--bottom" src="https://assets.ubuntu.com/v1/006db1f4-build-snapcraft-heroku.png" alt="" style="max-height: 95%;" />
-        </div>
-      </div>
-    </div>
-
-    <div class="p-strip is-deep is-bordered">
-      <div class="row">
-        <div class="col-6">
-          <h2>The Snap Store</h2>
-        </div>
-        <div class="col-6">
-          <p class="p-heading--five">The Snap Store is enabled by default on tens of millions of Linux systems. It allows developers to release free or paid apps for multiple architectures, on multiple release channels from daily builds to stable releases.</p>
-        </div>
-      </div>
-      {% if featured_snaps %}
-        <div class="row">
-          <div class="col-12">
-            <h3>Featured snaps</h3>
+    <div class="row">
+      {% for snap in featured_snaps %}
+        <div class="col-3">
+          <div class="p-heading-icon">
+            <a class="p-heading-icon__header" href="/{{ snap.package_name }}">
+              {% if snap.icon_url %}
+                <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
+              {% else %}
+                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
+              {% endif %}
+              <h5 class="u-no-margin">{{ snap.title }}</h5>
+            </a>
           </div>
         </div>
-        <div class="row">
-          {% for snap in featured_snaps %}
-            <div class="col-3">
-              <div class="p-heading-icon">
-                <a class="p-heading-icon__header" href="/{{ snap.package_name }}">
-                  {% if snap.icon_url %}
-                    <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
-                  {% else %}
-                    <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
-                  {% endif %}
-                  <h5 class="u-no-margin">{{ snap.title }}</h5>
-                </a>
-              </div>
-            </div>
 
-            {# end the row after every 4th snap #}
-            {% if (loop.index % 4 == 0) and not loop.last %}
-              </div>
-              <div class="row">
-            {% endif %}
-
-          {% endfor %}
-        </div>
+        {# end the row after every 4th snap #}
+        {% if (loop.index % 4 == 0) and not loop.last %}
+          </div>
+          <div class="row">
         {% endif %}
+
+      {% endfor %}
     </div>
+    {% endif %}
+</div>
 
-    <div class="p-strip is-deep">
-      <div class="row">
-        <div class="col-6">
-          <h2>Not sure yet?</h2>
-        </div>
-        <div class="col-6">
-          <ul class="p-list u-no-margin">
-            <li class="p-list__item p-heading--five"><a href="https://docs.snapcraft.io/build-snaps/">Learn more</a> about snaps and Snapcraft</li>
-            <li class="p-list__item p-heading--five"><a href="https://forum.snapcraft.io/categories">Ask on the forum</a> if you have any questions</li>
-          </ul>
-        </div>
-      </div>
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-6">
+      <h2>Not sure yet?</h2>
     </div>
-
-    {% include "_footer.html" %}
-
-  </body>
-</html>
+    <div class="col-6">
+      <ul class="p-list u-no-margin">
+        <li class="p-list__item p-heading--five"><a href="https://docs.snapcraft.io/build-snaps/">Learn more</a> about snaps and Snapcraft</li>
+        <li class="p-list__item p-heading--five"><a href="https://forum.snapcraft.io/categories">Ask on the forum</a> if you have any questions</li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -307,7 +307,7 @@
 
 {% block scripts %}
 <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
-<script src="/static/js/dist/publisher.js"></script>
+<script src="{{ static_url('js/dist/publisher.js') }}"></script>
 <script>
   Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
     whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -89,14 +89,14 @@ Publisher metrics for {{ snap_name }}
 {% endblock %}
 
 {% block scripts %}
-  <script src="/static/js/modules/moment.min.js"></script>
-  <script src="/static/js/modules/d3.min.js"></script>
-  <script src="/static/js/modules/d3-geo.min.js"></script>
-  <script src="/static/js/modules/topojson-client.min.js"></script>
-  <script src="/static/js/modules/billboard.min.js"></script>
+  <script src="{{ static_url('js/modules/moment.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/d3.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/d3-geo.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/topojson-client.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/billboard.min.js') }}"></script>
 
   <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
-  <script src="/static/js/dist/publisher.js"></script>
+  <script src="{{ static_url('js/dist/publisher.js') }}"></script>
   <script>
     Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
       whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -119,14 +119,14 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/static/js/modules/clipboard.min.js"></script>
-  <script src="/static/js/modules/d3.min.js"></script>
-  <script src="/static/js/modules/d3-geo.min.js"></script>
-  <script src="/static/js/modules/topojson-client.min.js"></script>
+  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/d3.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/d3-geo.min.js') }}"></script>
+  <script src="{{ static_url('js/modules/topojson-client.min.js') }}"></script>
 
   <!-- Illustration of country data -->
   <script src="https://cdn.ravenjs.com/3.22.3/raven.min.js" crossorigin="anonymous"></script>
-  <script src="/static/js/dist/public.js"></script>
+  <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
       whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
@@ -182,7 +182,7 @@
 
       if (ClipboardJS) {
         var copy = new ClipboardJS('#copy');
-        
+
         copy.on('success', function () {
           if (typeof ga !== 'undefined') {
             ga('gtm1.send', {


### PR DESCRIPTION
I've done a few things here, but the main one is that I made it so static files will have URLs of the form:

`/static/file.ext?v=a23ef45`

The hash at the end will be generated from the contents of the file, so whenever the file's contents changes, the hash will change. This should prevent old (cached) CSS or JS being applied to new versions of the site. It should also mean that we can in future extend the cache time on static files (currently set to 12 hours - [the flask default](http://flask.pocoo.org/docs/0.12/api/#flask.Flask.default_config)).

Things done:

- [Fix ApiResponseErrorList error handling](https://github.com/nottrobin/snapcraft.io/commit/6061093f3776e8cb027a94654731c4aeec2ef0ad) - this was causing 500 error rather than 502 as it should
- [Use standard _layout.html template for homepage as well](https://github.com/nottrobin/snapcraft.io/commit/9d25773fcb6be9bc3e57344bd84cf6845053299d) - this implicitly removes the Google Optimize tracking snippet - @evandandrea let me know if this is a problem
- Fixes #438 - Badly cached CSS (and possibly JS)

QA
--

`./run`

Go to http://127.0.0.1:8004 and browse around a lot.

- Check CSS and JS are loading correctly
- Check homepage still looks the same