### PR TITLE
Fix empty website address when value is None

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -234,7 +234,7 @@
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['website'] %}is-error{% endif %}">
                 <div class="p-form-validation__field">
-                  <input class="p-form-validation__input" type="url" name="website" value="{{ website }}" maxlength="256"/>
+                  <input class="p-form-validation__input" type="url" name="website" value="{{ website if website is not none else '' }}" maxlength="256"/>
                 </div>
                 {% if field_errors and field_errors['website'] %}
                   <p class="p-form-validation__message">
@@ -334,7 +334,7 @@
       title: {{ title|tojson }},
       summary: {{ summary|tojson }},
       description: {{ description|tojson }},
-      website: {{ website|tojson }},
+      website: {{ (website if website is not none else '')|tojson }},
       contact: {{ contact|tojson }},
       images: [
         {% if icon_url %}


### PR DESCRIPTION
Fixes #350 

For newly added snaps (with empty website field) API returns value `None` for website which was displayed in the market form as "None" string and failed validation (because it's not valid URL).

To fix this we make sure in template that `None` website is displayed as empty string.

### QA

- ./run
- go to a snap with market data that was not edited before (has empty website)
- website field should be empty (not show `None`)
- you should be able to change any values and save them without validation errors about invalid URL
