### PR TITLE
Publisher header template

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -284,7 +284,7 @@ def get_market_snap(snap_name):
     context = {
         "snap_id": snap_details['snap_id'],
         "snap_name": snap_details['snap_name'],
-        "title": snap_details['title'],
+        "snap_title": snap_details['title'],
         "summary": snap_details['summary'],
         "description": snap_details['description'],
         "license": snap_details['license'],
@@ -532,7 +532,7 @@ def post_market_snap(snap_name):
                 "public_metrics_blacklist": details_blacklist,
                 "display_title": snap_details['title'],
                 # values posted by user
-                "title": (
+                "snap_title": (
                     changes['title'] if 'title' in changes
                     else snap_details['title']
                 ),

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,0 +1,47 @@
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <nav class="p-tabs">
+    {# This row and it's contents needs to be removed before going live #}
+    <div class="row">
+      <a href="/account" class="u-float--left p-muted-heading">&lsaquo; Snap list</a>
+    </div>
+    <div class="row u-no-margin--top">
+      <div class="row">
+        <div class="col-6">
+          <h1 class="u-float--left p-heading--three">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
+        </div>
+        <div class="col-6">
+          <ul class="p-tabs__list u-float--right" role="tablist">
+            <li class="p-tabs__item" role="presentation">
+              <a
+                href="/account/snaps/{{ snap_name }}/market"
+                class="p-tabs__link"
+                tabindex="0"
+                role="tab"
+                {% if selected_tab == 'market' %}
+                  aria-selected="true"
+                {% endif %}
+              >
+                Market
+              </a>
+            </li>
+            <li class="p-tabs__item" role="presentation">
+              <a
+                href="/account/snaps/{{ snap_name }}/measure"
+                class="p-tabs__link"
+                tabindex="0"
+                role="tab"
+                {% if selected_tab == 'measure' %}
+                  aria-selected="true"
+                {% endif %}
+              >
+                Measure
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="row u-no-margin--top">
+        <hr class="u-no-margin" />
+      </div>
+  </nav>
+</section>

--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -1,38 +1,13 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market details for {% if display_title %}{{ display_title }}{% else %}{{ title }}{% endif %}
+  Market details for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}
 {% endblock %}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    <section class="p-strip is-shallow u-no-padding--bottom">
-      <nav class="p-tabs">
-        {# This row and it's contents needs to be removed before going live #}
-        <div class="row">
-          <a href="/account" class="u-float--left p-muted-heading">&lsaquo; Snap list</a>
-        </div>
-        <div class="row u-no-margin--top">
-        <div class="row">
-          <div class="col-6">
-            <h1 class="u-float--left p-heading--three">{% if display_title %}{{ display_title }}{% else %}{{ title }}{% endif %}</h1>
-          </div>
-          <div class="col-6">
-            <ul class="p-tabs__list u-float--right" role="tablist">
-              <li class="p-tabs__item" role="presentation">
-                <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Market</a>
-              </li>
-              <li class="p-tabs__item" role="presentation">
-                <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab">Measure</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="row u-no-margin--top">
-          <hr class="u-no-margin" />
-        </div>
-      </nav>
-    </section>
+    {% set selected_tab='market' %}
+    {% include "publisher/_header.html" %}
 
     <div class="p-strip is-shallow">
         <form id="market-form" method="POST" enctype='multipart/form-data'>
@@ -94,7 +69,7 @@
               <div class="p-media-object__image--large p-editable-icon">
                 <img id="snap_icon_image"
                   {% if icon_url %}
-                    src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ title }}{% endif %} snap"
+                    src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %} snap"
                   {% else %}
                     src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
                   {% endif %}
@@ -105,7 +80,7 @@
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['title'] %}is-error{% endif %}">
                 <label for="snap-title">Title:</label>
                 <div class="p-form-validation__field">
-                  <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ title }}" required maxlength="64"/>
+                  <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ snap_title }}" required maxlength="64"/>
                 </div>
                 {% if field_errors and field_errors['title'] %}
                   <p class="p-form-validation__message">
@@ -331,7 +306,7 @@
       screenshotsToolbar: "screenshots-toolbar",
       screenshotsWrapper: "snap-screenshots"
     }, {
-      title: {{ title|tojson }},
+      title: {{ snap_title|tojson }},
       summary: {{ summary|tojson }},
       description: {{ description|tojson }},
       website: {{ website|tojson }},

--- a/templates/publisher/measure.html
+++ b/templates/publisher/measure.html
@@ -1,37 +1,13 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-Publisher metrics for {{ snap_name }}
+Publisher metrics for {{ snap_title }}
 {% endblock %}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    <section class="p-strip is-shallow u-no-padding--bottom">
-      <nav class="p-tabs">
-        {# This row and it's contents needs to be removed before going live #}
-        <div class="row">
-          <a href="/account" class="u-float--left p-muted-heading">&lsaquo; Snap list</a>
-        </div>
-        <div class="row u-no-margin--top">
-          <div class="col-6">
-            <h1 class="u-float--left p-heading--three">{{ snap_title }}</h1>
-          </div>
-          <div class="col-6">
-            <ul class="p-tabs__list u-float--right" role="tablist">
-              <li class="p-tabs__item" role="presentation">
-                <a href="/account/snaps/{{ snap_name }}/market" class="p-tabs__link" tabindex="0" role="tab">Market</a>
-              </li>
-              <li class="p-tabs__item" role="presentation">
-                <a href="/account/snaps/{{ snap_name }}/measure" class="p-tabs__link" tabindex="0" role="tab" aria-selected="true">Measure</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="row u-no-margin--top">
-          <hr class="u-no-margin" />
-        </div>
-      </nav>
-    </section>
+    {% set selected_tab='measure' %}
+    {% include "publisher/_header.html" %}
 
     {% if nodata %}
       <section class="p-strip--light is-shallow">


### PR DESCRIPTION
# Done

- Created `publisher/_header.html` template
- Modified `publisher/market.html` and `publisher/measure.html` to use the new template
- Made sure `snap_title` is consistent throughout (some places was `title`)

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/SNAP_NAME/market and http://0.0.0.0:8004/account/snaps/SNAP_NAME/measure and ensure the title and tab bar still display correctly