### PR TITLE
Cross link notification

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -238,7 +238,7 @@ def publisher_snap_measure(snap_name):
     context = {
         # Data direct from details API
         'snap_name': snap_name,
-        'snap_display_name': details['title'],
+        'snap_title': details['title'],
         'metric_period': metric_period,
         'active_device_metric': installed_base_metric,
 

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -238,7 +238,7 @@ def publisher_snap_measure(snap_name):
     context = {
         # Data direct from details API
         'snap_name': snap_name,
-        'snap_title': details['title'],
+        'snap_display_name': details['title'],
         'metric_period': metric_period,
         'active_device_metric': installed_base_metric,
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "sass-lint": "^1.10.2",
     "topojson-client": "^3.0.0",
-    "vanilla-framework": "^1.6.5",
+    "vanilla-framework": "^1.6.7",
     "watch-cli": "^0.2.2"
   }
 }

--- a/static/sass/_snapcraft_p-beta-notification.scss
+++ b/static/sass/_snapcraft_p-beta-notification.scss
@@ -1,0 +1,17 @@
+@mixin snapcraft-p-beta-notification {
+  .p-beta-notification {
+    padding: {
+      top: $sp-small;
+      bottom: $sp-small;
+    }
+
+
+    .p-muted-heading {
+      margin-right: $sp-medium;
+    }
+
+    p {
+      max-width: 100%;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -120,3 +120,6 @@ $color-navigation-background: #252525;
 
 @import 'snapcraft_p-form-help-text';
 @include snapcraft-p-form-help-text;
+
+@import 'snapcraft_p-beta-notification';
+@include snapcraft-p-beta-notification;

--- a/templates/account.html
+++ b/templates/account.html
@@ -5,6 +5,8 @@ Account page — Linux software in the Snap Store
 {% endblock %}
 
 {% block content %}
+{% include "publisher/_beta-notification.html" %}
+
   <section class="p-strip is-shallow">
     <div class="row">
       <div class="col-2">

--- a/templates/developer_programme_agreement.html
+++ b/templates/developer_programme_agreement.html
@@ -5,49 +5,48 @@
 {% endblock %}
 
 {% block content %}
-<section class="p-layout__main">
+{% include "publisher/_beta-notification.html" %}
+<section class="p-strip">
   <div class="row">
-    <h1>Developer Programme Agreement</h1>
+    <h1 class="p-heading--three">Developer Programme Agreement</h1>
   </div>
 
   <div class="row">
     <div class="p-card">
-      <h2>Canonical Terms of Service</h2>
+      <h2 class="p-heading--four">Canonical Terms of Service</h2>
       <p class="p-card__content">
         <a class="p-link--external" href="https://www.ubuntu.com/legal/terms-and-policies/developer-terms-and-conditions" target="_blank">Developer Terms and Conditions</a>
       </p>
     </div>
   </div>
 
-  <div class="p-strip is-shallow u-no-padding--top" >
-    <div class="row u-no-margin--top">
-      <form method="POST" action="/account/agreement">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <div class="row">
-          <div class="col-8">
-            <div class="p-form-validation">
-              <input name="i_agree" id="id_i_agree" class="p-form-validation__input" type="checkbox">
-              <label for="id_i_agree"">I agree to these terms</label>
-            </div>
-          </div>
-          <div class="col-4 u-align--right">
-            <a class="p-button--neutral" href="/">Cancel</a>
-            <button class="p-button--positive" disabled="disabled" type="submit">Continue</button>
+  <div class="row u-no-margin--top">
+    <form method="POST" action="/account/agreement">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <div class="row">
+        <div class="col-8">
+          <div class="p-form-validation">
+            <input name="i_agree" id="id_i_agree" class="p-form-validation__input" type="checkbox">
+            <label for="id_i_agree"">I agree to these terms</label>
           </div>
         </div>
-        <script>
-         var checkbox = document.querySelector('#id_i_agree');
-         var button = document.querySelector('button[type="submit"]');
-         checkbox.addEventListener('change', function(event) {
-           if (this.checked) {
-             button.removeAttribute('disabled');
-           } else {
-             button.setAttribute('disabled', 'disabled');
-           }
-         });
-        </script>
-      </form>
-    </div>
+        <div class="col-4 u-align--right">
+          <a class="p-button--neutral" href="/">Cancel</a>
+          <button class="p-button--positive" disabled="disabled" type="submit">Continue</button>
+        </div>
+      </div>
+      <script>
+       var checkbox = document.querySelector('#id_i_agree');
+       var button = document.querySelector('button[type="submit"]');
+       checkbox.addEventListener('change', function(event) {
+         if (this.checked) {
+           button.removeAttribute('disabled');
+         } else {
+           button.setAttribute('disabled', 'disabled');
+         }
+       });
+      </script>
+    </form>
   </div>
 </section>
 {% endblock %}

--- a/templates/publisher/_beta-notification.html
+++ b/templates/publisher/_beta-notification.html
@@ -1,0 +1,12 @@
+<section class="p-strip--light u-no-margin--top u-no-padding">
+  <div class="row p-beta-notification">
+    <div class="col-12">
+      <p>
+        <span class="p-muted-heading"><b>Beta</b></span>
+        Snapcraft.io is in Beta. Can't find something?
+        <a href="https://dashboard.snapcraft.io/snaps" class="p-link--external">Go back to the old version</a> or
+        <a href="https://github.com/canonical-websites/snapcraft.io/issues" class="p-link--external">report an issue</a>.
+      </p>
+    </div>
+  </div>
+</section>

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -1,3 +1,5 @@
+{% include "publisher/_beta-notification.html" %}
+
 <section class="p-strip is-shallow u-no-padding--bottom">
   <nav class="p-tabs">
     {# This row and it's contents needs to be removed before going live #}

--- a/templates/username.html
+++ b/templates/username.html
@@ -5,12 +5,14 @@ Choose username — Linux software in the Snap Store
 {% endblock %}
 
 {% block content %}
-<section class="p-layout__main u-no-margin--top">
-  <div class="p-strip is-shallow">
-    <div class="row">
-      <h3>Choose a snap store username</h3>
-      {% if error_list %}
-        {% for error in error_list %}
+
+{% include "publisher/_beta-notification.html" %}
+
+<section class="p-strip">
+  <div class="row">
+    <h1 class="p-heading--three">Choose a snap store username</h1>
+    {% if error_list %}
+      {% for error in error_list %}
         <div class="p-notification--negative">
           <p class="p-notification__response">
             {{ error.message|safe }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5187,9 +5187,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@^1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.5.tgz#e6ea7ab6de38c8172e362474258981a57eec0993"
+vanilla-framework@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.7.tgz#c4fb65674e709abbf7e75a4f14152aa90c99c30f"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/394

- Updated vanilla to 1.6.7
- Added `_beta-notification.html` template for the notification

Depends on https://github.com/canonical-websites/snapcraft.io/pull/491

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account
- See the notification, click the links in the notification, close the notification
- Visit other account pages and see the notification

# Screenshot
![screenshot-2018-4-12 market details for lukotron](https://user-images.githubusercontent.com/479384/38667835-6f359c02-3e3a-11e8-9106-9f033f9d8915.png)
