### PR TITLE
Marks description as required on market page

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -163,7 +163,7 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['description'] %}is-error{% endif %}">
-                <textarea class="p-form-validation__input u-no-margin" name="description">{{ description }}</textarea>
+                <textarea class="p-form-validation__input u-no-margin" name="description" required>{{ description }}</textarea>
                 {% if field_errors and field_errors['description'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['description'] }}


### PR DESCRIPTION
Description field is required by store API, but was not marked as required on market page form, so it was possible to post empty description which resulted in API validation error.

This PR fixes it by marking description field as required in the form, so it's not possible to save empty description.

### QA
- ./run
- go to market page of any snap
- remove description
- field should be marked red and Apply should be disabled
- you should only be able to save the data when description is not empty