### PR TITLE
Publisher header template

### DIFF
--- a/app.py
+++ b/app.py
@@ -236,6 +236,18 @@ def get_account():
     return publisher_views.get_account()
 
 
+@app.route('/account/details')
+@login_required
+def get_account_details():
+    return publisher_views.get_account_details()
+
+
+@app.route('/account/snaps')
+@login_required
+def get_account_snaps():
+    return publisher_views.get_account_snaps()
+
+
 @app.route('/account/agreement')
 @login_required
 def get_agreement():

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -45,6 +45,77 @@ def get_account():
     )
 
 
+def get_account_details():
+    account = api.get_account(flask.session)
+    if 'redirect' in account:
+        return account['redirect']
+
+    error_list = []
+    if 'error_list' in account:
+        for error in account['error_list']:
+            if error['code'] == 'user-not-ready':
+                if 'has not signed agreement' in error['message']:
+                    return flask.redirect('/account/agreement')
+                elif 'missing namespace' in error['message']:
+                    return flask.redirect('/account/username')
+            else:
+                error_list.append(error)
+
+    flask_user = flask.session['openid']
+
+    context = {
+        'image': flask_user['image'],
+        'username': account['username'],
+        'displayname': account['displayname'],
+        'email': account['email'],
+        'error_list': error_list
+    }
+
+    return flask.render_template(
+        'publisher/account-details.html',
+        **context
+    )
+
+
+def get_account_snaps():
+    account = api.get_account(flask.session)
+    if 'redirect' in account:
+        return account['redirect']
+
+    error_list = []
+    if 'error_list' in account:
+        for error in account['error_list']:
+            if error['code'] == 'user-not-ready':
+                if 'has not signed agreement' in error['message']:
+                    return flask.redirect('/account/agreement')
+                elif 'missing namespace' in error['message']:
+                    return flask.redirect('/account/username')
+            else:
+                error_list.append(error)
+
+    user_snaps = {}
+    if '16' in account['snaps']:
+        user_snaps = account['snaps']['16']
+
+    registered_snaps = {}
+
+    for snap in user_snaps.keys():
+        if user_snaps[snap]['uploaded'] is False:
+            registered_snaps[snap] = user_snaps[snap]
+
+    context = {
+        'snaps': user_snaps,
+        'current_user': account['username'],
+        'registered_snaps': registered_snaps,
+        'error_list': error_list
+    }
+
+    return flask.render_template(
+        'publisher/account-snaps.html',
+        **context
+    )
+
+
 def get_agreement():
     return flask.render_template('developer_programme_agreement.html')
 

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -246,7 +246,7 @@ def publisher_snap_measure(snap_name):
     context = {
         # Data direct from details API
         'snap_name': snap_name,
-        'snap_title': details['title'],
+        'snap_display_name': details['title'],
         'metric_period': metric_period,
         'active_device_metric': installed_base_metric,
 
@@ -273,7 +273,7 @@ def get_market_snap(snap_name):
     context = {
         "snap_id": snap_details['snap_id'],
         "snap_name": snap_details['snap_name'],
-        "snap_title": snap_details['title'],
+        "snap_display_name": snap_details['title'],
         "summary": snap_details['summary'],
         "description": snap_details['description'],
         "license": snap_details['license'],
@@ -401,7 +401,7 @@ def post_market_snap(snap_name):
             context = {
                 "snap_id": snap_details['snap_id'],
                 "snap_name": snap_details['snap_name'],
-                "snap_title": snap_details['title'],
+                "snap_display_name": snap_details['title'],
                 "summary": snap_details['summary'],
                 "description": snap_details['description'],
                 "license": snap_details['license'],

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -273,7 +273,7 @@ def get_market_snap(snap_name):
     context = {
         "snap_id": snap_details['snap_id'],
         "snap_name": snap_details['snap_name'],
-        "title": snap_details['title'],
+        "snap_title": snap_details['title'],
         "summary": snap_details['summary'],
         "description": snap_details['description'],
         "license": snap_details['license'],
@@ -401,7 +401,7 @@ def post_market_snap(snap_name):
             context = {
                 "snap_id": snap_details['snap_id'],
                 "snap_name": snap_details['snap_name'],
-                "title": snap_details['title'],
+                "snap_title": snap_details['title'],
                 "summary": snap_details['summary'],
                 "description": snap_details['description'],
                 "license": snap_details['license'],

--- a/static/sass/_snapcraft_account-snaps.scss
+++ b/static/sass/_snapcraft_account-snaps.scss
@@ -1,0 +1,7 @@
+@mixin snapcraft-account-snaps {
+  .snapcraft-account-snaps {
+    &__inline-title {
+      margin-top: .5rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -101,6 +101,9 @@ $color-navigation-background: #252525;
 @import 'snapcraft_snap-list';
 @include snapcraft-snap-list;
 
+@import 'snapcraft_account-snaps';
+@include snapcraft-account-snaps;
+
 @import 'patterns_maas_modal';
 @include maas-p-modal;
 

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,0 +1,35 @@
+<section class="p-strip is-shallow">
+  <div class="row">
+    <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
+    <h1 class="u-no-margin--top">{{ snap_title }}</h1>
+  </div>
+</section>
+
+<section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+  <nav class="p-tabs">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a
+          href="/account/snaps/{{ snap_name }}/market"
+          class="p-tabs__link"
+          tabindex="0"
+          role="tab"
+          {% if selected_tab == 'market' %}
+          aria-selected="true"
+          {% endif %}>
+          Market</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a
+          href="/account/snaps/{{ snap_name }}/measure"
+          class="p-tabs__link"
+          tabindex="0"
+          role="tab"
+          {% if selected_tab == 'measure' %}
+          aria-selected="true"
+          {% endif %}>
+          Measure</a>
+      </li>
+    </ul>
+  </nav>
+</section>

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,7 +1,7 @@
 <section class="p-strip is-shallow">
   <div class="row">
     <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-    <h1 class="u-no-margin--top">{{ snap_title }}</h1>
+    <h1 class="u-no-margin--top">{{ snap_display_name }}</h1>
   </div>
 </section>
 

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -1,0 +1,81 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+Account details — Linux software in the Snap Store
+{% endblock %}
+
+{% block content %}
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-12">
+      <h3 class="u-float--left">Publisher account details</h3>
+      <a href="{{ LOGIN_URL }}" class="p-link--external u-float--right">Edit details</a>
+    </div>
+  </div>
+  <div class="row u-no-margin--top">
+    <hr />
+  </div>
+  {% if errors %}
+    <div class="row u-no-margin--top">
+      <div class="p-notification--negative">
+        <p class="p-notification__response">
+          {% for error in errors %}
+            {{ error.message }}<br />
+          {% endfor %}
+        </p>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row {% if not errors %}u-no-margin--top{% endif %}">
+    <div class="col-2">
+      Full name:
+    </div>
+    <div class="col-6">
+      <b>{{ displayname }}</b>
+    </div>
+    <div class="col-12">
+      <br />
+      <p class="p-form-help-text">
+        Who your users will see as the publisher of your snap.
+      </p>
+    </div>
+  </div>
+  <div class="row u-no-margin--top">
+    <hr />
+  </div>
+  <div class="row u-no-margin--top">
+    <div class="col-2">
+      Username:
+    </div>
+    <div class="col-6">
+      <b>{{ username }}</b>
+    </div>
+    <div class="col-12">
+      <br />
+      <p class="p-form-help-text">
+        This is a shorthand version of your name, used when space on screen is limited.
+      </p>
+    </div>
+  </div>
+  <div class="row u-no-margin--top">
+    <hr />
+  </div>
+  <div class="row u-no-margin--top">
+    <div class="col-2">
+      Email:
+    </div>
+    <div class="col-6">
+      <b>{{ email }}</b>
+    </div>
+    <div class="col-12">
+      <br />
+      <p class="p-form-help-text">
+        This is your account email address, it will not be shared unless you choose to use it as the publisher contact for your snap.
+      </p>
+    </div>
+  </div>
+  <div class="row u-no-margin--top">
+    <hr />
+  </div>
+</section>
+{% endblock %}

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -1,0 +1,129 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+My snaps — Linux software in the Snap Store
+{% endblock %}
+
+{% block content %}
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-12">
+      <h3 class="u-float--left">My snaps</h3>
+      <a href="https://docs.snapcraft.io/build-snaps/" class="p-link--external u-float--right">How to create a snap</a>
+    </div>
+  </div>
+  {% if not snaps %}
+    </div> {# close previous strip #}
+    <div class="p-strip--light is-shallow">
+      <div class="row">
+        <h5>You haven't published any snaps yet.</h5>
+        <p>Get started by <a class="p-link--external" href="https://docs.snapcraft.io/build-snaps/your-first-snap">
+          publishing your first snap</a>.
+        </p>
+      </div>
+    </div>
+  {% else %}
+    <div class="row">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Privacy</th>
+            <th>Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for snap in snaps|sort %}
+            {% if snaps[snap].uploaded %}
+              <tr>
+                <td>
+                  <a href="/account/snaps/{{snap}}/market" class="u-no-margin--top u-vertically-center">
+                    {% if snaps[snap].icon_url %}
+                      <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
+                    {% else %}
+                      <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-snap-list__image" />
+                    {% endif %}
+                    <span class="p-snap-list__name u-no-margin--top">
+                      {{snap}}
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  {% if snaps[snap].private %}
+                    Private
+                  {% else %}
+                    Public
+                  {% endif %}
+                </td>
+                <td>
+                  {% if snaps[snap].publisher.username == current_user %}
+                    You
+                  {% else %}
+                    {{ snaps[snap].publisher['display-name'] }}
+                  {% endif %}
+                </td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% if snaps|length == 1 %}
+      {% for snap in snaps %}
+        <div class="p-strip--light is-shallow">
+          <div class="row">
+            <div class="col-3">
+              <h4>Congratulations!</h4>
+            </div>
+            <div class="col-6">
+              <p>
+                You've just released a snap!<br />
+                {% if not snaps[snap].private %}
+                  This snap is public &mdash; anyone can find and install it, <a href="/account/snaps/{{ snap }}/market">make it private now<a/>.
+                {% else %}
+                Currently your app is set to private: <a href="/account/snaps/{{ snap }}/market">Make it public now</a>.
+                {% endif %}
+              </p>
+              <p>Things to do next:</p>
+            </div>
+          </div>
+          <div class="row u-no-margin--top">
+            <hr />
+          </div>
+          <div class="row u-no-margin--top">
+            <div class="col-3">
+              <h4>Market</h4>
+            </div>
+            <div class="col-5">
+              <p>
+                Want to improve the listings in stores?
+                You can add an icon and screenshots.
+              </p>
+              <p>
+                <a href="/account/snaps/{{ snap }}/market" class="p-button--neutral">Go to market listing</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
+  {% endif %}
+</div>
+{% if registered_snaps %}
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-12">
+        <h4 class="u-float--left">My registered snap names</h4>
+      </div>
+    </div>
+    <div class="row">
+      <p>
+        Names you own but have not pushed a snap to will appear in this list:
+      </p>
+      <p>
+        {% for registered_snap in registered_snaps|sort %}{% if loop.index > 1 %}, {% endif %}{{ registered_snap }}{% endfor %}
+      </p>
+    </div>
+  </div>
+{% endif %}
+{% endblock %}

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,30 +1,13 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market details for {{ title }}
+  Market details for {{ snap_title }}
 {% endblock %}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    <section class="p-strip is-shallow">
-      <div class="row">
-        <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-        <h1 class="u-no-margin--top">{{ title }}</h1>
-      </div>
-    </section>
-
-    <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Market</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab">Measure</a>
-          </li>
-        </ul>
-      </nav>
-    </section>
+    {% set selected_tab='market' %}
+    {% include "publisher/_header.html" %}
 
     <div class="p-strip is-shallow">
         <form id="market-form" method="POST" enctype='multipart/form-data'>
@@ -69,7 +52,7 @@
               <div class="p-media-object__image--large p-editable-icon">
                 <img id="snap_icon_image"
                   {% if icon_url %}
-                    src="{{ icon_url }}" alt="{{ title }} snap"
+                    src="{{ icon_url }}" alt="{{ snap_title }} snap"
                   {% else %}
                     src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
                   {% endif %}
@@ -78,7 +61,7 @@
             </div>
             <div class="col-8">
               <label for="snap-title">Title:</label>
-              <input id="snap-title" type="text" name="title" value="{{ title }}"/>
+              <input id="snap-title" type="text" name="title" value="{{ snap_title }}"/>
             </div>
           </div>
 

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,7 +1,7 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market details for {{ snap_title }}
+  Market details for {{ snap_display_name }}
 {% endblock %}
 
 {% block content %}
@@ -52,7 +52,7 @@
               <div class="p-media-object__image--large p-editable-icon">
                 <img id="snap_icon_image"
                   {% if icon_url %}
-                    src="{{ icon_url }}" alt="{{ snap_title }} snap"
+                    src="{{ icon_url }}" alt="{{ snap_display_name }} snap"
                   {% else %}
                     src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
                   {% endif %}
@@ -61,7 +61,7 @@
             </div>
             <div class="col-8">
               <label for="snap-title">Title:</label>
-              <input id="snap-title" type="text" name="title" value="{{ snap_title }}"/>
+              <input id="snap-title" type="text" name="title" value="{{ snap_display_name }}"/>
             </div>
           </div>
 

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -6,25 +6,9 @@ Publisher metrics for {{ snap_name }}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    <section class="p-strip is-shallow">
-      <div class="row">
-        <p><a href="/account">My snaps&nbsp;&rsaquo;</a></p>
-        <h1 class="u-no-margin--top">{{ snap_title }}</h1>
-      </div>
-    </section>
+    {% set selected_tab='measure' %}
+    {% include "publisher/_header.html" %}
 
-    <section class="metrics__nav-wrap p-strip is-shallow u-no-padding--top u-no-padding--bottom">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab">Market</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Measure</a>
-          </li>
-        </ul>
-      </nav>
-    </section>
     {% if nodata %}
       <section class="p-strip--light is-shallow">
         <div class="row">


### PR DESCRIPTION
# Done

- Created `publisher/_header.html` template
- Modified `publisher/market.html` and `publisher/measure.html` to use the new template
- Renamed `snap_title` and `title` to `snap_display_name` to better describe what it is

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/SNAP_NAME/market and http://0.0.0.0:8004/account/snaps/SNAP_NAME/measure and ensure the title and tab bar still display correctly