### PR TITLE
Highlight 'My snaps' and all sub-pages

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -99,6 +99,7 @@ def get_account_snaps():
             flask_user = flask.session['openid']
 
             context = {
+                'page_slug': 'my-snaps',
                 'snaps': user_snaps,
                 'current_user': flask_user['nickname'],
                 'registered_snaps': registered_snaps,
@@ -279,6 +280,7 @@ def publisher_snap_measure(snap_name):
             territories_total += 1
 
     context = {
+        'page_slug': 'my-snaps',
         # Data direct from details API
         'snap_name': snap_name,
         'snap_title': details['title'],
@@ -334,6 +336,7 @@ def get_market_snap(snap_name):
         if m['type'] == 'screenshot']
 
     context = {
+        "page_slug": 'my-snaps',
         "snap_id": snap_details['snap_id'],
         "snap_name": snap_details['snap_name'],
         "snap_title": snap_details['title'],
@@ -385,6 +388,7 @@ def snap_release(snap_name):
 
     return flask.render_template(
         'publisher/release.html',
+        page_slug='my-snaps',
         snap_name=snap_name,
         status=status_json,
     )
@@ -577,6 +581,7 @@ def post_market_snap(snap_name):
                 if m['type'] == 'screenshot']
 
             context = {
+                "page_slug": 'my-snaps',
                 # read-only values from details API
                 "snap_id": snap_details['snap_id'],
                 "snap_name": snap_details['snap_name'],

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -21,7 +21,9 @@
           </a>
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
-        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://dashboard.snapcraft.io/snaps">My snaps</a></li>
+        <li class="p-navigation__link" role="menuitem">
+          <a class="p-link--external{% if page_slug and page_slug == 'my-snaps' %} is-selected{% endif %}" href="https://dashboard.snapcraft.io/snaps">My snaps</a>
+        </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
         <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
       </ul>


### PR DESCRIPTION
# Done

Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/353
- Added `page_slug: 'my-snaps'` to each context where required
- Added `is-selected` class if the navigation item should be selected

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps, http://0.0.0.0:8004/account/snaps/<snap_name>/market, https://0.0.0.0:8004/account/snaps/<snap_name>/measure ensure 'My snaps' in the header is highlighted on each page!