### PR TITLE
Add tests post market page

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -368,13 +368,13 @@ def build_image_info(image, image_type):
 
 def post_market_snap(snap_name):
     changes = None
-    changed_fields = flask.request.form['changes']
+    changed_fields = flask.request.form.get('changes')
 
     if changed_fields:
         changes = loads(changed_fields)
 
     if changes:
-        snap_id = flask.request.form['snap_id']
+        snap_id = flask.request.form.get('snap_id')
         error_list = []
         info = []
         images_files = []

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -36,22 +36,6 @@ class BaseTestCases:
         def _get_location(self):
             return 'http://localhost{}'.format(self.endpoint_url)
 
-    class EndpointLoggedOut(BaseAppTesting):
-        def setUp(self, snap_name, endpoint_url):
-            super().setUp(snap_name, None, endpoint_url)
-
-        def test_access_not_logged_in(self):
-            response = self.client.get(self.endpoint_url)
-            self.assertEqual(302, response.status_code)
-            self.assertEqual(
-                'http://localhost/login?next={}'.format(self.endpoint_url),
-                response.location)
-
-    class EndpointLoggedIn(BaseAppTesting):
-        def setUp(self, snap_name, api_url, endpoint_url):
-            super().setUp(snap_name, api_url, endpoint_url)
-            self.authorization = self._log_in(self.client)
-
         def _log_in(self, client):
             """Emulates test client login in the store.
 
@@ -77,6 +61,33 @@ class BaseTestCases:
 
             return get_authorization_header(
                 root.serialize(), discharge.serialize())
+
+    class EndpointGetLoggedOut(BaseAppTesting):
+        def setUp(self, snap_name, endpoint_url):
+            super().setUp(snap_name, None, endpoint_url)
+
+        def test_access_not_logged_in(self):
+            response = self.client.get(self.endpoint_url)
+            self.assertEqual(302, response.status_code)
+            self.assertEqual(
+                'http://localhost/login?next={}'.format(self.endpoint_url),
+                response.location)
+
+    class EndpointPostLoggedOut(BaseAppTesting):
+        def setUp(self, snap_name, endpoint_url):
+            super().setUp(snap_name, None, endpoint_url)
+
+        def test_access_not_logged_in(self):
+            response = self.client.post(self.endpoint_url, data={})
+            self.assertEqual(302, response.status_code)
+            self.assertEqual(
+                'http://localhost/login?next={}'.format(self.endpoint_url),
+                response.location)
+
+    class EndpointGetLoggedIn(BaseAppTesting):
+        def setUp(self, snap_name, api_url, endpoint_url):
+            super().setUp(snap_name, api_url, endpoint_url)
+            self.authorization = self._log_in(self.client)
 
         @responses.activate
         def test_timeout(self):

--- a/tests/tests_market.py
+++ b/tests/tests_market.py
@@ -4,7 +4,7 @@ import responses
 from tests.endpoint_testing import BaseTestCases
 
 
-class MarketPageNotAuth(BaseTestCases.EndpointLoggedOut):
+class MarketPageNotAuth(BaseTestCases.EndpointGetLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
         endpoint_url = '/account/snaps/{}/market'.format(snap_name)
@@ -12,7 +12,7 @@ class MarketPageNotAuth(BaseTestCases.EndpointLoggedOut):
         super().setUp(snap_name, endpoint_url)
 
 
-class MarketPage(BaseTestCases.EndpointLoggedIn):
+class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
 

--- a/tests/tests_post_binary_metadata.py
+++ b/tests/tests_post_binary_metadata.py
@@ -1,0 +1,440 @@
+import unittest
+import responses
+import json
+import io
+from tests.endpoint_testing import BaseTestCases
+
+
+class PostBinaryMetadataMarketPage(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        self.snap_id = 'complexId'
+        snap_name = "test-snap"
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+
+        super().setUp(snap_name, None, endpoint_url)
+        self.authorization = self._log_in(self.client)
+
+    def _get_redirect(self):
+        return (
+            'http://localhost'
+            '/account/snaps/{}/market'
+        ).format(self.snap_name)
+
+    @responses.activate
+    def test_get_binary_metadata_macaroon_refresh(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/binary-metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.GET, api_url,
+            json=[], status=500,
+            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
+        responses.add(
+            responses.POST,
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            json={'discharge_macaroon': 'macaroon'}, status=200)
+
+        changes = {
+            "images":  None
+        }
+
+        data = dict(
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+        response = self.client.post(
+            self.endpoint_url,
+            content_type='multipart/form-data',
+            data=data)
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "GET",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        called = responses.calls[1]
+        self.assertEqual(
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            called.request.url)
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_post_binary_metadata_macaroon_refresh(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/binary-metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.GET, api_url,
+            json=[], status=200)
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=500,
+            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
+        responses.add(
+            responses.POST,
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            json={'discharge_macaroon': 'macaroon'}, status=200)
+
+        changes = {
+            "images": [
+                {
+                    'file': {},
+                    'url': 'blob:this_is_a_blob',
+                    'name': 'blue.png',
+                    'type': 'screenshot',
+                    'status': 'new'
+                }
+            ]
+        }
+
+        data = dict(
+            screenshots=[(io.BytesIO(b'my file contents'), "blue.png")],
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+
+        response = self.client.post(
+            self.endpoint_url,
+            content_type='multipart/form-data',
+            data=data)
+
+        self.assertEqual(3, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "GET",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        called = responses.calls[1]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "PUT",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertIn(
+            b'"key": "blue.png"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"type": "screenshot"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"filename": "blue.png"',
+            called.request.body
+        )
+        hash_screenshot = (
+            '"hash": '
+            '"114d70ba7d04c76d8c217c970f99682025c89b1a6ffe91eb9045653b4b954eb9'
+        )
+        self.assertIn(
+            bytes(hash_screenshot, encoding='utf-8'),
+            called.request.body
+        )
+        called = responses.calls[2]
+        self.assertEqual(
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            called.request.url)
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_upload_new_screenshot(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/binary-metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.GET, api_url,
+            json=[], status=200)
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "images": [
+                {
+                    'file': {},
+                    'url': 'blob:this_is_a_blob',
+                    'name': 'blue.png',
+                    'type': 'screenshot',
+                    'status': 'new'
+                }
+            ]
+        }
+
+        data = dict(
+            screenshots=[(io.BytesIO(b'my file contents'), "blue.png")],
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+
+        response = self.client.post(
+            self.endpoint_url,
+            content_type='multipart/form-data',
+            data=data)
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "GET",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        called = responses.calls[1]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "PUT",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertIn(
+            b'"key": "blue.png"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"type": "screenshot"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"filename": "blue.png"',
+            called.request.body
+        )
+        hash_screenshot = (
+            '"hash": '
+            '"114d70ba7d04c76d8c217c970f99682025c89b1a6ffe91eb9045653b4b954eb9'
+        )
+        self.assertIn(
+            bytes(hash_screenshot, encoding='utf-8'),
+            called.request.body
+        )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_upload_new_icon(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/binary-metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.GET, api_url,
+            json=[], status=200)
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "images": [
+                {
+                    'file': {},
+                    'url': 'blob:this_is_a_blob',
+                    'name': 'blue.png',
+                    'type': 'icon',
+                    'status': 'new'
+                }
+            ]
+        }
+
+        data = dict(
+            icon=[(io.BytesIO(b'my file contents'), "blue.png")],
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+
+        response = self.client.post(
+            self.endpoint_url,
+            content_type='multipart/form-data',
+            data=data)
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "GET",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        called = responses.calls[1]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "PUT",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertIn(
+            b'"key": "blue.png"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"type": "icon"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"filename": "blue.png"',
+            called.request.body
+        )
+        hash_screenshot = (
+            '"hash": '
+            '"114d70ba7d04c76d8c217c970f99682025c89b1a6ffe91eb9045653b4b954eb9'
+        )
+        self.assertIn(
+            bytes(hash_screenshot, encoding='utf-8'),
+            called.request.body
+        )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_upload_new_screenshot_with_existing_ones(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/binary-metadata').format(
+                self.snap_id)
+
+        current_screenshots = [
+            {
+                'url': 'URL',
+                'hash': 'HASH',
+                'type': 'screenshot',
+                'filename': 'red.png'
+            }
+        ]
+        responses.add(
+            responses.GET, api_url,
+            json=current_screenshots, status=200)
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "images": [
+                {
+                    'file': {},
+                    'url': 'blob:this_is_a_blob',
+                    'name': 'blue.png',
+                    'type': 'icon',
+                    'status': 'new'
+                },
+                {
+                    'url': 'URL',
+                    'type': 'screenshot',
+                    'status': 'uploaded'
+                }
+
+            ]
+        }
+
+        data = dict(
+            screenshots=[(io.BytesIO(b'my file contents'), "blue.png")],
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+
+        response = self.client.post(
+            self.endpoint_url,
+            content_type='multipart/form-data',
+            data=data)
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "GET",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        called = responses.calls[1]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            "PUT",
+            called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertIn(
+            b'"key": "blue.png"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"type": "screenshot"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"filename": "blue.png"',
+            called.request.body
+        )
+        hash_screenshot = (
+            '"hash": '
+            '"114d70ba7d04c76d8c217c970f99682025c89b1a6ffe91eb9045653b4b954eb9'
+        )
+        self.assertIn(
+            bytes(hash_screenshot, encoding='utf-8'),
+            called.request.body
+        )
+
+        self.assertIn(
+            b'"url": "URL"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"hash": "HASH"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"type": "screenshot"',
+            called.request.body
+        )
+        self.assertIn(
+            b'"filename": "red.png"',
+            called.request.body
+        )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tests_post_market.py
+++ b/tests/tests_post_market.py
@@ -1,0 +1,568 @@
+import unittest
+import responses
+import json
+
+from tests.endpoint_testing import BaseTestCases
+
+
+class PostMarketPageNotAuth(BaseTestCases.EndpointPostLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+
+        super().setUp(snap_name, endpoint_url)
+
+
+class PostMetadataMarketPage(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        self.snap_id = 'complexId'
+        snap_name = "test-snap"
+        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+
+        super().setUp(snap_name, None, endpoint_url)
+        self.authorization = self._log_in(self.client)
+
+    def _get_redirect(self):
+        return (
+            'http://localhost'
+            '/account/snaps/{}/market'
+        ).format(self.snap_name)
+
+    @responses.activate
+    def test_post_no_data(self):
+        response = self.client.post(
+            self.endpoint_url,
+        )
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_update_invalid_field(self):
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': '{"dumb_field": "this is a dumb field"}'
+            },
+        )
+
+        assert 0 == len(responses.calls)
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_expired_macaroon(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=500,
+            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
+        responses.add(
+            responses.POST,
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            json={'discharge_macaroon': 'macaroon'}, status=200)
+
+        changes = {
+            "contact": "contact-adress"
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"contact": "contact-adress"}',
+            called.request.body
+            )
+        called = responses.calls[1]
+        self.assertEqual(
+            'https://login.ubuntu.com/api/v2/tokens/refresh',
+            called.request.url)
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_update_valid_field(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "contact": "contact-adress"
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"contact": "contact-adress"}',
+            called.request.body
+            )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_update_description_with_carriage_return(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "description": "This is a description\r\n"
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"description": "This is a description\\n"}',
+            called.request.body
+            )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_update_no_metric_blacklist(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "public_metrics_blacklist": ""
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"public_metrics_blacklist": []}',
+            called.request.body
+            )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_update_one_metric_blacklist(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "public_metrics_blacklist": "metric"
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"public_metrics_blacklist": ["metric"]}',
+            called.request.body
+            )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_update_multiple_metrics_blacklist(self):
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        responses.add(
+            responses.PUT, api_url,
+            json={}, status=200)
+
+        changes = {
+            "public_metrics_blacklist": "metric1,metric2"
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"public_metrics_blacklist": ["metric1", "metric2"]}',
+            called.request.body
+            )
+
+        assert response.status_code == 302
+        assert response.location == self._get_redirect()
+
+    @responses.activate
+    def test_return_error_udpate_one_field(self):
+        metadata_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        metadata_payload = {
+            'error_list': [
+                {
+                    'code': 'code',
+                    'message': 'message'
+                }
+            ]
+        }
+
+        responses.add(
+            responses.PUT, metadata_url,
+            json=metadata_payload, status=500)
+
+        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        info_url = info_url.format(
+            self.snap_name
+        )
+
+        payload = {
+            'snap_id': self.snap_id,
+            'snap_name': self.snap_name,
+            'title': 'Snap title',
+            'summary': 'This is a summary',
+            'description': 'This is a description',
+            'license': 'license',
+            'media': [],
+            'publisher': {
+                'display-name': 'The publisher'
+            },
+            'contact': 'contact adress',
+            'website': 'website_url',
+            'public_metrics_enabled': True,
+            'public_metrics_blacklist': True,
+        }
+
+        responses.add(
+            responses.GET, info_url,
+            json=payload, status=200)
+
+        changes = {
+            "description": "This is an updated description"
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            metadata_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"description": "This is an updated description"}',
+            called.request.body
+        )
+        called = responses.calls[1]
+        self.assertEqual(
+            info_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used('publisher/market.html')
+
+        self.assert_context('snap_id', self.snap_id)
+        self.assert_context('snap_name', self.snap_name)
+        # udpated field
+        self.assert_context('description', 'This is an updated description')
+
+        self.assert_context('snap_title', 'Snap title')
+        self.assert_context('summary', 'This is a summary')
+        self.assert_context('license', 'license')
+        self.assert_context('icon_url', None)
+        self.assert_context('publisher_name', 'The publisher')
+        self.assert_context('screenshot_urls', [])
+        self.assert_context('contact', 'contact adress')
+        self.assert_context('website', 'website_url')
+        self.assert_context('public_metrics_enabled', True)
+        self.assert_context('public_metrics_blacklist', True)
+
+    @responses.activate
+    def test_return_error_udpate_all_field(self):
+        metadata_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        metadata_payload = {
+            'error_list': [
+                {
+                    'code': 'code',
+                    'message': 'message'
+                }
+            ]
+        }
+
+        responses.add(
+            responses.PUT, metadata_url,
+            json=metadata_payload, status=500)
+
+        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        info_url = info_url.format(
+            self.snap_name
+        )
+
+        payload = {
+            'snap_id': self.snap_id,
+            'snap_name': self.snap_name,
+            'title': 'Snap title',
+            'summary': 'This is a summary',
+            'description': 'This is a description',
+            'license': 'license',
+            'media': [],
+            'publisher': {
+                'display-name': 'The publisher'
+            },
+            'contact': 'contact adress',
+            'website': 'website_url',
+            'public_metrics_enabled': True,
+            'public_metrics_blacklist': True,
+        }
+
+        responses.add(
+            responses.GET, info_url,
+            json=payload, status=200)
+
+        changes = {
+            "snap_title": "New title",
+            "summary": "New summary",
+            "description": "New description",
+            "icon_url": None,
+            "publisher_name": "New publisher",
+            "screenshot_urls": [],
+            "contact": "New contact",
+            "website": "New website",
+            "public_metrics_enabled": False,
+            "public_metrics_blacklist": "new metric1,new metric2",
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            metadata_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        called = responses.calls[1]
+        self.assertEqual(
+            info_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used('publisher/market.html')
+
+        # Not updatable fields
+        self.assert_context('snap_id', self.snap_id)
+        self.assert_context('snap_name', self.snap_name)
+        self.assert_context('public_metrics_enabled', True)
+        self.assert_context('public_metrics_blacklist', True)
+        self.assert_context('license', 'license')
+        self.assert_context('icon_url', None)
+        self.assert_context('publisher_name', 'The publisher')
+        self.assert_context('screenshot_urls', [])
+        self.assert_context('snap_title', 'Snap title')
+
+        # All updatable fields
+        self.assert_context('summary', 'New summary')
+        self.assert_context('description', 'New description')
+        self.assert_context('contact', 'New contact')
+        self.assert_context('website', 'New website')
+
+    @responses.activate
+    def test_return_error_invalid_field(self):
+        metadata_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'snaps/{}/metadata').format(
+                self.snap_id)
+
+        metadata_payload = {
+            'error_list': [
+                {
+                    'code': 'invalid-field',
+                    'message': 'error message',
+                    'extra': {'name': 'description'}
+                }
+            ]
+        }
+
+        responses.add(
+            responses.PUT, metadata_url,
+            json=metadata_payload, status=500)
+
+        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        info_url = info_url.format(
+            self.snap_name
+        )
+
+        payload = {
+            'snap_id': self.snap_id,
+            'snap_name': self.snap_name,
+            'title': 'Snap title',
+            'summary': 'This is a summary',
+            'description': 'This is a description',
+            'license': 'license',
+            'media': [],
+            'publisher': {
+                'display-name': 'The publisher'
+            },
+            'contact': 'contact adress',
+            'website': 'website_url',
+            'public_metrics_enabled': True,
+            'public_metrics_blacklist': True,
+        }
+
+        responses.add(
+            responses.GET, info_url,
+            json=payload, status=200)
+
+        changes = {
+            "description": "This is an updated description",
+        }
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'changes': json.dumps(changes),
+                'snap_id': self.snap_id
+            },
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            metadata_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        called = responses.calls[1]
+        self.assertEqual(
+            info_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used('publisher/market.html')
+
+        self.assert_context('field_errors', {
+            'description': 'error message'
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Summary

- Add tests for POST endpoint
- Seperated in 2 files:
  - One for fields updates
  - One for screenshots/icon uploads

# QA

- `./run test`
