### PR TITLE
Handle errors metadata

### DIFF
--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -205,7 +205,7 @@ def snap_metadata(snap_id, session, json=None):
     if authentication.is_macaroon_expired(metadata_response.headers):
         raise MacaroonRefreshRequired()
 
-    return metadata_response.json()
+    return process_response(metadata_response)
 
 
 def get_snap_status(snap_id, session):

--- a/tests/test_get_metrics.py
+++ b/tests/test_get_metrics.py
@@ -67,12 +67,6 @@ class GetMetricsPostMetrics(
             method_api='POST'
         )
 
-    def _get_redirect(self):
-        return (
-            'http://localhost'
-            '/account/snaps/{}/metrics'
-        ).format(self.snap_name)
-
     @responses.activate
     def test_no_data(self):
         payload = {


### PR DESCRIPTION
# Summary 

- Handle errors get_metadata
- Reove useless function
Fixes #543

# QA

- `./run`
- http://0.0.0.0:8004/account/snaps/toto/listing
- Do a modification 
- Should work
- Manage to do a invalid modification
- Should display the error message

- `./run test`