### PR TITLE
Help text typo fix

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -235,7 +235,7 @@
                   </p>
                 {% endif %}
                 <p class="p-form-help-text">
-                  Use include a valid http://, https:// or mailto: link
+                  Please include a valid http://, https:// or mailto: link
                 </p>
               </div>
             </div>


### PR DESCRIPTION
# Done

Fixed typo under the Contact <username> row the help text said:
'Use include a valid....'

I've changed it to say:
'Please include a valid....'

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/snap_name/listing
- Check the help text is changed