### PR TITLE
Full stop after publicly to match other field descriptions on the page

### DIFF
--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -59,7 +59,7 @@ Account details — Linux software in the Snap Store
     <div class="col-6">
       <p><b>{{ email }}</b></p>
       <p class="p-form-help-text">
-        Your email address will not be shared publicly
+        Your email address will not be shared publicly.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Be consistent with punctuation.