### PR TITLE
Handle errors get_snap_status

### DIFF
--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -217,7 +217,7 @@ def get_snap_status(snap_id, session):
     if authentication.is_macaroon_expired(status_response.headers):
         raise MacaroonRefreshRequired()
 
-    return status_response.json()
+    return process_response(status_response)
 
 
 def snap_screenshots(snap_id, session, data=None, files=None):

--- a/tests/tests_snap_release.py
+++ b/tests/tests_snap_release.py
@@ -1,0 +1,68 @@
+import responses
+from tests.endpoint_testing import BaseTestCases
+
+
+class GetReleasePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = 'test-snap'
+        endpoint_url = '/account/snaps/{}/release'.format(
+            snap_name)
+
+        super().setUp(
+            snap_name=None,
+            endpoint_url=endpoint_url)
+
+
+class GetReleaseSnapIdPage(
+        BaseTestCases.EndpointLoggedInErrorHandling):
+    def setUp(self):
+        snap_name = 'test-snap'
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        endpoint_url = '/account/snaps/{}/release'.format(snap_name)
+        super().setUp(
+            snap_name=snap_name,
+            api_url=api_url,
+            endpoint_url=endpoint_url)
+
+
+class GetReleasePage(
+        BaseTestCases.EndpointLoggedInErrorHandling):
+    def setUp(self):
+        snap_name = 'test-snap'
+        snap_id = 'complexId'
+
+        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        self.info_url = info_url.format(
+            snap_name
+        )
+        payload = {
+            'snap_id': 'complexId',
+        }
+
+        responses.add(
+            responses.GET, self.info_url,
+            json=payload, status=200)
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/{}/status'
+
+        endpoint_url = '/account/snaps/{}/release'.format(snap_name)
+        api_url = api_url.format(
+            snap_id
+        )
+        super().setUp(
+            snap_name=snap_name,
+            api_url=api_url,
+            endpoint_url=endpoint_url)
+
+    @responses.activate
+    def test_release(self):
+        responses.add(
+            responses.GET, self.api_url,
+            json={}, status=200)
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used('publisher/release.html')


### PR DESCRIPTION
# Summary

- Handle errors get snap status
#544 

# QA

- `./run`
- http://0.0.0.0:8004/account/snaps/toto/release

- `run test`