### PR TITLE
Listing page notice/ link to public store

### DIFF
--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -376,6 +376,14 @@ def get_listing_snap(snap_name):
             flask.request.path
         )
 
+    is_on_stable = False
+    for series in snap_details['channel_maps_list']:
+        for series_map in series['map']:
+            is_on_stable = (
+                is_on_stable or
+                'channel' in series_map and
+                series_map['channel'] == 'stable')
+
     # Filter icon & screenshot urls from the media set.
     icon_urls = [
         m['url'] for m in snap_details['media']
@@ -396,9 +404,11 @@ def get_listing_snap(snap_name):
         "publisher_name": snap_details['publisher']['display-name'],
         "screenshot_urls": screenshot_urls,
         "contact": snap_details['contact'],
+        "private": snap_details['private'],
         "website": snap_details['website'] or '',
         "public_metrics_enabled": snap_details['public_metrics_enabled'],
         "public_metrics_blacklist": snap_details['public_metrics_blacklist'],
+        "is_on_stable": is_on_stable,
     }
 
     return flask.render_template(
@@ -629,6 +639,14 @@ def post_listing_snap(snap_name):
                 else snap_details['website']
             )
 
+            is_on_stable = False
+            for series in snap_details['channel_maps_list']:
+                for series_map in series['map']:
+                    is_on_stable = (
+                        is_on_stable or
+                        'channel' in series_map and
+                        series_map['channel'] == 'stable')
+
             # Filter icon & screenshot urls from the media set.
             icon_urls = [
                 m['url'] for m in snap_details['media']
@@ -666,7 +684,9 @@ def post_listing_snap(snap_name):
                     changes['contact'] if 'contact' in changes
                     else snap_details['contact']
                 ),
+                "private": snap_details['private'],
                 "website": website or '',
+                "is_on_stable": is_on_stable,
                 # errors
                 "error_list": error_list,
                 "field_errors": field_errors,

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -73,12 +73,23 @@
   // Stick the Revert, Apply buttons to the top
   .snapcraft-p-sticky {
     background: $color-x-light;
+    margin-bottom: $sp-small;
     position: sticky;
     top: 0;
     z-index: 1;
 
+    & .row {
+      padding-top: $sp-small;
+    }
+
+    & .snapcraft-p-market-message {
+      margin-top: $sp-x-small;
+    }
+
     @media screen and (max-width: $breakpoint-x-small) {
-      padding-top: $sp-medium;
+      .js-market-submit {
+        margin-top: $sp-x-small !important;
+      }
     }
   }
 }

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -15,11 +15,31 @@
           <input type="hidden" name="snap_id" value="{{ snap_id }}" />
           <input type="file" name="icon" id="snap_icon" hidden class="hidden" accept="image/*"/>
 
-          <div class="row snapcraft-p-sticky">
-            <div class="col-12 u-align--right">
-                <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
-                <input type="submit" class="p-button--positive js-market-submit" name="submit_apply" value="Apply"/>
-                <hr class="u-no-margin--bottom" />
+          <div class="snapcraft-p-sticky u-no-margin--top">
+            <div class="row">
+              <div class="col-7">
+                <p class="snapcraft-p-market-message">
+                  {% if is_on_stable %}
+                    {% if private %}
+                      This listing is not public because the snap is set to private.
+                      <a href="https://dashboard.snapcraft.io/snaps/{{ snap_name }}">Settings</a>
+                    {% else %}
+                      Changes you make here will appear immediately on the <a href="/{{ snap_name }}">public listing</a>.
+                    {% endif %}
+                  {% else %}
+                    This listing will appear in the Snap Store when there is a <a href="https://docs.snapcraft.io/build-snaps/release">stable release</a>.
+                  {% endif %}
+                </p>
+              </div>
+              <div class="col-5">
+                <div class="u-align--right">
+                  <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
+                  <input type="submit" class="u-no-margin--top p-button--positive js-market-submit" name="submit_apply" value="Save"/>
+                </div>
+              </div>
+            </div>
+            <div class="row u-no-margin--top">
+              <hr class="u-no-margin" />
             </div>
           </div>
 

--- a/tests/tests_listing.py
+++ b/tests/tests_listing.py
@@ -76,6 +76,8 @@ class GetListingPage(BaseTestCases.EndpointLoggedIn):
             'publisher': {
                 'display-name': 'The publisher'
             },
+            'private': True,
+            'channel_maps_list': [{'map': [{'info': 'info'}]}],
             'contact': 'contact adress',
             'website': 'website_url',
             'public_metrics_enabled': True,
