### PR TITLE
Get channel map and send to template

### DIFF
--- a/modules/public/api.py
+++ b/modules/public/api.py
@@ -15,15 +15,16 @@ SNAP_DETAILS_URL = ''.join([
     SNAPCRAFT_IO_API,
     'snaps/details/{snap_name}',
     '?channel=stable',
-    '&fields=snap_id,package_name,title,summary,description,license,contact,'
-    'website,publisher,prices,media,'
+    '&fields=snap_id,package_name,title,summary,description,license,contact,',
+    'website,publisher,prices,media,',
     # Released (stable) revision fields will eventually be replaced by
     # `channel_maps_list` contextual information.
-    'revision,version,binary_filesize,last_updated'
+    'revision,version,binary_filesize,last_updated,',
+    'channel_maps_list'
 ])
 DETAILS_QUERY_HEADERS = {
     'X-Ubuntu-Series': '16',
-    'X-Ubuntu-Architecture': 'amd64',
+    'X-Ubuntu-Architecture': 'any',
 }
 
 SNAP_METRICS_URL = ''.join([

--- a/modules/public/logic.py
+++ b/modules/public/logic.py
@@ -281,3 +281,45 @@ def split_description_into_paragraphs(unformatted_description):
         formatted_paragraphs.append(paragraph.replace('\n', '<br />'))
 
     return formatted_paragraphs
+
+
+def convert_channel_maps(channel_maps_list):
+    """
+    Converts channel maps list to format easier to manipulate
+
+    Example:
+    - Input:
+    [
+      {
+        'architecture': 'arch'
+        'map': [{'info': 'release', ...}, ...],
+        'track': 'track 1'
+      },
+      ...
+    ]
+    - Output:
+    {
+      'arch': {
+        'track 1': [{'info': 'release', ...}, ...],
+        ...
+      },
+      ...
+    }
+
+    :param channel_maps_list: The channel maps list returned by the API
+
+    :returns: The channel maps reshaped
+    """
+    channel_maps = {}
+    for channel_map in channel_maps_list:
+        arch = channel_map.get('architecture')
+        track = channel_map.get('track')
+        if arch not in channel_maps:
+            channel_maps[arch] = {}
+        channel_maps[arch][track] = []
+
+        for channel in channel_map['map']:
+            if channel.get('info'):
+                channel_maps[arch][track].append(channel)
+
+    return channel_maps

--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -170,8 +170,10 @@ def snap_details(snap_name):
         flask.abort(502, str(api_error))
 
     formatted_paragraphs = logic.split_description_into_paragraphs(
-        details['description']
-    )
+        details['description'])
+
+    channel_maps_list = logic.convert_channel_maps(
+        details.get('channel_maps_list'))
 
     status_code = 200
     country_data = []
@@ -222,6 +224,7 @@ def snap_details(snap_name):
         'website': details.get('website'),
         'summary': details['summary'],
         'description_paragraphs': formatted_paragraphs,
+        'channel_map': channel_maps_list,
 
         # Transformed API data
         'filesize': humanize.naturalsize(details['binary_filesize']),

--- a/tests/tests_public_logic.py
+++ b/tests/tests_public_logic.py
@@ -1,0 +1,81 @@
+import unittest
+import modules.public.logic as logic
+
+
+class PublicLogicTest(unittest.TestCase):
+
+    # convert_channel_maps
+    # ===
+    def test_empty_channel_map(self):
+        channel_maps_list = []
+        result = logic.convert_channel_maps(channel_maps_list)
+
+        self.assertEqual(result, {})
+
+    def test_one_track_channel_map(self):
+        channel_maps_list = [
+            {
+                'architecture': 'arch',
+                'map': [{'info': 'release'}],
+                'track': 'track'
+            }
+        ]
+
+        result = logic.convert_channel_maps(channel_maps_list)
+        expected_result = {
+            'arch': {
+                'track': [{'info': 'release'}]
+            }
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_multiple_track_same_arch_channel_map(self):
+        channel_maps_list = [
+            {
+                'architecture': 'arch',
+                'map': [{'info': 'release'}],
+                'track': 'track'
+            },
+            {
+                'architecture': 'arch',
+                'map': [{'info': 'release'}],
+                'track': 'track1'
+            }
+        ]
+
+        result = logic.convert_channel_maps(channel_maps_list)
+        expected_result = {
+            'arch': {
+                'track': [{'info': 'release'}],
+                'track1': [{'info': 'release'}]
+            }
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_multiple_track_different_arch_channel_map(self):
+        channel_maps_list = [
+            {
+                'architecture': 'arch',
+                'map': [{'info': 'release'}],
+                'track': 'track'
+            },
+            {
+                'architecture': 'arch1',
+                'map': [{'info': 'release'}],
+                'track': 'track'
+            }
+        ]
+
+        result = logic.convert_channel_maps(channel_maps_list)
+        expected_result = {
+            'arch': {
+                'track': [{'info': 'release'}],
+            },
+            'arch1': {
+                'track': [{'info': 'release'}],
+            }
+        }
+
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
# Summary

Send channel map to template on snap details page

# QA 

- `./run`
- 0.0.0.0:8004/toto
- should work

This is the structure sent to the template: https://pastebin.canonical.com/p/d4qs6fMRZJ/