### PR TITLE
Cache-control for public and private endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ A Flask application for snapcraft.io.
 The web frontend for the snap store.
 """
 
-import functools
+# Core packages
 import os
 import socket
 from urllib.parse import (
@@ -12,20 +12,23 @@ from urllib.parse import (
     urlparse,
     urlunparse,
 )
-from hashlib import md5
 
+# Third-party packages
 import flask
 import talisker.flask
+import prometheus_flask_exporter
 from flask_openid import OpenID
 from flask_wtf.csrf import CSRFProtect
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
-import prometheus_flask_exporter
 
+# Local modules
 import modules.authentication as authentication
 import modules.helpers as helpers
 import modules.public.views as public_views
 import modules.publisher.views as publisher_views
+import template_functions
+import decorators
 from modules.macaroon import (
     MacaroonRequest,
     MacaroonResponse,
@@ -76,65 +79,13 @@ app.config['SENTRY_CONFIG'] = {
 }
 
 
-def public_cache_headers(decorated):
-    """
-    Add standard caching headers to a public route:
-
-    - Cache pages for 30 seconds
-      (allows Squid to take significant load of the app)
-    - Serve stale pages while revalidating the cache for 5 minutes
-      (allows Squid to response instantly while doing cache refreshes)
-    - Show stale pages if the app is erroring for 1 day
-      (gives us a 1 day buffer to fix errors before they are publicly visible)
-    """
-
-    cache_control_headers = [
-        'max-age=30',
-        'stale-while-revalidate=300',
-        'stale-if-error=86400',
-    ]
-
-    @functools.wraps(decorated)
-    def decorated_function(*args, **kwargs):
-        response = flask.make_response(
-            decorated(*args, **kwargs)
-        )
-        response.headers['Cache-Control'] = ', '.join(cache_control_headers)
-
-        return response
-
-    return decorated_function
-
-
 @app.context_processor
 def utility_processor():
-    def contains(arr, str):
-        return str in arr
-
-    def join(arr, str):
-        return str.join(arr)
-
-    def static_url(filename):
-        """
-        Given the path for a static file
-        Output a url path with a hex has query string for versioning
-        """
-
-        filepath = os.path.join('static', filename)
-        url = '/' + filepath
-
-        if not os.path.isfile(filepath):
-            print('Could not find static file: ' + filepath)
-            return url
-
-        # Use MD5 as we care about speed a lot
-        # and not security in this case
-        file_hash = md5()
-        with open(filepath, "rb") as file_contents:
-            for chunk in iter(lambda: file_contents.read(4096), b""):
-                file_hash.update(chunk)
-
-        return url + '?v=' + file_hash.hexdigest()[:7]
+    """
+    This defines the set of properties and functions that will be added
+    to the default context for processing templates. All these items
+    can be used in all templates
+    """
 
     return {
         # Variables
@@ -144,28 +95,10 @@ def utility_processor():
         'ENVIRONMENT': ENVIRONMENT,
 
         # Functions
-        'contains': contains,
-        'join': join,
-        'static_url': static_url,
+        'contains': template_functions.contains,
+        'join': template_functions.join,
+        'static_url': template_functions.static_url,
     }
-
-
-def login_required(func):
-    """
-    Decorator that checks if a user is logged in, and redirects
-    to login page if not.
-    """
-    @functools.wraps(func)
-    def is_user_logged_in(*args, **kwargs):
-        if not authentication.is_authenticated(flask.session):
-            return redirect_to_login()
-
-        return func(*args, **kwargs)
-    return is_user_logged_in
-
-
-def redirect_to_login():
-    return flask.redirect('login?next=' + flask.request.path)
 
 
 # Error handlers
@@ -278,7 +211,7 @@ def logout():
 # Normal views
 # ===
 @app.route('/')
-@public_cache_headers
+@decorators.public_cache_headers
 def homepage():
     return public_views.homepage()
 
@@ -289,7 +222,7 @@ def status():
 
 
 @app.route('/store')
-@public_cache_headers
+@decorators.public_cache_headers
 def store():
     return public_views.store()
 
@@ -305,13 +238,13 @@ def snaps():
 
 
 @app.route('/search')
-@public_cache_headers
+@decorators.public_cache_headers
 def search_snap():
     return public_views.search_snap()
 
 
 @app.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
-@public_cache_headers
+@decorators.public_cache_headers
 def snap_details(snap_name):
     return public_views.snap_details(snap_name)
 
@@ -319,54 +252,54 @@ def snap_details(snap_name):
 # Publisher views
 # ===
 @app.route('/account')
-@login_required
+@decorators.login_required
 def get_account():
     return publisher_views.get_account()
 
 
 @app.route('/account/agreement')
-@login_required
+@decorators.login_required
 def get_agreement():
     return publisher_views.get_agreement()
 
 
 @app.route('/account/agreement', methods=['POST'])
-@login_required
+@decorators.login_required
 def post_agreement():
     return publisher_views.post_agreement()
 
 
 @app.route('/account/username')
-@login_required
+@decorators.login_required
 def get_account_name():
     return publisher_views.get_account_name()
 
 
 @app.route('/account/username', methods=['POST'])
-@login_required
+@decorators.login_required
 def post_account_name():
     return publisher_views.post_account_name()
 
 
 @app.route('/account/snaps/<snap_name>/measure')
-@login_required
+@decorators.login_required
 def publisher_snap_measure(snap_name):
     return publisher_views.publisher_snap_measure(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/market', methods=['GET'])
-@login_required
+@decorators.login_required
 def get_market_snap(snap_name):
     return publisher_views.get_market_snap(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/release')
-@login_required
+@decorators.login_required
 def snap_release(snap_name):
     return publisher_views.snap_release(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/market', methods=['POST'])
-@login_required
+@decorators.login_required
 def post_market_snap(snap_name):
     return publisher_views.post_market_snap(snap_name)

--- a/decorators.py
+++ b/decorators.py
@@ -1,0 +1,50 @@
+# Core packages
+import functools
+
+# Third party packages
+import flask
+import modules.authentication as authentication
+
+
+def login_required(func):
+    """
+    Decorator that checks if a user is logged in, and redirects
+    to login page if not.
+    """
+    @functools.wraps(func)
+    def is_user_logged_in(*args, **kwargs):
+        if not authentication.is_authenticated(flask.session):
+            return flask.redirect('login?next=' + flask.request.path)
+
+        return func(*args, **kwargs)
+    return is_user_logged_in
+
+
+def public_cache_headers(decorated):
+    """
+    Add standard caching headers to a public route:
+
+    - Cache pages for 30 seconds
+      (allows Squid to take significant load of the app)
+    - Serve stale pages while revalidating the cache for 5 minutes
+      (allows Squid to response instantly while doing cache refreshes)
+    - Show stale pages if the app is erroring for 1 day
+      (gives us a 1 day buffer to fix errors before they are publicly visible)
+    """
+
+    cache_control_headers = [
+        'max-age=30',
+        'stale-while-revalidate=300',
+        'stale-if-error=86400',
+    ]
+
+    @functools.wraps(decorated)
+    def decorated_function(*args, **kwargs):
+        response = flask.make_response(
+            decorated(*args, **kwargs)
+        )
+        response.headers['Cache-Control'] = ', '.join(cache_control_headers)
+
+        return response
+
+    return decorated_function

--- a/decorators.py
+++ b/decorators.py
@@ -32,7 +32,7 @@ def public_cache_headers(decorated):
       (gives us a 1 day buffer to fix errors before they are publicly visible)
     """
 
