### PR TITLE
Make description field bigger

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -138,7 +138,7 @@
             </div>
             <div class="col-8">
               <div class="p-form-validation u-no-margin {% if field_errors and field_errors['description'] %}is-error{% endif %}">
-                <textarea class="p-form-validation__input u-no-margin" name="description" required>{{ description }}</textarea>
+                <textarea class="p-form-validation__input u-no-margin" name="description" rows="10" required>{{ description }}</textarea>
                 {% if field_errors and field_errors['description'] %}
                   <p class="p-form-validation__message">
                     <strong>Error:</strong> {{ field_errors['description'] }}


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/322

Makes description field on market page bigger (to encourage longer descriptions).

### QA

- ./run
- go to market page of your snap
- description field should be visually bigger then other fields (enough to contain couple of lines of text).

<img width="1034" alt="screen shot 2018-04-16 at 10 56 06" src="https://user-images.githubusercontent.com/83575/38799610-30db32f4-4165-11e8-83f0-249efdbac1b5.png">
