### PR TITLE
Remove license field from market page

### DIFF
--- a/templates/publisher/market.html
+++ b/templates/publisher/market.html
@@ -189,21 +189,6 @@
 
           <div class="row">
             <div class="col-2">
-              <label>License: </label>
-            </div>
-            <div class="col-8">
-              {{ license }}
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-12">
-              <hr />
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-2">
               <label class="p-label--grid-baseline">Developer website: </label>
             </div>
             <div class="col-8">


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/531

- Removed non-editable 'License' on the market page.

# QA

- Pull the branch
- `./run`
- Visit `/account/snaps/<snap_name>/market`
- Make sure license decleration isn't there