### PR TITLE
Changes “Hello world” tutorial link

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -23,14 +23,12 @@ My snaps — Linux software in the Snap Store
     </div>
     <div class="row">
       <div class="col-6">
-        <h3 class="p-heading--five">'Hello world' with snapcraft</h3>
-        <p>Try this 15 minute tutorial to get to know the basics of the snap format and snapcraft tool.</p>
+        <h3 class="p-heading--five">“Hello world” with snapcraft</h3>
+        <p>Get to know the basics of <code>snapcraft</code> and the snap format.</p>
         <p>
           <a
-            href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap#0"
-            rel="noreferrer noopener"
-            target="_blank"
-            class="p-button--neutral p-link--external"
+            href="https://docs.snapcraft.io/build-snaps/your-first-snap"
+            class="p-button--neutral"
           >
             Try the tutorial
           </a>


### PR DESCRIPTION
Changes the link to point at [the “Build your first snap” hello world tutorial](https://docs.snapcraft.io/build-snaps/your-first-snap) instead of [the “Create your first snap” hello world tutorial](https://tutorials.ubuntu.com/tutorial/create-your-first-snap).

Since the link is now to a page on snapcraft.io, removes the external-link icon.

Fixes [snapcraft-design#420](https://github.com/CanonicalLtd/snapcraft-design/issues/420).