### PR TITLE
Give all session responses Cache-Control: private

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ import modules.public.views as public_views
 import modules.publisher.views as publisher_views
 import modules.publisher.api as publisher_api
 import template_functions
-import decorators
+from decorators import login_required
 from modules.macaroon import (
     MacaroonRequest,
     MacaroonResponse,
@@ -137,8 +137,28 @@ def clear_trailing():
 
 
 @app.after_request
-def apply_caching(response):
+def add_headers(response):
+    """
+    Generic rules for headers to add to all requests
+
+    - X-Hostname: Mention the name of the host/pod running the application
+    - Cache-Control: Add cache-control headers for public and private pages
+    """
+
     response.headers["X-Hostname"] = socket.gethostname()
+
+    if response.status_code == 200:
+        if flask.session:
+            response.headers['Cache-Control'] = 'private'
+        else:
+            # Only add caching headers to successful responses
+            response.headers['Cache-Control'] = ', '.join({
+                'public',
+                'max-age=61',
+                'stale-while-revalidate=300',
+                'stale-if-error=86400',
+            })
+
     return response
 
 
@@ -223,7 +243,6 @@ def logout():
 # Normal views
 # ===
 @app.route('/')
-@decorators.public_cache_headers
 def homepage():
     return public_views.homepage()
 
@@ -234,7 +253,6 @@ def status():
 
 
 @app.route('/store')
-@decorators.public_cache_headers
 def store():
     return public_views.store()
 
@@ -250,13 +268,11 @@ def snaps():
 
 
 @app.route('/search')
-@decorators.public_cache_headers
 def search_snap():
     return public_views.search_snap()
 
 
 @app.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
-@decorators.public_cache_headers
 def snap_details(snap_name):
     return public_views.snap_details(snap_name)
 
@@ -264,54 +280,54 @@ def snap_details(snap_name):
 # Publisher views
 # ===
 @app.route('/account')
-@decorators.login_required
+@login_required
 def get_account():
     return publisher_views.get_account()
 
 
 @app.route('/account/agreement')
-@decorators.login_required
+@login_required
 def get_agreement():
     return publisher_views.get_agreement()
 
 
 @app.route('/account/agreement', methods=['POST'])
-@decorators.login_required
+@login_required
 def post_agreement():
     return publisher_views.post_agreement()
 
 
 @app.route('/account/username')
-@decorators.login_required
+@login_required
 def get_account_name():
     return publisher_views.get_account_name()
 
 
 @app.route('/account/username', methods=['POST'])
-@decorators.login_required
+@login_required
 def post_account_name():
     return publisher_views.post_account_name()
 
 
 @app.route('/account/snaps/<snap_name>/measure')
-@decorators.login_required
+@login_required
 def publisher_snap_measure(snap_name):
     return publisher_views.publisher_snap_measure(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/market', methods=['GET'])
-@decorators.login_required
+@login_required
 def get_market_snap(snap_name):
     return publisher_views.get_market_snap(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/release')
-@decorators.login_required
+@login_required
 def snap_release(snap_name):
     return publisher_views.snap_release(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/market', methods=['POST'])
-@decorators.login_required
+@login_required
 def post_market_snap(snap_name):
     return publisher_views.post_market_snap(snap_name)

--- a/decorators.py
+++ b/decorators.py
@@ -12,68 +12,9 @@ def login_required(func):
     to login page if not.
     """
     @functools.wraps(func)
-    @private_cache_headers
     def is_user_logged_in(*args, **kwargs):
         if not authentication.is_authenticated(flask.session):
             return flask.redirect('login?next=' + flask.request.path)
 
         return func(*args, **kwargs)
     return is_user_logged_in
-
-
-def _cache_headers_decorator(route_function, cache_headers):
-    """
-    Return a decorator function to add a set of Cache-Control headers
-    to the response
-    """
-
-    @functools.wraps(route_function)
-    def decorated_function(*args, **kwargs):
-        response = flask.make_response(
-            route_function(*args, **kwargs)
-        )
-
-        if response.status_code == 200:
-            # Only add caching headers to successful responses
-            response.headers['Cache-Control'] = ', '.join(cache_headers)
-
-        return response
-
-    return decorated_function
-
-
-def public_cache_headers(route_function):
-    """
-    Add standard caching headers to a public route:
-
-    - Cache pages for 30 seconds
-      (allows Squid to take significant load of the app)
-    - Serve stale pages while revalidating the cache for 5 minutes
-      (allows Squid to response instantly while doing cache refreshes)
-    - Show stale pages if the app is erroring for 1 day
-      (gives us a 1 day buffer to fix errors before they are publicly visible)
-    """
-
-    cache_headers = [
-        'public',
-        'max-age=61',
-        'stale-while-revalidate=300',
-        'stale-if-error=86400',
-    ]
-
-    return _cache_headers_decorator(route_function, cache_headers)
-
-
-def private_cache_headers(route_function):
-    """
-    Add standard caching headers to a private route:
-
-    - Most importantly, add "private"
-      (to prevent responses going where they shouldn't)
-    """
-
-    cache_headers = [
-        'private',  # Important
-    ]
-
-    return _cache_headers_decorator(route_function, cache_headers)


### PR DESCRIPTION
Make the logic to apply Cache-Control headers apply to *all* responses,
and use the existence of a `flask.session` cookie to decide whether it's
"public" or "private".

QA
--

``` bash
./run
```

Now check the headers in the command-line:

``` bash
$ curl -I http://0.0.0.0:8004 | grep 'Cache'
Cache-Control: max-age=61, stale-while-revalidate=300, stale-if-error=86400, public
```

Now open the browser, go to the homepage, check the "network" tab in developer tools to inspect the response headers. Check again the cache-control is as above.

Now to go http://0.0.0.0:8004/account and login. Check the response headers now have "Cache-Control: private".

Go back to the homepage, check the response headers, should still have "Cache-Control: private".