### PR TITLE
Improve first snap experience

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -71,14 +71,30 @@ My snaps — Linux software in the Snap Store
             <h3 class="p-heading--four">Congratulations!</h3>
           </div>
           <div class="col-6">
-            <p>
-              You've just released a snap to the "{{ snaps[snap].latest_revisions[0].channels[0] }}" channel!<br />
-              Want to improve the listing in stores? You can add an icon and screenshots.<br />
-              <a href="/account/snaps/{{ snap }}/listing" class="p-button--neutral">Go to listing listing</a>
-            </p>
+            {% if snaps[snap].latest_revisions[0].channels[0] %}
+              <p>
+                You've just released {{ snap }} to the "{{ snaps[snap].latest_revisions[0].channels[0] }}" channel!
+              </p>
+            {% else %}
+              <p>
+                You've just uploaded {{ snap }}!
+              </p>
+            {% endif %}
+            <ul>
+              <li>
+                Want to improve the listing in stores?
+                <a href="/account/snaps/{{ snap }}/market">Edit Store listing</a>
+              </li>
+              {% if not snap[snap].latest_revisions[0].channels[0] %}
+                <li>
+                  Is your snap ready to release?
+                  <a href="https://docs.snapcraft.io/build-snaps/release" target="_blank">Release it</a>
+                </li>
+              {% endif %}
+            </ul>
           </div>
           <div class="col-3" style="margin-top: -25px">
-            <img src="https://assets.ubuntu.com/v1/320a508d-rocket-icon-with-stars.png" />
+            <img alt="Rocket among stars" src="https://assets.ubuntu.com/v1/320a508d-rocket-icon-with-stars.png" />
           </div>
         </div>
       </section>


### PR DESCRIPTION
# Done

Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/398 and https://github.com/CanonicalLtd/snapcraft-design/issues/402

- Updated messaging for when first snap is uploaded:
 > You've just uploaded <snap_name>!
 > - Is your snap ready to release? Release it [1]
 > - Want to improve the listing in stores? Edit store listing [2]
- Updated messaging for when first snap is release:
 > You've just uploaded <snap_name> to the "<channel>" channel!
 > - Want to improve the listing in stores? Edit store listing [2]

Where [1] links to release docs and [2] links to listings page

# QA

You will need:
- An account with 1 snap that has been uploaded, but not released.
- An account with 1 snap that has been uploaded and released.

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps
- Check the two versions

# Screenshots

## Uploaded snap
![screenshot-2018-4-23 my snaps linux software in the snap store 2](https://user-images.githubusercontent.com/479384/39130783-df911732-4705-11e8-9457-10568fa54f33.png)

## Released snap
![screenshot-2018-4-23 my snaps linux software in the snap store 3](https://user-images.githubusercontent.com/479384/39130792-e2ebdc64-4705-11e8-8843-21979ab330ec.png)
