### PR TITLE
Add werkzeug debugger in development mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from flask_openid import OpenID
 from flask_wtf.csrf import CSRFProtect
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.debug import DebuggedApplication
 
 # Local modules
 import modules.authentication as authentication
@@ -38,6 +39,8 @@ from modules.macaroon import (
 app = flask.Flask(__name__)
 talisker.flask.register(app)
 app.wsgi_app = ProxyFix(app.wsgi_app)
+if app.debug:
+    app.wsgi_app = DebuggedApplication(app.wsgi_app)
 app.secret_key = os.environ['SECRET_KEY']
 app.url_map.strict_slashes = False
 app.url_map.converters['regex'] = helpers.RegexConverter

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/d3-geo/build/d3-geo.min.js static/js/modules && cp node_modules/topojson-client/dist/topojson-client.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/moment/min/moment.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-transpile": "rollup -c",
-    "serve": "talisker.gunicorn app:app --reload --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "talisker.gunicorn app:app --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",


### PR DESCRIPTION
Fixes #577.

QA
--

Break the application by e.g. adding `    sdfgsdf` to [line 93 of app.py](https://github.com/nottrobin/snapcraft.io/blob/add-back-werkzeug-debugger/app.py#L93).

Then `./run`, and load http://0.0.0.0:8004/ in the browser, and check you see:

> builtins.NameError
> NameError: name 'sdfgsdf' is not defined