### PR TITLE
Handle errors account details and snap page

### DIFF
--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -64,12 +64,11 @@ def process_response(response):
 
     if not response.ok:
         if 'error_list' in body:
-            api_error_exception = ApiResponseErrorList(
+            raise ApiResponseErrorList(
                 'The api returned a list of errors',
                 response.status_code,
                 body['error_list']
             )
-            raise api_error_exception
         else:
             raise ApiResponseError(
                 'Unknown error from api',
@@ -91,16 +90,7 @@ def get_authorization_header(session):
 
 
 def get_account(session):
-    authorization = authentication.get_authorization_header(
-        session['macaroon_root'],
-        session['macaroon_discharge']
-    )
-
-    headers = {
-        'X-Ubuntu-Series': '16',
-        'X-Ubuntu-Architecture': 'amd64',
-        'Authorization': authorization
-    }
+    headers = get_authorization_header(session)
 
     response = cache.get(
         url=ACCOUNT_URL,
@@ -111,7 +101,7 @@ def get_account(session):
     if authentication.is_macaroon_expired(response.headers):
         raise MacaroonRefreshRequired()
 
-    return response.json()
+    return process_response(response)
 
 
 def get_agreement(session):

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -129,29 +129,6 @@ class BaseTestCases:
             assert response.status_code == 502
 
         @responses.activate
-        def test_page_not_found(self):
-            payload = {
-                'error_list': []
-            }
-            responses.add(
-                responses.GET, self.api_url,
-                json=payload, status=404)
-
-            response = self.client.get(self.endpoint_url)
-
-            self.assertEqual(1, len(responses.calls))
-            called = responses.calls[0]
-            self.assertEqual(
-                self.api_url,
-                called.request.url)
-            self.assertEqual(
-                self.authorization,
-                called.request.headers.get('Authorization'))
-
-            assert response.status_code == 404
-            self.assert_template_used('404.html')
-
-        @responses.activate
         def test_broken_json(self):
             # To test this I return no json from the server, this makes the
             # call to the function response.json() raise a ValueError exception
@@ -242,3 +219,63 @@ class BaseTestCases:
 
             assert response.status_code == 302
             assert response.location == self._get_location()
+
+        @responses.activate
+        def test_account_not_signed_agreement_logged_in(self):
+            payload = {
+                'error_list': [
+                    {
+                        'code': 'user-not-ready',
+                        'message': 'has not signed agreement'
+                    }
+                ]
+            }
+            responses.add(
+                responses.GET, self.api_url,
+                json=payload, status=403)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            self.assertEqual(302, response.status_code)
+            self.assertEqual(
+                'http://localhost/account/agreement',
+                response.location)
+
+        @responses.activate
+        def test_account_no_username_logged_in(self):
+            payload = {
+                'error_list': [
+                    {
+                        'code': 'user-not-ready',
+                        'message': 'missing namespace'
+                    }
+                ]
+            }
+            responses.add(
+                responses.GET, self.api_url,
+                json=payload, status=403)
+
+            response = self.client.get(self.endpoint_url)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            self.assertEqual(302, response.status_code)
+            self.assertEqual(
+                'http://localhost/account/username',
+                response.location)

--- a/tests/tests_account_details.py
+++ b/tests/tests_account_details.py
@@ -1,225 +1,48 @@
 import unittest
-
-import pymacaroons
 import responses
-
-from app import app
-from flask_testing import TestCase
-from modules.authentication import get_authorization_header
+from tests.endpoint_testing import BaseTestCases
 
 
 # Make sure tests fail on stray responses.
 responses.mock.assert_all_requests_are_fired = True
 
 
-class AccountDetailsPage(TestCase):
+class AccountDetailsNotAuth(BaseTestCases.EndpointGetLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/details'
 
-    render_templates = False
+        super().setUp(None, endpoint_url)
 
-    def create_app(self):
-        app.config['WTF_CSRF_METHODS'] = []
-        app.testing = True
 
-        return app
+class AccountDetailsPage(BaseTestCases.EndpointGetLoggedIn):
+    def setUp(self):
+        api_url = 'https://dashboard.snapcraft.io/dev/api/account'
+        endpoint_url = '/account/details'
 
-    def _log_in(self, client):
-        """Emulates test client login in the store.
-
-        Fill current session with `openid`, `macaroon_root` and
-        `macaroon_discharge`.
-
-        Return the expected `Authorization` header for further verification in
-        API requests.
-        """
-        # Basic root/discharge macaroons pair.
-        root = pymacaroons.Macaroon('test', 'testing', 'a_key')
-        root.add_third_party_caveat('3rd', 'a_caveat-key', 'a_ident')
-        discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
-
-        with client.session_transaction() as s:
-            s['openid'] = {
-                'image': None,
-                'nickname': 'Toto',
-                'fullname': 'El Toto',
-                'email': 'testing@testing.com'
-            }
-            s['macaroon_root'] = root.serialize()
-            s['macaroon_discharge'] = discharge.serialize()
-
-        return get_authorization_header(
-            root.serialize(), discharge.serialize())
-
-    def test_account_not_logged_in(self):
-        # `account` page redirects unauthenticated access to `login`
-        # with the appropriate `next` path.
-        response = self.client.get('/account/details')
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/login?next=/account/details',
-            response.location)
+        super().setUp(None, api_url, endpoint_url)
 
     @responses.activate
-    def test_account_logged_in(self):
+    def test_account(self):
         responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            responses.GET, self.api_url,
             json={}, status=200)
 
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/details')
-        self.assertEqual(200, response.status_code)
-        # Add pyQuery basic context checks
+        response = self.client.get(self.endpoint_url)
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
-        assert response.status_code == 200
+        self.assertEqual(200, response.status_code)
         self.assert_template_used('publisher/account-details.html')
         self.assert_context('username', 'Toto')
         self.assert_context('displayname', 'El Toto')
         self.assert_context('email', 'testing@testing.com')
         self.assert_context('image', None)
-
-    @responses.activate
-    def test_account_not_signed_agreement_logged_in(self):
-        payload = {
-            'error_list': [
-                {
-                    'code': 'user-not-ready',
-                    'message': 'has not signed agreement'
-                }
-            ]
-        }
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json=payload, status=403)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/details')
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/agreement',
-            response.location)
-
-    @responses.activate
-    def test_account_no_username_logged_in(self):
-        payload = {
-            'error_list': [
-                {
-                    'code': 'user-not-ready',
-                    'message': 'missing namespace'
-                }
-            ]
-        }
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json=payload, status=403)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/details')
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/username',
-            response.location)
-
-    @responses.activate
-    def test_account_custom_error_logged_in(self):
-        payload = {
-            'error_list': [
-                {
-                    'code': 'custom-error',
-                    'message': 'great message'
-                }
-            ]
-        }
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json=payload, status=403)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/details')
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 200
-        self.assert_template_used('publisher/account-details.html')
-        self.assert_context('error_list', payload['error_list'])
-
-    @responses.activate
-    def test_account_expired_macaroon_logged_in(self):
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json={}, status=400,
-            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
-        responses.add(
-            responses.POST, 'https://login.ubuntu.com/api/v2/tokens/refresh',
-            json={'discharge_macaroon': 'macaroon'}, status=200)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/details')
-
-        self.assertEqual(2, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-        called = responses.calls[1]
-        self.assertEqual(
-            'https://login.ubuntu.com/api/v2/tokens/refresh',
-            called.request.url)
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/details',
-            response.location)
-
-    @responses.activate
-    def test_account_api_failure(self):
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json={}, status=500)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/details')
-        self.assertEqual(200, response.status_code)
-
-        self.assertEqual(1, len(responses.calls))
-        [account_call] = responses.calls
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            account_call.request.url)
-        self.assertEqual(
-            authorization, account_call.request.headers.get('Authorization'))
 
 
 if __name__ == '__main__':

