### PR TITLE
Market > Listings, Measure > Metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -327,16 +327,16 @@ def post_account_name():
     return publisher_views.post_account_name()
 
 
-@app.route('/account/snaps/<snap_name>/measure')
+@app.route('/account/snaps/<snap_name>/metrics')
 @login_required
-def publisher_snap_measure(snap_name):
-    return publisher_views.publisher_snap_measure(snap_name)
+def publisher_snap_metrics(snap_name):
+    return publisher_views.publisher_snap_metrics(snap_name)
 
 
-@app.route('/account/snaps/<snap_name>/market', methods=['GET'])
+@app.route('/account/snaps/<snap_name>/listing', methods=['GET'])
 @login_required
-def get_market_snap(snap_name):
-    return publisher_views.get_market_snap(snap_name)
+def get_listing_snap(snap_name):
+    return publisher_views.get_listing_snap(snap_name)
 
 
 @app.route('/account/snaps/<snap_name>/release')
@@ -345,7 +345,23 @@ def snap_release(snap_name):
     return publisher_views.snap_release(snap_name)
 
 
-@app.route('/account/snaps/<snap_name>/market', methods=['POST'])
+@app.route('/account/snaps/<snap_name>/listing', methods=['POST'])
 @login_required
-def post_market_snap(snap_name):
-    return publisher_views.post_market_snap(snap_name)
+def post_listing_snap(snap_name):
+    return publisher_views.post_listing_snap(snap_name)
+
+
+@app.route('/account/snaps/<snap_name>/market')
+@login_required
+def get_market_snap(snap_name):
+    return flask.redirect(
+        "/account/snaps/{snap_name}/listing".format(
+            snap_name=snap_name))
+
+
+@app.route('/account/snaps/<snap_name>/measure')
+@login_required
+def get_measure_snap(snap_name):
+    return flask.redirect(
+        "/account/snaps/{snap_name}/metrics".format(
+            snap_name=snap_name))

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -171,12 +171,12 @@ def post_account_name():
         return flask.redirect('/account/username')
 
 
-def publisher_snap_measure(snap_name):
+def publisher_snap_metrics(snap_name):
     """
-    A view to display the snap measure page for specific snaps.
+    A view to display the snap metrics page for specific snaps.
 
     This queries the snapcraft API (api.snapcraft.io) and passes
-    some of the data through to the publisher/measure.html template,
+    some of the data through to the publisher/metrics.html template,
     with appropriate sanitation.
     """
     try:
@@ -317,12 +317,12 @@ def publisher_snap_measure(snap_name):
     }
 
     return flask.render_template(
-        'publisher/measure.html',
+        'publisher/metrics.html',
         **context
     )
 
 
-def get_market_snap(snap_name):
+def get_listing_snap(snap_name):
     try:
         snap_details = api.get_snap_info(snap_name, flask.session)
     except ApiTimeoutError as api_timeout_error:
@@ -379,7 +379,7 @@ def get_market_snap(snap_name):
     }
 
     return flask.render_template(
-        'publisher/market.html',
+        'publisher/listing.html',
         **context
     )
 
@@ -445,7 +445,7 @@ def build_image_info(image, image_type):
     }
 
 
-def post_market_snap(snap_name):
+def post_listing_snap(snap_name):
     changes = None
     changed_fields = flask.request.form.get('changes')
 
@@ -651,7 +651,7 @@ def post_market_snap(snap_name):
             }
 
             return flask.render_template(
-                'publisher/market.html',
+                'publisher/listing.html',
                 **context
             )
 
@@ -660,7 +660,7 @@ def post_market_snap(snap_name):
         flask.flash("No changes to save.", 'information')
 
     return flask.redirect(
-        "/account/snaps/{snap_name}/market".format(
+        "/account/snaps/{snap_name}/listing".format(
             snap_name=snap_name
         )
     )

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -14,28 +14,28 @@
       <ul class="p-tabs__list u-float--right" role="tablist">
         <li class="p-tabs__item" role="presentation">
           <a
-            href="/account/snaps/{{ snap_name }}/market"
+            href="/account/snaps/{{ snap_name }}/listing"
             class="p-tabs__link"
             tabindex="0"
             role="tab"
-            {% if selected_tab == 'market' %}
+            {% if selected_tab == 'listing' %}
           aria-selected="true"
           {% endif %}
           >
-          Market
+          Listing
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
           <a
-            href="/account/snaps/{{ snap_name }}/measure"
+            href="/account/snaps/{{ snap_name }}/metrics"
             class="p-tabs__link"
             tabindex="0"
             role="tab"
-            {% if selected_tab == 'measure' %}
+            {% if selected_tab == 'metrics' %}
           aria-selected="true"
           {% endif %}
           >
-          Measure
+          Metrics
           </a>
         </li>
       </ul>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -74,7 +74,7 @@ My snaps — Linux software in the Snap Store
             <p>
               You've just released a snap to the "{{ snaps[snap].latest_revisions[0].channels[0] }}" channel!<br />
               Want to improve the listing in stores? You can add an icon and screenshots.<br />
-              <a href="/account/snaps/{{ snap }}/market" class="p-button--neutral">Go to market listing</a>
+              <a href="/account/snaps/{{ snap }}/listing" class="p-button--neutral">Go to listing listing</a>
             </p>
           </div>
           <div class="col-3" style="margin-top: -25px">
@@ -99,7 +99,7 @@ My snaps — Linux software in the Snap Store
           {% for snap in snaps|sort %}
             <tr>
               <td>
-                <a href="/account/snaps/{{snap}}/market" class="u-no-margin--top u-vertically-center">
+                <a href="/account/snaps/{{snap}}/listing" class="u-no-margin--top u-vertically-center">
                   {% if snaps[snap].icon_url %}
                     <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
                   {% else %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -1,12 +1,12 @@
 {% extends "_layout.html" %}
 
 {% block title %}
-  Market details for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}
+  Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}
 {% endblock %}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    {% set selected_tab='market' %}
