### PR TITLE
Improved first snap experience

### DIFF
--- a/modules/publisher/logic.py
+++ b/modules/publisher/logic.py
@@ -1,4 +1,5 @@
 import hashlib
+import datetime
 from json import dumps
 
 
@@ -19,6 +20,22 @@ def get_snaps_account_info(account_info):
                 registered_snaps[snap] = snaps[snap]
             else:
                 user_snaps[snap] = snaps[snap]
+
+    now = datetime.datetime.utcnow()
+
+    if len(user_snaps) == 1:
+        for snap in user_snaps:
+            snap_info = user_snaps[snap]
+            revisions = snap_info['latest_revisions']
+
+            revision_since = datetime.datetime.strptime(
+                revisions[-1]['since'],
+                '%Y-%m-%dT%H:%M:%SZ')
+
+            if (abs((revision_since - now).days) < 30 and
+                (not revisions[0]['channels'] or
+                    revisions[0]['channels'][0] == 'edge')):
+                snap_info['is_new'] = True
 
     return user_snaps, registered_snaps
 

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -82,6 +82,7 @@ def get_account_snaps():
     user_snaps, registered_snaps = logic.get_snaps_account_info(account)
 
     flask_user = flask.session['openid']
+
     context = {
         'page_slug': 'my-snaps',
         'snaps': user_snaps,

--- a/static/sass/_snapcraft_snap-list.scss
+++ b/static/sass/_snapcraft_snap-list.scss
@@ -11,4 +11,23 @@
       margin-right: $sp-medium;
     }
   }
+
+  .p-snapcraft-first-snap {
+    position: relative;
+
+    &__notification {
+      margin-top: 1rem;
+    }
+
+    &__rocket {
+      margin: {
+        top: -1rem;
+        bottom: -1rem;
+      }
+
+      img {
+        height: 130px;
+      }
+    }
+  }
 }

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -65,39 +65,35 @@ My snaps — Linux software in the Snap Store
   {% else %}
     {% if snaps|length == 1 %}
       {% for snap in snaps %}
-      <section class="p-strip--light is-shallow">
-        <div class="row">
-          <div class="col-3">
-            <h3 class="p-heading--four">Congratulations!</h3>
-          </div>
-          <div class="col-6">
-            {% if snaps[snap].latest_revisions[0].channels[0] %}
-              <p>
-                You've just released {{ snap }} to the "{{ snaps[snap].latest_revisions[0].channels[0] }}" channel!
-              </p>
-            {% else %}
-              <p>
-                You've just uploaded {{ snap }}!
-              </p>
-            {% endif %}
-            <ul>
-              <li>
-                Want to improve the listing in stores?
-                <a href="/account/snaps/{{ snap }}/market">Edit Store listing</a>
-              </li>
-              {% if not snaps[snap].latest_revisions[0].channels[0] %}
-                <li>
-                  Is your snap ready to release?
-                  <a href="https://docs.snapcraft.io/build-snaps/release" target="_blank">Release it</a>
-                </li>
-              {% endif %}
-            </ul>
-          </div>
-          <div class="col-3" style="margin-top: -25px">
-            <img alt="Rocket among stars" src="https://assets.ubuntu.com/v1/320a508d-rocket-icon-with-stars.png" />
-          </div>
-        </div>
-      </section>
+        {% if snaps[snap].is_new %}
+          <section class="p-strip--light is-shallow p-snapcraft-first-snap__notification">
+            <div class="row">
+              <div class="col-9">
+                {% if snaps[snap].latest_revisions[0].channels[0] %}
+                  <p>
+                    You've released {{ snap }} to the "{{ snaps[snap].latest_revisions[0].channels[0] }}" channel!
+                  </p>
+                {% else %}
+                  <p>
+                    You've uploaded {{ snap }}!
+                  </p>
+                {% endif %}
+                <p>
+                  Want to improve the listing in stores?
+                  <a href="/account/snaps/{{ snap }}/listing">Edit Store listing</a>
+                  {% if not snaps[snap].latest_revisions[0].channels[0] %}
+                    <br />
+                    Is your snap ready to release?
+                    <a href="https://docs.snapcraft.io/build-snaps/release" target="_blank">Release it</a>
+                  {% endif %}
+                </p>
+              </div>
+              <div class="col-3 p-snapcraft-first-snap__rocket">
+                <img alt="Rocket among stars" src="https://assets.ubuntu.com/v1/abd70be7-Rocket+V2.png" />
+              </div>
+            </div>
+          </section>
+        {% endif %}
       {% endfor %}
     {% endif %}
     <div class="row">