--- a/tests/tests_account_snaps.py
+++ b/tests/tests_account_snaps.py
@@ -1,62 +1,24 @@
 import unittest
-
-import pymacaroons
 import responses
-
-from app import app
-from flask_testing import TestCase
-from modules.authentication import get_authorization_header
-
+from tests.endpoint_testing import BaseTestCases
 
 # Make sure tests fail on stray responses.
 responses.mock.assert_all_requests_are_fired = True
 
 
-class AccountSnapsPage(TestCase):
+class AccountSnapsNotAuth(BaseTestCases.EndpointGetLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/snaps'
 
-    render_templates = False
+        super().setUp(None, endpoint_url)
 
-    def create_app(self):
-        app.config['WTF_CSRF_METHODS'] = []
-        app.testing = True
 
-        return app
+class AccountSnapsPage(BaseTestCases.EndpointGetLoggedIn):
+    def setUp(self):
+        api_url = 'https://dashboard.snapcraft.io/dev/api/account'
+        endpoint_url = '/account/snaps'
 
-    def _log_in(self, client):
-        """Emulates test client login in the store.
-
-        Fill current session with `openid`, `macaroon_root` and
-        `macaroon_discharge`.
-
-        Return the expected `Authorization` header for further verification in
-        API requests.
-        """
-        # Basic root/discharge macaroons pair.
-        root = pymacaroons.Macaroon('test', 'testing', 'a_key')
-        root.add_third_party_caveat('3rd', 'a_caveat-key', 'a_ident')
-        discharge = pymacaroons.Macaroon('3rd', 'a_ident', 'a_caveat_key')
-
-        with client.session_transaction() as s:
-            s['openid'] = {
-                'image': None,
-                'nickname': 'Toto',
-                'fullname': 'El Toto',
-                'email': 'testing@testing.com'
-            }
-            s['macaroon_root'] = root.serialize()
-            s['macaroon_discharge'] = discharge.serialize()
-
-        return get_authorization_header(
-            root.serialize(), discharge.serialize())
-
-    def test_account_not_logged_in(self):
-        # `account` page redirects unauthenticated access to `login`
-        # with the appropriate `next` path.
-        response = self.client.get('/account/snaps')
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/login?next=/account/snaps',
-            response.location)
+        super().setUp(None, api_url, endpoint_url)
 
     @responses.activate
     def test_no_snaps(self):
