### PR TITLE
Distro chart

### DIFF
--- a/modules/public/logic.py
+++ b/modules/public/logic.py
@@ -53,6 +53,19 @@ def calculate_color(thisCountry, maxCountry, maxColor, minColor):
     return int(colorRange*countryFactor+minColor)
 
 
+def find_metric(full_response, name):
+    """Find a named metric in a metric response
+
+    :param full_response: The JSON response from the metrics API
+    :name: Name of the metric to find
+
+    :returns: A dictionnary with the metric information
+    """
+    for metric in full_response:
+        if metric['metric_name'] == name:
+            return metric
+
+
 def calculate_metrics_countries(geodata):
     """Calculate metrics per countries:
     - Number of users
@@ -158,6 +171,38 @@ def build_country_info(users_by_country, display_number_users=False):
             country_data[country.numeric]['number_of_users'] = number_of_users
 
     return country_data
+
+
+def build_os_info(series):
+    """Build information for OS distro graph
+
+        Input:
+        ```
+        [
+            {
+                'values': [0.4],
+                'name': 'fedora/25'
+            }
+            ...
+        ]
+
+        :param series: A series list from the metrics endpoint
+
+        :returns: A list with the sorted distros
+        """
+    oses = []
+
+    for distro in series:
+        if distro['values'][0]:
+            name = distro['name'].replace('/-', '')
+            oses.append({
+                'name': name.replace('/', ' - '),
+                'value': distro['values'][-1]
+            })
+
+    oses.sort(key=lambda x: x['value'], reverse=True)
+
+    return oses
 
 
 def get_searched_snaps(search_results):

--- a/static/js/publisher/market/publicMetrics.js
+++ b/static/js/publisher/market/publicMetrics.js
@@ -1,5 +1,6 @@
 const NAMES = {
-  'public_metrics_territories': 'installed_base_by_country_percent'
+  'public_metrics_territories': 'installed_base_by_country_percent',
+  'public_metrics_distros': 'weekly_installed_base_by_operating_system_normalized'
 };
 
 function publicMetrics(form) {

--- a/static/sass/_snapcraft_distro-chart.scss
+++ b/static/sass/_snapcraft_distro-chart.scss
@@ -1,0 +1,48 @@
+@mixin snapcraft-distro-chart {
+
+  $bar-color: #084081;
+
+  .snapcraft-distro-chart {
+
+    @media screen and (min-width: $breakpoint-navigation-threshold) {
+      max-height: 80vh;
+      overflow: auto;
+    }
+
+    &__names,
+    &__bars {
+      display: block;
+      float: left;
+      min-height: 1px;
+      position: relative;
+    }
+
+    &__names {
+      width: 8rem;
+    }
+
+    &__bars {
+      margin-left: 1rem;
+      margin-top: 0;
+      width: calc(100% - 9rem);
+    }
+
+    &__name {
+      font-size: .75rem;
+      line-height: 1rem;
+      margin-top: 1px;
+      overflow: hidden;
+      text-align: right;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    &__bar {
+      background: $bar-color;
+      height: 1px;
+      margin: .53125rem 0 .46875rem;
+      float: left;
+      clear: left;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -131,3 +131,6 @@ $color-navigation-background: #252525;
 
 @import 'snapcraft_p-beta-notification';
 @include snapcraft-p-beta-notification;
+
+@import 'snapcraft_distro-chart';
+@include snapcraft-distro-chart;

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -303,8 +303,23 @@
                   disabled="disabled"
                 {% endif %}
                 />
-              <label class="u-no-margin--top" for="public-metrics-territories">Territories</label>
+              <label class="u-no-margin--top" for="public-metrics-territories">World map</label>
               <p class="p-form-help-text">Displays where your snap is being used by country</p>
+            </div>
+            <div class="col-6">
+              <input
+                type="checkbox"
+                name="public_metrics_distros"
+                id="public-metrics-distros"
+                {% if not contains(public_metrics_blacklist, 'weekly_installed_base_by_operating_system_normalized') %}
+                  checked="checked"
+                {% endif %}
+                {% if not public_metrics_enabled %}
+                  disabled="disabled"
+                {% endif %}
+                />
+              <label class="u-no-margin--top" for="public-metrics-distros">Linux distributions</label>
+              <p class="p-form-help-text">Displays where you snap is being used by distro</p>
             </div>
           </div>
         </form>

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -97,14 +97,34 @@
         </table>
       </div>
     </div>
-    {% if countries %}
-      <div class="row js-snap-map-holder" style="margin-top: 2rem;">
-        <div class="col-12">
+    <div class="row" style="margin-top: 2rem;">
+      {% if countries %}
+        <div class="{% if normalized_os %}col-8{% else %}col-12{% endif %} js-snap-map-holder">
           <h4>Where people are using {{ snap_title }}</h4>
           <div id="js-snap-map" class="snapcraft-territories"></div>
         </div>
-      </div>
-    {% endif %}
+      {% endif %}
+      {% if normalized_os %}
+        <div class="col-4">
+          <h4>Users by distribution (log)</h4>
+          <div class="snapcraft-distro-chart">
+            <div class="snapcraft-distro-chart__names">
+              {% for distro in normalized_os %}
+                <div class="snapcraft-distro-chart__name">{{ distro.name }}</div>
+              {% endfor %}
+            </div>
+            <div class="snapcraft-distro-chart__bars">
+              {% for distro in normalized_os %}
+                <div
+                  class="snapcraft-distro-chart__bar"
+                  style="width: {{ distro.value * 100 }}%"
+                ></div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    </div>
   </div>
 
 

--- a/tests/tests_public_logic.py
+++ b/tests/tests_public_logic.py
@@ -79,3 +79,31 @@ class PublicLogicTest(unittest.TestCase):
         }
 
         self.assertEqual(result, expected_result)
+
+    # build_os_info
+    # ===
+    def test_build_os_info(self):
+        oses = [
+            {
+                'name': 'test/-',
+                'values': ['0.1']
+            },
+            {
+                'name': 'test2/test',
+                'values': ['0.5', '0.9']
+            }
+        ]
+
+        result = logic.build_os_info(oses)
+        expected_result = [
+            {
+                'name': 'test2 - test',
+                'value': '0.9'
+            },
+            {
+                'name': 'test',
+                'value': '0.1'
+            }
+        ]
+
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/534
Fixes https://github.com/canonical-websites/snapcraft.io/issues/533

# Done

- Added distro graph - without JS :open_mouth: shocker
- Added checkbox to listings page (fixes: https://github.com/canonical-websites/snapcraft.io/issues/524)

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snap_name
- Make sure the distro chart shows at the bottom of the page
- Visit Some other snaps
- See if the chart shows at the bottom of the page or not (won't show if no users)


- Go to http://0.0.0.0:8004/account/snaps/snap_name/listing
- Check/ uncheck the checkbox at the bottom of the page - visit the public page and see what happens with the graphs

# Screenshots
![screenshot-2018-4-24 listing details for toto](https://user-images.githubusercontent.com/479384/39196062-214bc6a8-47d9-11e8-8fd9-a06d3ddd0e7a.png)
![screenshot-2018-4-24 toto linux software in the snap store](https://user-images.githubusercontent.com/479384/39196063-217bf1ac-47d9-11e8-9c1a-4951140a6c91.png)
![screenshot-2018-4-24 toto linux software in the snap store 1](https://user-images.githubusercontent.com/479384/39196064-21a89cf2-47d9-11e8-9abb-4e411fe53e24.png)
