### PR TITLE
Remove 'Linux' from find snaps

### DIFF
--- a/templates/store.html
+++ b/templates/store.html
@@ -1,12 +1,12 @@
 {% extends "_layout.html" %}
 
-{% block title %}Find snaps for Linux — Linux software in the Snap Store{% endblock %}
+{% block title %}Find snaps — Linux software in the Snap Store{% endblock %}
 
 {% block content %}
   <section id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
     <div class="row">
       <div class="col-10">
-        <h2>Find snaps for Linux</h2>
+        <h2>Find snaps</h2>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/325

Removes `for Linux` from title.
<img width="1306" alt="screen shot 2018-04-11 at 09 24 15" src="https://user-images.githubusercontent.com/83575/38602260-827bc9ce-3d6a-11e8-9391-5ed92b79fc37.png">
