### PR TITLE
Open tutorial in new window

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -25,7 +25,16 @@ My snaps — Linux software in the Snap Store
       <div class="col-6">
         <h3 class="p-heading--five">'Hello world' with snapcraft</h3>
         <p>Try this 15 minute tutorial to get to know the basics of the snap format and snapcraft tool.</p>
-        <p><a href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap#0" class="p-button--neutral p-link--external">Try the tutorial</a></p>
+        <p>
+          <a
+            href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap#0"
+            rel="noreferrer noopener"
+            target="_blank"
+            class="p-button--neutral p-link--external"
+          >
+            Try the tutorial
+          </a>
+        </p>
       </div>
       <div class="col-6">
         <h3 class="p-heading--five">Publish a snap with the tools you know</h3>


### PR DESCRIPTION
# Done

Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/358
- Added `target="_blank"` to tutorials link on 'no snaps' page

# QA

- Pull the branch
- `./run`
- Create new account/ modify `publisher/views.py` for a user/ object with no snaps
- Visit http://0.0.0.0:8004/account/snaps
- Click the 'Try the tutorial' link, it should open a tutorial in a new window/ tab.