### PR TITLE
Test get market page

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from modules.exceptions import (
     ApiError,
     ApiTimeoutError,
+    ApiConnectionError,
     ApiResponseDecodeError,
     ApiResponseError,
     ApiResponseErrorList,
@@ -263,6 +264,8 @@ def get_market_snap(snap_name):
         snap_details = api.get_snap_info(snap_name, flask.session)
     except ApiTimeoutError as api_timeout_error:
         flask.abort(504, str(api_timeout_error))
+    except ApiConnectionError as api_connection_error:
+        flask.abort(502, str(api_connection_error))
     except ApiResponseDecodeError as api_response_decode_error:
         flask.abort(502, str(api_response_decode_error))
     except ApiResponseErrorList as api_response_error_list:
@@ -274,8 +277,6 @@ def get_market_snap(snap_name):
             flask.abort(502, error_messages)
     except ApiResponseError as api_response_error:
         flask.abort(502, str(api_response_error))
-    except ApiError as api_error:
-        flask.abort(502, str(api_error))
     except MacaroonRefreshRequired:
         return refresh_redirect(
             flask.request.path

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -1,0 +1,232 @@
+import requests
+
+import pymacaroons
+import responses
+
+from app import app
+from flask_testing import TestCase
+from modules.authentication import get_authorization_header
+
+
+# Make sure tests fail on stray responses.
+responses.mock.assert_all_requests_are_fired = True
+
+
+class BaseTestCases:
+    '''
+    This class has a set of test classes that should be inherited by endpoint
+    that have authentication.
+
+    It is also used to avoid unittest to run this tests file.
+    '''
+    class BaseAppTesting(TestCase):
+        render_templates = False
+
+        def setUp(self, snap_name, api_url, endpoint_url):
+            self.snap_name = snap_name
+            self.api_url = api_url
+            self.endpoint_url = endpoint_url
+
+        def create_app(self):
+            app.config['WTF_CSRF_METHODS'] = []
+            app.testing = True
+
+            return app
+
+        def _get_location(self):
+            return 'http://localhost{}'.format(self.endpoint_url)
+
+    class EndpointLoggedOut(BaseAppTesting):
+        def setUp(self, snap_name, endpoint_url):
+            super().setUp(snap_name, None, endpoint_url)
+
+        def test_access_not_logged_in(self):
+            response = self.client.get(self.endpoint_url)
+            self.assertEqual(302, response.status_code)
+            self.assertEqual(
+                'http://localhost/login?next={}'.format(self.endpoint_url),
+                response.location)
+
+    class EndpointLoggedIn(BaseAppTesting):
+        def setUp(self, snap_name, api_url, endpoint_url):
+            super().setUp(snap_name, api_url, endpoint_url)
+            self.authorization = self._log_in(self.client)
+
+        def _log_in(self, client):
+            """Emulates test client login in the store.
+
+            Fill current session with `openid`, `macaroon_root` and
+            `macaroon_discharge`.
+
+            Return the expected `Authorization` header for further verification
+            in API requests.
+            """
+            # Basic root/discharge macaroons pair.
+            root = pymacaroons.Macaroon('test', 'testing', 'a_key')
+            root.add_third_party_caveat('3rd', 'a_caveat-key', 'a_ident')
+            discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
+
+            with client.session_transaction() as s:
+                s['openid'] = {
+                    'image': None,
+                    'nickname': 'Toto',
+                    'fullname': 'El Toto'
+                }
+                s['macaroon_root'] = root.serialize()
+                s['macaroon_discharge'] = discharge.serialize()
+
+            return get_authorization_header(
+                root.serialize(), discharge.serialize())
+
+        @responses.activate
+        def test_timeout(self):
+            responses.add(
+                responses.GET, self.api_url,
+                body=requests.exceptions.Timeout(), status=504)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 504
+
+        @responses.activate
+        def test_connection_error(self):
+            responses.add(
+                responses.GET, self.api_url,
+                body=requests.exceptions.ConnectionError(), status=500)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_page_not_found(self):
+            payload = {
+                'error_list': []
+            }
+            responses.add(
+                responses.GET, self.api_url,
+                json=payload, status=404)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 404
+            self.assert_template_used('404.html')
+
+        @responses.activate
+        def test_broken_json(self):
+            # To test this I return no json from the server, this makes the
+            # call to the function response.json() raise a ValueError exception
+            responses.add(
+                responses.GET, self.api_url,
+                status=500)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_unknown_error(self):
+            responses.add(
+                responses.GET, self.api_url,
+                json={}, status=500)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_error_4xx(self):
+            payload = {
+                'error_list': []
+            }
+            responses.add(
+                responses.GET, self.api_url,
+                json=payload, status=400)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_expired_macaroon(self):
+            responses.add(
+                responses.GET, self.api_url,
+                json={}, status=500,
+                headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
+            responses.add(
+                responses.POST,
+                'https://login.ubuntu.com/api/v2/tokens/refresh',
+                json={'discharge_macaroon': 'macaroon'}, status=200)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(2, len(responses.calls))
+
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+            called = responses.calls[1]
+            self.assertEqual(
+                'https://login.ubuntu.com/api/v2/tokens/refresh',
+                called.request.url)
+
+            assert response.status_code == 302
+            assert response.location == self._get_location()

--- a/tests/tests_market.py
+++ b/tests/tests_market.py
@@ -1,0 +1,426 @@
+import unittest
+import requests
+
+import pymacaroons
+import responses
+
+from app import app
+from flask_testing import TestCase
+from modules.authentication import get_authorization_header
+
+
+# Make sure tests fail on stray responses.
+responses.mock.assert_all_requests_are_fired = True
+
+
+class MarketPage(TestCase):
+
+    render_templates = False
+
+    def create_app(self):
+        app.config['WTF_CSRF_METHODS'] = []
+        app.testing = True
+
+        return app
+
+    def _log_in(self, client):
+        """Emulates test client login in the store.
+
+        Fill current session with `openid`, `macaroon_root` and
+        `macaroon_discharge`.
+
+        Return the expected `Authorization` header for further verification in
+        API requests.
+        """
+        # Basic root/discharge macaroons pair.
+        root = pymacaroons.Macaroon('test', 'testing', 'a_key')
+        root.add_third_party_caveat('3rd', 'a_caveat-key', 'a_ident')
+        discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
+
+        with client.session_transaction() as s:
+            s['openid'] = {
+                'image': None,
+                'nickname': 'Toto',
+                'fullname': 'El Toto'
+            }
+            s['macaroon_root'] = root.serialize()
+            s['macaroon_discharge'] = discharge.serialize()
+
+        return get_authorization_header(
+            root.serialize(), discharge.serialize())
+
+    def test_snap_market_not_logged_in(self):
+        # `snap-market` page redirects unauthenticated access to `login`
+        # with the appropriate `next` path.
+        response = self.client.get('/account/snaps/lxd/market')
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/login?next=/account/snaps/lxd/market',
+            response.location)
+
+    @responses.activate
+    def test_timeout(self):
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            body=requests.exceptions.Timeout(), status=504)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 504
+
+    @responses.activate
+    def test_connection_error(self):
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            body=requests.exceptions.ConnectionError(), status=500)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_snap_not_found(self):
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        payload = {
+            'error_list': []
+        }
+        responses.add(
+            responses.GET, api_url,
+            json=payload, status=404)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 404
+        self.assert_template_used('404.html')
+
+    @responses.activate
+    def test_broken_json(self):
+        # To test this I return no json from the server, this makes the call
+        # to the function response.json() raise a ValueError exception
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            status=500)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_unknown_error(self):
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            json={}, status=500)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_error_4xx(self):
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        payload = {
+            'error_list': []
+        }
+        responses.add(
+            responses.GET, api_url,
+            json=payload, status=400)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_expired_macaroon(self):
+        # To test this I return no json from the server, this makes the call
+        # to the function response.json() raise a ValueError exception
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            json={}, status=500,
+            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
+        responses.add(
+            responses.POST, 'https://login.ubuntu.com/api/v2/tokens/refresh',
+            json={'discharge_macaroon': 'macaroon'}, status=200)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(2, len(responses.calls))
+
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+        called = responses.calls[1]
+        self.assertEqual(
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            called.request.url)
+
+        assert response.status_code == 302
+        assert response.location == 'http://localhost{}'.format(endpoint_url)
+
+    @responses.activate
+    def test_account_logged_in(self):
+        snap_name = "test-snap"
+
+        payload = {
+            'snap_id': 'id',
+            'snap_name': snap_name,
+            'title': 'Snap title',
+            'summary': 'This is a summary',
+            'description': 'This is a description',
+            'license': 'license',
+            'media': [],
+            'publisher': {
+                'display-name': 'The publisher'
+            },
+            'contact': 'contact adress',
+            'website': 'website_url',
+            'public_metrics_enabled': True,
+            'public_metrics_blacklist': True,
+        }
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            json=payload, status=200)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 200
+        self.assert_template_used('publisher/market.html')
+
+        self.assert_context('snap_id', 'id')
+        self.assert_context('snap_name', snap_name)
+        self.assert_context('snap_title', 'Snap title')
+        self.assert_context('summary', 'This is a summary')
+        self.assert_context('description', 'This is a description')
+        self.assert_context('license', 'license')
+        self.assert_context('icon_url', None)
+        self.assert_context('publisher_name', 'The publisher')
+        self.assert_context('screenshot_urls', [])
+        self.assert_context('contact', 'contact adress')
+        self.assert_context('website', 'website_url')
+        self.assert_context('public_metrics_enabled', True)
+        self.assert_context('public_metrics_blacklist', True)
+
+    @responses.activate
+    def test_icon(self):
+        snap_name = "test-snap"
+
+        payload = {
+            'snap_id': 'id',
+            'snap_name': snap_name,
+            'title': 'Snap title',
+            'summary': 'This is a summary',
+            'description': 'This is a description',
+            'license': 'license',
+            'media': [
+                {
+                    'url': 'this is a url',
+                    'type': 'icon'
+                }
+            ],
+            'publisher': {
+                'display-name': 'The publisher'
+            },
+            'contact': 'contact adress',
+            'website': 'website_url',
+            'public_metrics_enabled': True,
+            'public_metrics_blacklist': True,
+        }
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            json=payload, status=200)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 200
+        self.assert_template_used('publisher/market.html')
+
+        self.assert_context('icon_url', 'this is a url')
+
+    @responses.activate
+    def test_screenshots(self):
+        snap_name = "test-snap"
+
+        payload = {
+            'snap_id': 'id',
+            'snap_name': snap_name,
+            'title': 'Snap title',
+            'summary': 'This is a summary',
+            'description': 'This is a description',
+            'license': 'license',
+            'media': [
+                {
+                    'url': 'this is a url',
+                    'type': 'screenshot'
+                }
+            ],
+            'publisher': {
+                'display-name': 'The publisher'
+            },
+            'contact': 'contact adress',
+            'website': 'website_url',
+            'public_metrics_enabled': True,
+            'public_metrics_blacklist': True,
+        }
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        responses.add(
+            responses.GET, api_url,
+            json=payload, status=200)
+
+        authorization = self._log_in(self.client)
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            authorization, called.request.headers.get('Authorization'))
+
+        assert response.status_code == 200
+        self.assert_template_used('publisher/market.html')
+
+        self.assert_context('screenshot_urls', ['this is a url'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tests_market.py
+++ b/tests/tests_market.py
@@ -1,265 +1,28 @@
 import unittest
-import requests
-
-import pymacaroons
 import responses
 
-from app import app
-from flask_testing import TestCase
-from modules.authentication import get_authorization_header
+from tests.endpoint_testing import BaseTestCases
 
 
-# Make sure tests fail on stray responses.
-responses.mock.assert_all_requests_are_fired = True
+class MarketPageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+
+        super().setUp(snap_name, endpoint_url)
 
 
-class MarketPage(TestCase):
-
-    render_templates = False
-
-    def create_app(self):
-        app.config['WTF_CSRF_METHODS'] = []
-        app.testing = True
-
-        return app
-
-    def _log_in(self, client):
-        """Emulates test client login in the store.
-
-        Fill current session with `openid`, `macaroon_root` and
-        `macaroon_discharge`.
-
-        Return the expected `Authorization` header for further verification in
-        API requests.
-        """
-        # Basic root/discharge macaroons pair.
-        root = pymacaroons.Macaroon('test', 'testing', 'a_key')
-        root.add_third_party_caveat('3rd', 'a_caveat-key', 'a_ident')
-        discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
-
-        with client.session_transaction() as s:
-            s['openid'] = {
-                'image': None,
-                'nickname': 'Toto',
-                'fullname': 'El Toto'
-            }
-            s['macaroon_root'] = root.serialize()
-            s['macaroon_discharge'] = discharge.serialize()
-
-        return get_authorization_header(
-            root.serialize(), discharge.serialize())
-
-    def test_snap_market_not_logged_in(self):
-        # `snap-market` page redirects unauthenticated access to `login`
-        # with the appropriate `next` path.
-        response = self.client.get('/account/snaps/lxd/market')
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/login?next=/account/snaps/lxd/market',
-            response.location)
-
-    @responses.activate
-    def test_timeout(self):
+class MarketPage(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
         snap_name = "test-snap"
 
         api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
         api_url = api_url.format(
             snap_name
         )
-        responses.add(
-            responses.GET, api_url,
-            body=requests.exceptions.Timeout(), status=504)
-
-        authorization = self._log_in(self.client)
         endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
 
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 504
-
-    @responses.activate
-    def test_connection_error(self):
-        snap_name = "test-snap"
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
-        responses.add(
-            responses.GET, api_url,
-            body=requests.exceptions.ConnectionError(), status=500)
-
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 502
-
-    @responses.activate
-    def test_snap_not_found(self):
-        snap_name = "test-snap"
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
-        payload = {
-            'error_list': []
-        }
-        responses.add(
-            responses.GET, api_url,
-            json=payload, status=404)
-
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 404
-        self.assert_template_used('404.html')
-
-    @responses.activate
-    def test_broken_json(self):
-        # To test this I return no json from the server, this makes the call
-        # to the function response.json() raise a ValueError exception
-        snap_name = "test-snap"
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
-        responses.add(
-            responses.GET, api_url,
-            status=500)
-
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 502
-
-    @responses.activate
-    def test_unknown_error(self):
-        snap_name = "test-snap"
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
-        responses.add(
-            responses.GET, api_url,
-            json={}, status=500)
-
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 502
-
-    @responses.activate
-    def test_error_4xx(self):
-        snap_name = "test-snap"
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
-        payload = {
-            'error_list': []
-        }
-        responses.add(
-            responses.GET, api_url,
-            json=payload, status=400)
-
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 502
-
-    @responses.activate
-    def test_expired_macaroon(self):
-        # To test this I return no json from the server, this makes the call
-        # to the function response.json() raise a ValueError exception
-        snap_name = "test-snap"
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
-        responses.add(
-            responses.GET, api_url,
-            json={}, status=500,
-            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
-        responses.add(
-            responses.POST, 'https://login.ubuntu.com/api/v2/tokens/refresh',
-            json={'discharge_macaroon': 'macaroon'}, status=200)
-
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
-
-        self.assertEqual(2, len(responses.calls))
-
-        called = responses.calls[0]
-        self.assertEqual(
-            api_url,
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-        called = responses.calls[1]
-        self.assertEqual(
-            'https://login.ubuntu.com/api/v2/tokens/refresh',
-            called.request.url)
-
-        assert response.status_code == 302
-        assert response.location == 'http://localhost{}'.format(endpoint_url)
+        super().setUp(snap_name, api_url, endpoint_url)
 
     @responses.activate
     def test_account_logged_in(self):
@@ -282,25 +45,19 @@ class MarketPage(TestCase):
             'public_metrics_blacklist': True,
         }
 
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
         responses.add(
-            responses.GET, api_url,
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
+        response = self.client.get(self.endpoint_url)
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            api_url,
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
         self.assert_template_used('publisher/market.html')
@@ -321,11 +78,9 @@ class MarketPage(TestCase):
 
     @responses.activate
     def test_icon(self):
-        snap_name = "test-snap"
-
         payload = {
             'snap_id': 'id',
-            'snap_name': snap_name,
+            'snap_name': self.snap_name,
             'title': 'Snap title',
             'summary': 'This is a summary',
             'description': 'This is a description',
@@ -345,25 +100,19 @@ class MarketPage(TestCase):
             'public_metrics_blacklist': True,
         }
 
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
         responses.add(
-            responses.GET, api_url,
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
+        response = self.client.get(self.endpoint_url)
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            api_url,
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
         self.assert_template_used('publisher/market.html')
@@ -372,11 +121,9 @@ class MarketPage(TestCase):
 
     @responses.activate
     def test_screenshots(self):
-        snap_name = "test-snap"
-
         payload = {
             'snap_id': 'id',
-            'snap_name': snap_name,
+            'snap_name': self.snap_name,
             'title': 'Snap title',
             'summary': 'This is a summary',
             'description': 'This is a description',
@@ -396,25 +143,19 @@ class MarketPage(TestCase):
             'public_metrics_blacklist': True,
         }
 
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        api_url = api_url.format(
-            snap_name
-        )
         responses.add(
-            responses.GET, api_url,
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
-        response = self.client.get(endpoint_url)
+        response = self.client.get(self.endpoint_url)
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            api_url,
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
         self.assert_template_used('publisher/market.html')


### PR DESCRIPTION
# Summary

- Add tests for the market endpoint Fixes #480 
- Refactor test to get a generic test class for authenticated endpoints

# QA

- `./run test`