### PR TITLE
Removes invalid new line chars from description

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -410,6 +410,12 @@ def post_market_snap(snap_name):
 
                 body_json['public_metrics_blacklist'] = metrics_blacklist
 
+            if 'description' in body_json:
+                # remove invalid characters from description
+                body_json['description'] = (
+                    body_json['description'].replace('\r\n', '\n')
+                )
+
             metadata = api.snap_metadata(
                 snap_id,
                 flask.session,

--- a/static/js/publisher/market/state.js
+++ b/static/js/publisher/market/state.js
@@ -15,7 +15,9 @@ function updateState(state, values) {
     if (values.forEach) {
       values.forEach((value, key) => {
         if (allowedKeys.includes(key)) {
-          state[key] = value;
+          // FormData values encode new lines as \r\n which are invalid for our API
+          // so we need to replace them back to \n
+          state[key] = value.replace(/\r\n/g, '\n');
         }
       });
     // else if it's just a plain object


### PR DESCRIPTION
Fixes #356 

Store API doesn't allow control characters in description. This includes `\r` in line breaks.
Browser form data encodes line breaks in textarea as `\r\n` which is invalid for API.
This caused an error, because for descriptions containing new lines (`\n`) browser was rendering and sending it back as `\r\n` which caused validation in store to fail.

This PR fixes this by making sure that both in front-end side validation (to correctly detect if description changed) and in back-end before sending description to API we remove invalid `\r` characters from line breaks.

### QA

- ./run
- go to a snap with new lines in the description
- change any value (not description), `Apply`
- value should be saved without validation error for description
- change description (make sure there are some new lines), `Apply`
- description should be saved with new lines