### PR TITLE
Handle errors POST agreement errors

### DIFF
--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -133,7 +133,7 @@ def post_agreement(session, agreed):
     if authentication.is_macaroon_expired(agreement_response.headers):
         raise MacaroonRefreshRequired()
 
-    return agreement_response.json()
+    return process_response(agreement_response)
 
 
 def post_username(session, username):

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -279,3 +279,139 @@ class BaseTestCases:
             self.assertEqual(
                 'http://localhost/account/username',
                 response.location)
+
+    class EndpointPostLoggedIn(BaseAppTesting):
+        def setUp(self, snap_name, api_url, endpoint_url, data):
+            super().setUp(snap_name, api_url, endpoint_url)
+            self.authorization = self._log_in(self.client)
+            self.data = data
+
+        @responses.activate
+        def test_timeout(self):
+            responses.add(
+                responses.POST, self.api_url,
+                body=requests.exceptions.Timeout(), status=504)
+
+            response = self.client.post(self.endpoint_url, data=self.data)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 504
+
+        @responses.activate
+        def test_connection_error(self):
+            responses.add(
+                responses.POST, self.api_url,
+                body=requests.exceptions.ConnectionError(), status=500)
+
+            response = self.client.post(self.endpoint_url, data=self.data)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_broken_json(self):
+            # To test this I return no json from the server, this makes the
+            # call to the function response.json() raise a ValueError exception
+            responses.add(
+                responses.POST, self.api_url,
+                status=500)
+
+            response = self.client.post(self.endpoint_url, data=self.data)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_unknown_error(self):
+            responses.add(
+                responses.POST, self.api_url,
+                json={}, status=500)
+
+            response = self.client.post(self.endpoint_url, data=self.data)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_error_4xx(self):
+            payload = {
+                'error_list': []
+            }
+            responses.add(
+                responses.POST, self.api_url,
+                json=payload, status=400)
+
+            response = self.client.post(self.endpoint_url, data=self.data)
+
+            self.assertEqual(1, len(responses.calls))
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+
+            assert response.status_code == 502
+
+        @responses.activate
+        def test_expired_macaroon(self):
+            responses.add(
+                responses.POST, self.api_url,
+                json={}, status=500,
+                headers={'WWW-Authenticate': 'Macaroon needs_refresh=1'})
+            responses.add(
+                responses.POST,
+                'https://login.ubuntu.com/api/v2/tokens/refresh',
+                json={'discharge_macaroon': 'macaroon'}, status=200)
+
+            response = self.client.post(self.endpoint_url, data=self.data)
+
+            self.assertEqual(2, len(responses.calls))
+
+            called = responses.calls[0]
+            self.assertEqual(
+                self.api_url,
+                called.request.url)
+            self.assertEqual(
+                self.authorization,
+                called.request.headers.get('Authorization'))
+            called = responses.calls[1]
+            self.assertEqual(
+                'https://login.ubuntu.com/api/v2/tokens/refresh',
+                called.request.url)
+
+            assert response.status_code == 302
+            assert response.location == self._get_location()

--- a/tests/tests_agreement.py
+++ b/tests/tests_agreement.py
@@ -1,0 +1,89 @@
+import responses
+
+from tests.endpoint_testing import BaseTestCases
+
+
+class GetAgreementPageNotAuth(BaseTestCases.EndpointGetLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/agreement'
+        super().setUp(None, endpoint_url)
+
+
+class GetAgreementPage(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        endpoint_url = '/account/agreement'
+        super().setUp(None, None, endpoint_url)
+
+    @responses.activate
+    def test_agreement_logged_in(self):
+        self._log_in(self.client)
+        response = self.client.get("/account/agreement")
+
+        assert response.status_code == 200
+        self.assert_template_used('developer_programme_agreement.html')
+
+
+class PostAgreementPageNotAuth(BaseTestCases.EndpointPostLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/agreement'
+        super().setUp(None, endpoint_url)
+
+
+class PostAgreementPage(BaseTestCases.EndpointPostLoggedIn):
+    def setUp(self):
+        api_url = 'https://dashboard.snapcraft.io/dev/api/agreement/'
+        data = {
+            'i_agree': 'on'
+        }
+        endpoint_url = '/account/agreement'
+
+        super().setUp(None, api_url, endpoint_url, data)
+
+    @responses.activate
+    def test_post_agreement_on(self):
+        responses.add(
+            responses.POST,
+            self.api_url,
+            json={}, status=200)
+
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'i_agree': 'on'
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            called.response.json(),
+            {},
+        )
+        self.assertEqual(
+            b'{"latest_tos_accepted": true}',
+            called.request.body
+            )
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/account',
+            response.location)
+
+    @responses.activate
+    def test_post_agreement_off(self):
+        response = self.client.post(
+            self.endpoint_url,
+            data={
+                'i_agree': 'off'
+            },
+        )
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            'http://localhost/account/agreement',
+            response.location)

--- a/tests/tests_publisher.py
+++ b/tests/tests_publisher.py
@@ -66,25 +66,11 @@ class PublisherPage(TestCase):
         return get_authorization_header(
             root.serialize(), discharge.serialize())
 
-    def test_snap_metrics_not_logged_in(self):
-        response = self.client.get('/account/snaps/lxd/metrics')
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/login?next=/account/snaps/lxd/metrics',
-            response.location)
-
     def test_username_not_logged_in(self):
         response = self.client.get('/account/username')
         self.assertEqual(302, response.status_code)
         self.assertEqual(
             'http://localhost/login?next=/account/username',
-            response.location)
-
-    def test_agreeement_not_logged_in(self):
-        response = self.client.get('/account/agreement')
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/login?next=/account/agreement',
             response.location)
 
     def test_account_not_logged_in(self):
@@ -202,67 +188,6 @@ class PublisherPage(TestCase):
         self.assert_template_used('username.html')
         self.assert_context('username', 'toto')
         self.assert_context('error_list', payload['error_list'])
-
-    # /account/agreement endpoint
-    # ===
-    @responses.activate
-    def test_agreement_logged_in(self):
-        self._log_in(self.client)
-        response = self.client.get("/account/agreement")
-
-        assert response.status_code == 200
-        self.assert_template_used('developer_programme_agreement.html')
-
-    @responses.activate
-    def test_post_agreement_logged_in(self):
-        responses.add(
-            responses.POST,
-            'https://dashboard.snapcraft.io/dev/api/agreement/',
-            json={}, status=200)
-
-        authorization = self._log_in(self.client)
-        response = self.client.post(
-            '/account/agreement',
-            data={
-                'i_agree': 'on'
-            },
-        )
-
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(
-            'https://dashboard.snapcraft.io/dev/api/agreement/',
-            called.request.url)
-        self.assertEqual(
-            authorization, called.request.headers.get('Authorization'))
-        self.assertEqual(
-            called.response.json(),
-            {},
-        )
-        self.assertEqual(
-            b'{"latest_tos_accepted": true}',
-            called.request.body
-            )
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account',
-            response.location)
-
-    @responses.activate
-    def test_post_agreement_off_logged_in(self):
-        self._log_in(self.client)
-        response = self.client.post(
-            '/account/agreement',
-            data={
-                'i_agree': 'off'
-            },
-        )
-
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            'http://localhost/account/agreement',
-            response.location)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary

- Handle errors on POST agreement
- Add test class for POSTs endpoints
Fixes #540

# QA

- `./run`
- Create a new user
- access account page
- Confirm agreement
- Should be redirected to /account page