### PR TITLE
Updates snap details heading for upcomming channel map

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -1,0 +1,50 @@
+@mixin snapcraft-details-heading {
+  .p-snap-heading {
+    display: flex;
+
+    &__icon {
+      align-self: flex-start;
+      flex-shrink: 0;
+      margin-right: $sp-medium;
+      max-height: 3.75rem;
+      max-width: 3.75rem;
+      vertical-align: middle;
+      width: auto;
+    }
+
+    &__title {
+      flex-grow: 1;
+      margin: 0;
+      overflow: hidden;
+    }
+
+    &__name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    &__publisher {
+      margin-top: $sp-x-small;
+    }
+
+    @media screen and (min-width: $breakpoint-medium) {
+      flex-direction: column;
+
+      &__title {
+        margin-top: $sp-x-small;
+      }
+    }
+  }
+
+  .p-snap-install {
+    font-size: .875rem; // same as .p-form-help-text
+
+    .p-code-snippet {
+      margin-top: $sp-x-small;
+    }
+
+    @media screen and (min-width: $breakpoint-medium) {
+      margin-top: $sp-xxx-large;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -111,6 +111,9 @@ $color-navigation-background: #252525;
 @import 'patterns_maas_modal';
 @include maas-p-modal;
 
+@import 'snapcraft_details_heading';
+@include snapcraft-details-heading;
+
 @import 'snapcraft_details_screenshots';
 @include snapcraft-details-screenshots;
 

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -17,41 +17,44 @@
 {% endblock %}
 
 {% block content %}
-  <div class="p-strip is-shallow is-bordered">
+  <div class="p-strip--light is-shallow">
     <div class="row">
-      <div class="col-12">
-        <div class="p-media-object u-no-margin--bottom">
+      <div class="col-5">
+        <div class="p-snap-heading">
           {% if icon_url %}
-            <img class="p-media-object__image--large" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
+            <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
           {% else %}
-            <img class="p-media-object__image--large" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
+            <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
           {% endif %}
-          <div class="p-media-object__details">
-            <h1>{{ snap_title }}</h1>
-            <p class="p-media-object__content--large">{{ publisher }}</p>
-            <div class="row p-media-object__content--large snapcraft-snap-details__snippet">
-              <div class="col-6">
-                <div class="p-code-snippet">
-                  <input
-                    class="p-code-snippet__input"
-                    id="snap-install"
-                    value="sudo snap install {{ package_name }}"
-                    readonly="readonly"
-                  />
-                  <button
-                    class="p-code-snippet__action"
-                    id="copy"
-                    data-clipboard-target="#snap-install">
-                    Copy to clipboard
-                  </button>
-                </div>
-                <p class="p-form-help-text">
-                  To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
-                </p>
-              </div>
-            </div>
+          <div class="p-snap-heading__title">
+            <h1 class="p-heading--two p-snap-heading__name">{{ snap_title }}</h1>
+            <p class="p-snap-heading__publisher">by {{ publisher }}</p>
           </div>
         </div>
+      </div>
+      <div class="col-5">
+        <div class="p-snap-install">
+          <p>Install stable version</p>
+          <div class="p-code-snippet">
+            <input
+              class="p-code-snippet__input"
+              id="snap-install"
+              value="sudo snap install {{ package_name }}"
+              readonly="readonly"
+            />
+            <button
+              class="p-code-snippet__action"
+              id="copy"
+              data-clipboard-target="#snap-install">
+              Copy to clipboard
+            </button>
+          </div>
+          <p class="p-form-help-text">
+            To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
+          </p>
+        </div>
+      </div>
+      <div class="col-2">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #526 

Updates the design of snap details heading section.
Design: [desktop](https://github.com/CanonicalLtd/snapcraft-design/blob/master/public-facing/Channel%20map%20%5Bclosed%5D%20-%20V23.jpg) [mobile](https://github.com/CanonicalLtd/snapcraft-design/blob/master/public-facing/Channel%20map%20%5BClosed%5D%20-%20320%20(Wireframe).png)

## QA

- ./run or http://snapcraft.io-pr-571.run.demo.haus/
- visit couple of snap details pages (featured snaps, etc)
- try different screen sizes
- make sure everything is fine

<img width="1286" alt="screen shot 2018-04-23 at 14 52 44" src="https://user-images.githubusercontent.com/83575/39127684-06bb7514-4706-11e8-9f99-f9966323962e.png">
<img width="1051" alt="screen shot 2018-04-23 at 14 52 29" src="https://user-images.githubusercontent.com/83575/39127685-06d5ed40-4706-11e8-86ed-265e1e6c55f3.png">
<img width="545" alt="screen shot 2018-04-23 at 14 52 12" src="https://user-images.githubusercontent.com/83575/39127686-06f0a842-4706-11e8-81a8-32044d4d0033.png">