+    {% set selected_tab='listing' %}
     {% include "publisher/_header.html" %}
 
     <div class="p-strip is-shallow">
@@ -17,7 +17,7 @@
 
           <div class="row">
             <div class="col-12 u-align--right">
-                <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/market">Revert</a>
+                <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
                 <input type="submit" class="p-button--positive js-market-submit" name="submit_apply" value="Apply"/>
                 <hr />
             </div>

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -6,7 +6,7 @@ Publisher metrics for {{ snap_title }}
 
 {% block content %}
   <div id="main-content" class="u-no-margin--top">
-    {% set selected_tab='measure' %}
+    {% set selected_tab='metrics' %}
     {% include "publisher/_header.html" %}
 
     {% if nodata %}

--- a/tests/test_get_metrics.py
+++ b/tests/test_get_metrics.py
@@ -5,15 +5,15 @@ import responses
 from tests.endpoint_testing import BaseTestCases
 
 
-class MeasurePageNotAuth(BaseTestCases.EndpointGetLoggedOut):
+class MetricsPageNotAuth(BaseTestCases.EndpointGetLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = '/account/snaps/{}/measure'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/metrics'.format(snap_name)
 
         super().setUp(snap_name, endpoint_url)
 
 
-class GetMeasureGetInfoPage(BaseTestCases.EndpointGetLoggedIn):
+class GetMetricsGetInfoPage(BaseTestCases.EndpointGetLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
 
@@ -21,12 +21,12 @@ class GetMeasureGetInfoPage(BaseTestCases.EndpointGetLoggedIn):
         api_url = api_url.format(
             snap_name
         )
-        endpoint_url = '/account/snaps/{}/measure'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/metrics'.format(snap_name)
 
         super().setUp(snap_name, api_url, endpoint_url)
 
 
-class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
+class GetMetricsPostMetrics(BaseTestCases.BaseAppTesting):
     def setUp(self):
         snap_name = "test-snap"
 
@@ -46,7 +46,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             json=payload, status=200)
 
         api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/metrics'
-        endpoint_url = '/account/snaps/{}/measure'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/metrics'.format(snap_name)
 
         super().setUp(snap_name, api_url, endpoint_url)
         self.authorization = self._log_in(self.client)
@@ -54,7 +54,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
     def _get_redirect(self):
         return (
             'http://localhost'
-            '/account/snaps/{}/measure'
+            '/account/snaps/{}/metrics'
         ).format(self.snap_name)
 
     @responses.activate
@@ -135,7 +135,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '30d')
@@ -197,7 +197,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '30d')
@@ -259,7 +259,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '7d')
@@ -324,7 +324,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '3m')
@@ -386,7 +386,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '7d')
@@ -448,7 +448,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '30d')
@@ -513,7 +513,7 @@ class GetMeasurePostMeasure(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/measure.html')
+        self.assert_template_used('publisher/metrics.html')
         self.assert_context('snap_name', self.snap_name)
         self.assert_context('snap_title', 'Test Snap')
         self.assert_context('metric_period', '3m')

--- a/tests/tests_listing.py
+++ b/tests/tests_listing.py
@@ -4,15 +4,15 @@ import responses
 from tests.endpoint_testing import BaseTestCases
 
 
-class MarketPageNotAuth(BaseTestCases.EndpointGetLoggedOut):
+class ListingPageNotAuth(BaseTestCases.EndpointGetLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/listing'.format(snap_name)
 
         super().setUp(snap_name, endpoint_url)
 
 
-class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
+class GetListingPage(BaseTestCases.EndpointGetLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
 
@@ -20,7 +20,7 @@ class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
         api_url = api_url.format(
             snap_name
         )
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/listing'.format(snap_name)
 
         super().setUp(snap_name, api_url, endpoint_url)
 
@@ -83,7 +83,7 @@ class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
             self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
-        self.assert_template_used('publisher/market.html')
+        self.assert_template_used('publisher/listing.html')
 
         self.assert_context('snap_id', 'id')
         self.assert_context('snap_name', snap_name)
@@ -138,7 +138,7 @@ class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
             self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
-        self.assert_template_used('publisher/market.html')
+        self.assert_template_used('publisher/listing.html')
 
         self.assert_context('icon_url', 'this is a url')
 
@@ -181,7 +181,7 @@ class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
             self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
-        self.assert_template_used('publisher/market.html')
+        self.assert_template_used('publisher/listing.html')
 
         self.assert_context('screenshot_urls', ['this is a url'])
 

--- a/tests/tests_post_binary_metadata.py
+++ b/tests/tests_post_binary_metadata.py
@@ -5,11 +5,11 @@ import io
 from tests.endpoint_testing import BaseTestCases
 
 
-class PostBinaryMetadataMarketPage(BaseTestCases.BaseAppTesting):
+class PostBinaryMetadataListingPage(BaseTestCases.BaseAppTesting):
     def setUp(self):
         self.snap_id = 'complexId'
         snap_name = "test-snap"
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/listing'.format(snap_name)
 
         super().setUp(snap_name, None, endpoint_url)
         self.authorization = self._log_in(self.client)
@@ -17,7 +17,7 @@ class PostBinaryMetadataMarketPage(BaseTestCases.BaseAppTesting):
     def _get_redirect(self):
         return (
             'http://localhost'
-            '/account/snaps/{}/market'
+            '/account/snaps/{}/listing'
         ).format(self.snap_name)
 
     @responses.activate

--- a/tests/tests_post_listing.py
+++ b/tests/tests_post_listing.py
@@ -5,19 +5,19 @@ import json
 from tests.endpoint_testing import BaseTestCases
 
 
-class PostMarketPageNotAuth(BaseTestCases.EndpointPostLoggedOut):
+class PostListingPageNotAuth(BaseTestCases.EndpointPostLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/listing'.format(snap_name)
 
         super().setUp(snap_name, endpoint_url)
 
 
-class PostMetadataMarketPage(BaseTestCases.BaseAppTesting):
+class PostMetadataListingPage(BaseTestCases.BaseAppTesting):
     def setUp(self):
         self.snap_id = 'complexId'
         snap_name = "test-snap"
-        endpoint_url = '/account/snaps/{}/market'.format(snap_name)
+        endpoint_url = '/account/snaps/{}/listing'.format(snap_name)
 
         super().setUp(snap_name, None, endpoint_url)
         self.authorization = self._log_in(self.client)
@@ -25,7 +25,7 @@ class PostMetadataMarketPage(BaseTestCases.BaseAppTesting):
     def _get_redirect(self):
         return (
             'http://localhost'
-            '/account/snaps/{}/market'
+            '/account/snaps/{}/listing'
         ).format(self.snap_name)
 
     @responses.activate
@@ -364,7 +364,7 @@ class PostMetadataMarketPage(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/market.html')
+        self.assert_template_used('publisher/listing.html')
 
         self.assert_context('snap_id', self.snap_id)
         self.assert_context('snap_name', self.snap_name)
@@ -464,7 +464,7 @@ class PostMetadataMarketPage(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/market.html')
+        self.assert_template_used('publisher/listing.html')
 
         # Not updatable fields
         self.assert_context('snap_id', self.snap_id)
@@ -557,7 +557,7 @@ class PostMetadataMarketPage(BaseTestCases.BaseAppTesting):
             self.authorization, called.request.headers.get('Authorization'))
 
         self.assertEqual(response.status_code, 200)
-        self.assert_template_used('publisher/market.html')
+        self.assert_template_used('publisher/listing.html')
 
         self.assert_context('field_errors', {
             'description': 'error message'

--- a/tests/tests_publisher.py
+++ b/tests/tests_publisher.py
@@ -66,11 +66,11 @@ class PublisherPage(TestCase):
         return get_authorization_header(
             root.serialize(), discharge.serialize())
 
-    def test_snap_measure_not_logged_in(self):
-        response = self.client.get('/account/snaps/lxd/measure')
+    def test_snap_metrics_not_logged_in(self):
+        response = self.client.get('/account/snaps/lxd/metrics')
         self.assertEqual(302, response.status_code)
         self.assertEqual(
-            'http://localhost/login?next=/account/snaps/lxd/measure',
+            'http://localhost/login?next=/account/snaps/lxd/metrics',
             response.location)
 
     def test_username_not_logged_in(self):


### PR DESCRIPTION
# Done

- Renam the `market` endpoint `listing`
- Rename `market.html` to `listing.html`
- Rename the `measure` endpoint `metrics`
- Rename `measure.html` to `metrics.html`
- Update python function names
- Update tests
- Update references in templates

# Not done

- Update JS variables and function names

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account and click around:
- There should be no reference to 'market' or 'measure'
- Visit http://0.0.0.0:8004/account/snaps/<snap_name>/market and http://0.0.0.0:8004/account/snaps/<snap_name>/measure, you should be redirected to the appropriate page