@@ -112,6 +114,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedIn):
         self.assert_context('website', 'website_url')
         self.assert_context('public_metrics_enabled', True)
         self.assert_context('public_metrics_blacklist', True)
+        self.assert_context('is_on_stable', False)
 
     @responses.activate
     def test_icon(self):
@@ -131,6 +134,8 @@ class GetListingPage(BaseTestCases.EndpointLoggedIn):
             'publisher': {
                 'display-name': 'The publisher'
             },
+            'private': True,
+            'channel_maps_list': [{'map': [{'info': 'info'}]}],
             'contact': 'contact adress',
             'website': 'website_url',
             'public_metrics_enabled': True,
@@ -174,6 +179,8 @@ class GetListingPage(BaseTestCases.EndpointLoggedIn):
             'publisher': {
                 'display-name': 'The publisher'
             },
+            'private': True,
+            'channel_maps_list': [{'map': [{'info': 'info'}]}],
             'contact': 'contact adress',
             'website': 'website_url',
             'public_metrics_enabled': True,

--- a/tests/tests_post_listing.py
+++ b/tests/tests_post_listing.py
@@ -323,6 +323,8 @@ class PostMetadataListingPage(BaseTestCases.BaseAppTesting):
             'publisher': {
                 'display-name': 'The publisher'
             },
+            'private': True,
+            'channel_maps_list': [{'map': [{'info': 'info'}]}],
             'contact': 'contact adress',
             'website': 'website_url',
             'public_metrics_enabled': True,
@@ -381,6 +383,7 @@ class PostMetadataListingPage(BaseTestCases.BaseAppTesting):
         self.assert_context('website', 'website_url')
         self.assert_context('public_metrics_enabled', True)
         self.assert_context('public_metrics_blacklist', True)
+        self.assert_context('is_on_stable', False)
 
     @responses.activate
     def test_return_error_udpate_all_field(self):
@@ -418,6 +421,8 @@ class PostMetadataListingPage(BaseTestCases.BaseAppTesting):
             'publisher': {
                 'display-name': 'The publisher'
             },
+            'private': True,
+            'channel_maps_list': [{'map': [{'info': 'info'}]}],
             'contact': 'contact adress',
             'website': 'website_url',
             'public_metrics_enabled': True,
@@ -476,6 +481,7 @@ class PostMetadataListingPage(BaseTestCases.BaseAppTesting):
         self.assert_context('publisher_name', 'The publisher')
         self.assert_context('screenshot_urls', [])
         self.assert_context('snap_title', 'Snap title')
+        self.assert_context('is_on_stable', False)
 
         # All updatable fields
         self.assert_context('summary', 'New summary')
@@ -520,6 +526,8 @@ class PostMetadataListingPage(BaseTestCases.BaseAppTesting):
             'publisher': {
                 'display-name': 'The publisher'
             },
+            'private': True,
+            'channel_maps_list': [{'map': [{'info': 'info'}]}],
             'contact': 'contact adress',
             'website': 'website_url',
             'public_metrics_enabled': True,


### PR DESCRIPTION
# Done

Partially fixes https://github.com/CanonicalLtd/snapcraft-design/issues/405
Fixes https://github.com/CanonicalLtd/snapcraft-design/issues/328 and https://github.com/CanonicalLtd/snapcraft-design/issues/383

- Changed padding around the buttons
- Changed 'Apply' to 'Save'
- Added notification text for the following cases:
  - Is not released to stable
  - Is released to stable but is not public
  - Is released to stable and is public

**Note** There is currently no way of knowing which store the snap is released to on this page. Once the field is added we can do some magic with that information. I'm not sure it's an issue for now though as there is only a small number of brand stores with exclusive snaps, afaik.

# QA

You'll need:
- A snap that has not been released to stable, but has the .snap file uploaded
- A snap that has been released to stable and is private
- A snap that has been released to stable and is public

Now:
- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/snap_name_from_above_list/listing
- Ensure the correct message is displayed and links go to the appropriate places

# Screenshots
## Public and released to stable
![screenshot-2018-4-23 listing details for lukotron test test](https://user-images.githubusercontent.com/479384/39175001-18ef8720-47a1-11e8-8ded-c490cc79182f.png)

## Private and released to stable
![screenshot-2018-4-25 listing details for lukotron test test](https://user-images.githubusercontent.com/479384/39236157-ea43f800-486f-11e8-98e9-5557c57ce3bb.png)

## Not released to stable
![screenshot-2018-4-23 listing details for test-lukewh](https://user-images.githubusercontent.com/479384/39175028-29d09c64-47a1-11e8-8466-2a76f8296b10.png)