--- a/tests/tests_account_snaps.py
+++ b/tests/tests_account_snaps.py
@@ -99,7 +99,12 @@ class AccountSnapsPage(
                 '16': {
                     'test': {
                         'snap-name': 'test',
-                        'latest_revisions': [{'test': 'test'}]
+                        'latest_revisions': [
+                            {
+                                'test': 'test',
+                                'since': '2018-01-01T00:00:00Z'
+                            }
+                        ]
                     }
                 }
             }
@@ -133,7 +138,12 @@ class AccountSnapsPage(
                 '16': {
                     'test': {
                         'snap-name': 'test',
-                        'latest_revisions': [{'test': 'test'}]
+                        'latest_revisions': [
+                            {
+                                'test': 'test',
+                                'since': '2018-01-01T00:00:00Z'
+                            }
+                        ]
                     },
                     'test2': {
                         'snap-name': 'test2',
@@ -167,9 +177,14 @@ class AccountSnapsPage(
 
         uploaded_snaps = {
             'test': {
-                 'snap-name': 'test',
-                 'latest_revisions': [{'test': 'test'}]
-             }
+                'snap-name': 'test',
+                'latest_revisions': [
+                    {
+                        'test': 'test',
+                        'since': '2018-01-01T00:00:00Z'
+                    }
+                ]
+            }
         }
 
         assert response.status_code == 200

--- a/tests/tests_publisher_logic.py
+++ b/tests/tests_publisher_logic.py
@@ -21,7 +21,11 @@ class PublisherLogicTest(unittest.TestCase):
             'snaps': {
                 '16': {
                     'snap1': {
-                        'latest_revisions': 'revision'
+                        'latest_revisions': [
+                            {
+                                'since': '2018-01-01T00:00:00Z'
+                            }
+                        ]
                     }
                 }
             }
@@ -31,7 +35,11 @@ class PublisherLogicTest(unittest.TestCase):
 
         expected_user_snaps = {
             'snap1': {
-                'latest_revisions': 'revision'
+                'latest_revisions': [
+                    {
+                        'since': '2018-01-01T00:00:00Z'
+                    }
+                ]
             }
         }
 
@@ -65,7 +73,11 @@ class PublisherLogicTest(unittest.TestCase):
             'snaps': {
                 '16': {
                     'snap1': {
-                        'latest_revisions': 'revision'
+                        'latest_revisions': [
+                            {
+                                'since': '2018-01-01T00:00:00Z'
+                            }
+                        ]
                     },
                     'snap2': {
                         'latest_revisions': None
@@ -78,7 +90,11 @@ class PublisherLogicTest(unittest.TestCase):
 
         expected_user_snaps = {
             'snap1': {
-                'latest_revisions': 'revision'
+                'latest_revisions': [
+                    {
+                        'since': '2018-01-01T00:00:00Z'
+                    }
+                ]
             }
         }
         expected_registered_snaps = {


### PR DESCRIPTION
# Done

- Added some more logic: If the oldest upload was over 30 days ago - it's not longer classed as 'new'
- Added close button that's persisted with a cookie
- Improved 'what to do next' from a list to paragraphs

# QA

You'll need:
- An account with 1 newly created snap
- An account with 1 snap that's over 30days old (or hack the code as described below)

To QA:
- Pull the branch
- `./run`
- Visit https://0.0.0.0:8004/account/snaps

To test different cases, edit the following code:
`/modules/publisher/logic.py:26` add `user_snaps = {'snap_you_have': user_snaps['snap_you_have']}`