@@ -66,21 +28,20 @@ class AccountSnapsPage(TestCase):
             }
         }
         responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
+        response = self.client.get(self.endpoint_url)
         self.assertEqual(200, response.status_code)
         # Add pyQuery basic context checks
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
         self.assert_template_used('publisher/account-snaps.html')
@@ -101,21 +62,20 @@ class AccountSnapsPage(TestCase):
             }
         }
         responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
+        response = self.client.get(self.endpoint_url)
         self.assertEqual(200, response.status_code)
         # Add pyQuery basic context checks
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
         self.assert_template_used('publisher/account-snaps.html')
@@ -136,21 +96,20 @@ class AccountSnapsPage(TestCase):
             }
         }
         responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
+        response = self.client.get(self.endpoint_url)
         self.assertEqual(200, response.status_code)
         # Add pyQuery basic context checks
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         assert response.status_code == 200
         self.assert_template_used('publisher/account-snaps.html')
@@ -175,21 +134,20 @@ class AccountSnapsPage(TestCase):
             }
         }
         responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
+            responses.GET, self.api_url,
             json=payload, status=200)
 
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
+        response = self.client.get(self.endpoint_url)
         self.assertEqual(200, response.status_code)
         # Add pyQuery basic context checks
 
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
+            self.api_url,
             called.request.url)
         self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
+            self.authorization, called.request.headers.get('Authorization'))
 
         registered_snaps = {
             'test2': {
@@ -210,125 +168,6 @@ class AccountSnapsPage(TestCase):
         self.assert_context('current_user', 'Toto')
         self.assert_context('snaps', uploaded_snaps)
         self.assert_context('registered_snaps', registered_snaps)
-
-    @responses.activate
-    def test_account_not_signed_agreement_logged_in(self):
-        payload = {
-            'error_list': [
-                {
-                    'code': 'user-not-ready',
-                    'message': 'has not signed agreement'
-                }
-            ]
-        }
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json=payload, status=403)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/agreement',
-            response.location)
-
-    @responses.activate
-    def test_account_no_username_logged_in(self):
-        payload = {
-            'error_list': [
-                {
-                    'code': 'user-not-ready',
-                    'message': 'missing namespace'
-                }
-            ]
-        }
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json=payload, status=403)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/username',
-            response.location)
-
-    @responses.activate
-    def test_account_custom_error_logged_in(self):
-        payload = {
-            'error_list': [
-                {
-                    'code': 'custom-error',
-                    'message': 'great message'
-                }
-            ]
-        }
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json=payload, status=403)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-
-        assert response.status_code == 200
-        self.assert_template_used('publisher/account-snaps.html')
-        self.assert_context('error_list', payload['error_list'])
-
-    @responses.activate
-    def test_account_expired_macaroon_logged_in(self):
-        responses.add(
-            responses.GET, 'https://dashboard.snapcraft.io/dev/api/account',
-            json={}, status=400,
-            headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
-        responses.add(
-            responses.POST, 'https://login.ubuntu.com/api/v2/tokens/refresh',
-            json={'discharge_macaroon': 'macaroon'}, status=200)
-
-        authorization = self._log_in(self.client)
-        response = self.client.get('/account/snaps')
-
-        self.assertEqual(2, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/account',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-        called = responses.calls[1]
-        self.assertEqual(
-            'https://login.ubuntu.com/api/v2/tokens/refresh',
-            called.request.url)
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/snaps',
-            response.location)
 
 
 if __name__ == '__main__':

--- a/tests/tests_market.py
+++ b/tests/tests_market.py
@@ -25,6 +25,29 @@ class GetMarketPage(BaseTestCases.EndpointGetLoggedIn):
         super().setUp(snap_name, api_url, endpoint_url)
 
     @responses.activate
+    def test_page_not_found(self):
+        payload = {
+            'error_list': []
+        }
+        responses.add(
+            responses.GET, self.api_url,
+            json=payload, status=404)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization,
+            called.request.headers.get('Authorization'))
+
+        assert response.status_code == 404
+        self.assert_template_used('404.html')
+
+    @responses.activate
     def test_account_logged_in(self):
         snap_name = "test-snap"
 


### PR DESCRIPTION
# Summary

- Handle errors on account endpoint
- handle errors on `/account/snaps` and `/account/details` endpoint
- Update tests by using BaseTesting structure
Fixes canonical-websites/snapcraft.io#539 

# QA

- `./run`
- 0.0.0.0:8004/account/snaps
- 0.0.0.0:8004/account/details
- Try with different accounts (just registered etc.)