### PR TITLE
Use username, fullname from API instead of l.u.com

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ import modules.authentication as authentication
 import modules.helpers as helpers
 import modules.public.views as public_views
 import modules.publisher.views as publisher_views
+import modules.publisher.api as publisher_api
 import template_functions
 import decorators
 from modules.macaroon import (
@@ -189,15 +190,26 @@ def login():
 
 @open_id.after_login
 def after_login(resp):
-    flask.session['openid'] = {
-        'identity_url': resp.identity_url,
-        'nickname': resp.nickname,
-        'fullname': resp.fullname,
-        'image': resp.image,
-        'email': resp.email
-    }
-
     flask.session['macaroon_discharge'] = resp.extensions['macaroon'].discharge
+
+    try:
+        account = publisher_api.get_account(flask.session)
+        flask.session['openid'] = {
+            'identity_url': resp.identity_url,
+            'nickname': account['username'],
+            'fullname': account['displayname'],
+            'image': resp.image,
+            'email': account['email']
+        }
+    except Exception:
+        flask.session['openid'] = {
+            'identity_url': resp.identity_url,
+            'nickname': resp.nickname,
+            'fullname': resp.fullname,
+            'image': resp.image,
+            'email': resp.email
+        }
+
     return flask.redirect(open_id.get_next_url())
 
 

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -53,8 +53,8 @@ def get_account():
 
             context = {
                 'image': flask_user['image'],
-                'username': account['username'],
-                'displayname': account['displayname'],
+                'username': flask_user['nickname'],
+                'displayname': flask_user['fullname'],
                 'email': account['email'],
                 'snaps': user_snaps,
                 'error_list': error_list

--- a/tests_basic.py
+++ b/tests_basic.py
@@ -137,7 +137,9 @@ def _log_in(client):
 
     with client.session_transaction() as s:
         s['openid'] = {
-            'image': None
+            'image': None,
+            'nickname': 'Toto',
+            'fullname': 'El Toto'
             }
         s['macaroon_root'] = root.serialize()
         s['macaroon_discharge'] = discharge.serialize()

--- a/tests_publisher.py
+++ b/tests_publisher.py
@@ -56,7 +56,9 @@ class PublisherPage(TestCase):
 
         with client.session_transaction() as s:
             s['openid'] = {
-                'image': None
+                'image': None,
+                'nickname': 'Toto',
+                'fullname': 'El Toto'
             }
             s['macaroon_root'] = root.serialize()
             s['macaroon_discharge'] = discharge.serialize()
@@ -124,8 +126,8 @@ class PublisherPage(TestCase):
         }
 
         payload = {
-            'username': 'testing',
-            'displayname': 'testing',
+            'username': 'Toto',
+            'displayname': 'El Toto',
             'email': 'testing@testing.com',
             'snaps': {
                 '16': snaps
@@ -150,8 +152,8 @@ class PublisherPage(TestCase):
 
         assert response.status_code == 200
         self.assert_template_used('account.html')
-        self.assert_context('username', 'testing')
-        self.assert_context('displayname', 'testing')
+        self.assert_context('username', 'Toto')
+        self.assert_context('displayname', 'El Toto')
         self.assert_context('email', 'testing@testing.com')
         self.assert_context('snaps', snaps)
         self.assert_context('image', None)


### PR DESCRIPTION
# Summary

Instead of using the data received from login.ubuntu.com we use the data from dashboard
This will fix https://github.com/canonical-websites/snapcraft.io/pull/498#discussion_r180426317

# QA

- `./run`
- http://0.0.0.0:8004/logout
- http://0.0.0.0:8004/account
- The username and display name should be the same
- http://0.0.0.0:8004/logout
- http://0.0.0.0:8004/account/snaps/toto/market
- login
- http://0.0.0.0:8004/account
- The username and displayname should be OK