### PR TITLE
update report links in footer

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -13,11 +13,11 @@
         You can contribute to, or report problems with,
         <a
           class="p-link--external"
-          href="https://bugs.launchpad.net/snappy"
+          href="https://bugs.launchpad.net/snapd"
         >snapd</a>,
         <a
           class="p-link--external"
-          href="https://github.com/snapcore/snapcraft/issues"
+          href="https://bugs.launchpad.net/snapcraft"
         >Snapcraft</a>,
         or
         <a


### PR DESCRIPTION
# Done

Fixes: #501

- Updated the snapcraft report link to https://bugs.launchpad.net/snapcraft
- Updated the snapd report link to https://bugs.launchpad.net/snapd 

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/
- Go to the footer and check if the links direct users to the correct report links, described in this issue: https://github.com/canonical-websites/build.snapcraft.io/issues/1078
