### PR TITLE
Dropped the word 'devices' from tooltip

### DIFF
--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -80,7 +80,7 @@ export default function renderMap(el, snapData) {
 
           let content = ['<span class="u-no-margin--top">', countrySnapData.name];
           if (countrySnapData['number_of_users'] !== undefined) {
-            content.push(`<br />${countrySnapData['number_of_users']} active devices`);
+            content.push(`<br />${countrySnapData['number_of_users']} active`);
           }
           content.push('</span>');
           tooltipMsg.html(


### PR DESCRIPTION
# Done

Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/323
- Removed the word 'devices' from the territories tooltip

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/<snap_name>/measure where <snap_name> is the name of a snap with users
- Make sure the tooltip says 'x active'