### PR TITLE
Sticky Revert and Apply buttons

### DIFF
--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -69,4 +69,16 @@
   .has-counter .p-form-validation__input {
     background-image: none;
   }
+
+  // Stick the Revert, Apply buttons to the top
+  .snapcraft-p-sticky {
+    background: $color-x-light;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+
+    @media screen and (max-width: $breakpoint-x-small) {
+      padding-top: $sp-medium;
+    }
+  }
 }

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -9,17 +9,17 @@
     {% set selected_tab='listing' %}
     {% include "publisher/_header.html" %}
 
-    <div class="p-strip is-shallow">
+    <div class="p-strip is-shallow u-no-padding--top">
         <form id="market-form" method="POST" enctype='multipart/form-data'>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <input type="hidden" name="snap_id" value="{{ snap_id }}" />
           <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>
 
-          <div class="row">
+          <div class="row snapcraft-p-sticky">
             <div class="col-12 u-align--right">
                 <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
                 <input type="submit" class="p-button--positive js-market-submit" name="submit_apply" value="Apply"/>
-                <hr />
+                <hr class="u-no-margin--bottom" />
             </div>
           </div>
 


### PR DESCRIPTION
# Done

Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/377

- Added `snapcraft-p-sticky` class
- Removed some padding/ margins from around the buttons

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/<snap_name>/market
- Scroll down and see the buttons 'stick'

# Screenshot

![screenshot-2018-4-23 market details for lukotron test test](https://user-images.githubusercontent.com/479384/39123116-b9b8f618-46ee-11e8-98bc-fcdd23018255.png)