-    cache_control_headers = [
+    cache_headers = [
         'max-age=30',
         'stale-while-revalidate=300',
         'stale-if-error=86400',
@@ -43,7 +43,10 @@ def public_cache_headers(decorated):
         response = flask.make_response(
             decorated(*args, **kwargs)
         )
-        response.headers['Cache-Control'] = ', '.join(cache_control_headers)
+
+        if response.status_code == 200:
+            # Only add caching headers to successful responses
+            response.headers['Cache-Control'] = ', '.join(cache_headers)
 
         return response
 

--- a/template_functions.py
+++ b/template_functions.py
@@ -1,0 +1,43 @@
+# Core
+import hashlib
+import os
+
+
+def contains(arr, contents):
+    """
+    Template helper for detecting if an array contains an item
+    """
+
+    return contents in arr
+
+
+def join(arr, separator=''):
+    """
+    Template helper for joining array items into a string, using a separator
+    """
+
+    return separator.join(arr)
+
+
+def static_url(filename):
+    """
+    Template function for generating URLs to static assets:
+    Given the path for a static file, output a url path
+    with a hex hash as a query string for versioning
+    """
+
+    filepath = os.path.join('static', filename)
+    url = '/' + filepath
+
+    if not os.path.isfile(filepath):
+        print('Could not find static file: ' + filepath)
+        return url
+
+    # Use MD5 as we care about speed a lot
+    # and not security in this case
+    file_hash = hashlib.md5()
+    with open(filepath, "rb") as file_contents:
+        for chunk in iter(lambda: file_contents.read(4096), b""):
+            file_hash.update(chunk)
+
+    return url + '?v=' + file_hash.hexdigest()[:7]


### PR DESCRIPTION
Add standard caching headers to public routes:

- Cache pages for 30 seconds
  (allows Squid to take significant load of the app)
- Serve stale pages while revalidating the cache for 5 minutes
  (allows Squid to response instantly while doing cache refreshes)
- Show stale pages if the app is erroring for 1 day
  (gives us a 1 day buffer to fix errors before they are publicly visible)

These caching headers should now be included on /, /store, /search,
/{snap-name}

All private routes should now have `Cache-Control: private`.

I also restructured the code a bit to separate out decorators and template functions from `app.py`, to keep things more focused.

Fixes #424

QA
--

``` bash
$ curl -sI http://127.0.0.1:8004/ | grep 'Cache-Control'
Cache-Control: max-age=30, stale-while-revalidate=300, stale-if-error=86400
$ curl -sI http://127.0.0.1:8004/store | grep 'Cache-Control'
Cache-Control: max-age=30, stale-while-revalidate=300, stale-if-error=86400
$ curl -sI http://127.0.0.1:8004/search | grep 'Cache-Control'
Cache-Control: max-age=30, stale-while-revalidate=300, stale-if-error=86400
$ curl -sI http://127.0.0.1:8004/skype | grep 'Cache-Control'
Cache-Control: max-age=30, stale-while-revalidate=300, stale-if-error=86400
$ curl -sI http://127.0.0.1:8004/lxd | grep 'Cache-Control'
Cache-Control: max-age=30, stale-while-revalidate=300, stale-if-error=86400
$ curl -sI http://127.0.0.1:8004/account  # Should have no cache-control
HTTP/1.1 302 FOUND
Server: gunicorn/19.7.1
Date: Fri, 06 Apr 2018 17:28:27 GMT
Connection: close
Content-Type: text/html; charset=utf-8
Content-Length: 245
Location: http://127.0.0.1:8004/login?next=/account
X-Hostname: 8cc34cf58ef7
X-VCS-Revision: 0811fe1175be2c42754b91b0dadd2e0deb9a3bcb
X-Request-Id: fad12c89-ae6e-4791-af16-664e716e2cba
```

Check cache-control settings make sense ^.

Then browse to http://127.0.0.1, check the headers in the Network inspector.

Then browse to http://127.0.0.1/account, log in, then check the headers in the network inspector include `Cache-Control: private`.