### PR TITLE
Channel map

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -1,4 +1,5 @@
 import map from './snap-details/map';
 import screenshots from './snap-details/screenshots';
+import channelMap from './snap-details/channelMap';
 
-export { map, screenshots };
+export { map, screenshots, channelMap };

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -1,0 +1,69 @@
+const LATEST = 'latest';
+export default function initChannelMap(el, packageName, channelMapData) {
+  const channelMapEl = document.querySelector(el);
+
+  document.querySelector('.js-open-channel-map').addEventListener('click', () => {
+    channelMapEl.style.display = 'block';
+  });
+
+  document.querySelector('.js-hide-channel-map').addEventListener('click', () => {
+    channelMapEl.style.display = 'none';
+  });
+
+  const architectures = Object.keys(channelMapData);
+  const arch = architectures[0];
+  if (!arch) {
+    return;
+  }
+
+  const tracks = Object.keys(channelMapData[arch]);
+  const track = channelMapData[arch][LATEST] ? LATEST : tracks[0];
+
+  if (!track) {
+    return;
+  }
+
+  const channels = channelMapData[arch][track];
+  const channelMap = {};
+
+  channels.forEach(channel => {
+    channelMap[channel.channel] = channel;
+  });
+
+  const archSelect = document.getElementById("js-channel-map-architecture-select");
+  const trackSelect = document.getElementById("js-channel-map-track-select");
+
+  archSelect.innerHTML = `<option value="${arch}">${arch}</option>`;
+  archSelect.disabled = 'disabled';
+
+  trackSelect.innerHTML = `<option value="${track}">${track}</option>`;
+  trackSelect.disabled = 'disabled';
+
+  ['stable', 'candidate', 'beta', 'edge'].forEach((risk, i, risks) => {
+    const channelEl = document.getElementById(`js-channel-map-${risk}`);
+    const channelData = channelMap[risk];
+
+    // show install instructions
+    channelEl.querySelector('input').value = `sudo snap install ${packageName} ${risk !== 'stable' ? `--${risk}` : '' }`;
+
+    const versionEl = channelEl.querySelector('.p-form-help-text');
+    // show version
+    if (channelData) {
+      versionEl.innerHTML = `Version: ${channelData.version}`;
+    } else {
+      let fallbackRisk;
+      for (let j = 0; j < i; j++) {
+        if (channelMap[risks[j]]) {
+          fallbackRisk = risks[j];
+        }
+      }
+
+      if (fallbackRisk) {
+        versionEl.innerHTML = `No release in ${risk} channel, using ${fallbackRisk} release.`;
+      } else {
+        versionEl.innerHTML = `No release in ${risk} channel.`;
+      }
+    }
+
+  });
+}

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -1,17 +1,63 @@
 const LATEST = 'latest';
-export default function initChannelMap(el, packageName, channelMapData) {
-  const channelMapEl = document.querySelector(el);
 
-  document.querySelector('.js-open-channel-map').addEventListener('click', () => {
-    channelMapEl.style.display = 'block';
+function setTrack(arch, track, packageName, channelMap) {
+  ['stable', 'candidate', 'beta', 'edge'].forEach((risk, i, risks) => {
+    const channelEl = document.getElementById(`js-channel-map-${risk}`);
+
+    // channel names in tracks other then latest are prefixed with track name
+    const channelName = track === LATEST ? risk : `${track}/${risk}`;
+
+    channelEl.querySelector('.js-channel-name').innerHTML = channelName;
+    const channelData = channelMap[channelName];
+
+    // update install instructions
+    let command = `sudo snap install ${packageName}`;
+
+    if (track === LATEST) {
+      if (risk !== 'stable') {
+        command += ` --${risk}`;
+      }
+    } else {
+      command += ` --channel=${track}/${risk}`;
+    }
+
+    channelEl.querySelector('input').value = command;
+
+    const versionEl = channelEl.querySelector('.p-form-help-text');
+
+    // show version
+    if (channelData) {
+      versionEl.innerHTML = `Version: ${channelData.version}`;
+    } else {
+      let fallbackRisk;
+      for (let j = 0; j < i; j++) {
+        const channelName = track === LATEST ? risks[j] : `${track}/${risks[j]}`;
+        if (channelMap[channelName]) {
+          fallbackRisk = risks[j];
+        }
+      }
+
+      if (fallbackRisk) {
+        versionEl.innerHTML = `No release in ${risk} channel, using ${fallbackRisk} release.`;
+      } else {
+        versionEl.innerHTML = `No release in ${risk} channel.`;
+      }
+    }
+  });
+}
+
+function getArchTrackChannels(arch, track, channelMapData) {
+  const channels = channelMapData[arch][track];
+  const archTrackChannels = {};
+
+  channels.forEach(channel => {
+    archTrackChannels[channel.channel] = channel;
   });
 
-  document.querySelector('.js-hide-channel-map').addEventListener('click', () => {
-    channelMapEl.style.display = 'none';
-  });
+  return archTrackChannels;
+}
 
-  const architectures = Object.keys(channelMapData);
-  const arch = architectures[0];
+function setArchitecture(arch, packageName, channelMapData) {
   if (!arch) {
     return;
   }
@@ -23,47 +69,53 @@ export default function initChannelMap(el, packageName, channelMapData) {
     return;
   }
 
-  const channels = channelMapData[arch][track];
-  const channelMap = {};
+  // update tracks select
+  const trackSelect = document.getElementById("js-channel-map-track-select");
+  trackSelect.innerHTML = tracks.map(track => `<option value="${track}">${track}</option>`).join('');
+  trackSelect.value = track;
 
-  channels.forEach(channel => {
-    channelMap[channel.channel] = channel;
+  // hide tracks if there is only one
+  if (tracks.length === 1) {
+    trackSelect.closest('.js-channel-map-track-field').style.display = 'none';
+  } else {
+    trackSelect.closest('.js-channel-map-track-field').style.display = '';
+  }
+
+  const channelMap = getArchTrackChannels(arch, track, channelMapData);
+  setTrack(arch, track, packageName, channelMap);
+}
+
+export default function initChannelMap(el, packageName, channelMapData) {
+  const channelMapEl = document.querySelector(el);
+
+  // init open/hide buttons
+  document.querySelector('.js-open-channel-map').addEventListener('click', () => {
+    channelMapEl.style.display = 'block';
   });
 
+  document.querySelector('.js-hide-channel-map').addEventListener('click', () => {
+    channelMapEl.style.display = 'none';
+  });
+
+  // get architectures from data
+  const architectures = Object.keys(channelMapData);
+
+  // initialize arch and track selects
   const archSelect = document.getElementById("js-channel-map-architecture-select");
   const trackSelect = document.getElementById("js-channel-map-track-select");
 
-  archSelect.innerHTML = `<option value="${arch}">${arch}</option>`;
-  archSelect.disabled = 'disabled';
+  archSelect.innerHTML = architectures.map(arch => `<option value="${arch}">${arch}</option>`).join('');
 
-  trackSelect.innerHTML = `<option value="${track}">${track}</option>`;
-  trackSelect.disabled = 'disabled';
-
-  ['stable', 'candidate', 'beta', 'edge'].forEach((risk, i, risks) => {
-    const channelEl = document.getElementById(`js-channel-map-${risk}`);
-    const channelData = channelMap[risk];
-
-    // show install instructions
-    channelEl.querySelector('input').value = `sudo snap install ${packageName} ${risk !== 'stable' ? `--${risk}` : '' }`;
-
-    const versionEl = channelEl.querySelector('.p-form-help-text');
-    // show version
-    if (channelData) {
-      versionEl.innerHTML = `Version: ${channelData.version}`;
-    } else {
-      let fallbackRisk;
-      for (let j = 0; j < i; j++) {
-        if (channelMap[risks[j]]) {
-          fallbackRisk = risks[j];
-        }
-      }
-
-      if (fallbackRisk) {
-        versionEl.innerHTML = `No release in ${risk} channel, using ${fallbackRisk} release.`;
-      } else {
-        versionEl.innerHTML = `No release in ${risk} channel.`;
-      }
-    }
-
+  archSelect.addEventListener('change', ()=> {
+    setArchitecture(archSelect.value, packageName, channelMapData);
   });
+
+  trackSelect.addEventListener('change', ()=> {
+    const channels = getArchTrackChannels(archSelect.value, trackSelect.value, channelMapData);
+    setTrack(archSelect.value, trackSelect.value, packageName, channels);
+  });
+
+  const arch = channelMapData['amd64'] ? 'amd64' : architectures[0];
+  archSelect.value = arch;
+  setArchitecture(arch, packageName, channelMapData);
 }

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -39,12 +39,70 @@
   .p-snap-install {
     font-size: .875rem; // same as .p-form-help-text
 
+    &__versions {
+      margin-top: 77px; // align with install instructions
+      text-align: right;
+    }
+
     .p-code-snippet {
+      font-size: 1rem;
       margin-top: $sp-x-small;
     }
 
     @media screen and (min-width: $breakpoint-medium) {
       margin-top: $sp-xxx-large;
+    }
+  }
+
+
+  .p-channel-map {
+    box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 57px; // just under the header (mobile)
+    z-index: 1;
+
+    @media screen and (min-width: $breakpoint-medium) {
+      top: 48px; // just under the header (desktop)
+    }
+
+    // align hide button with stable install instructions
+    &__hide {
+      text-align: right;
+
+      @media screen and (min-width: $breakpoint-medium) {
+        float: right;
+        margin-left: $sp-x-small;
+        margin-top: 49px; // align with install instructions
+      }
+    }
+
+    &__row {
+      @extend %clearfix;
+      border-bottom: 1px solid $color-mid-light;
+      margin: 0;
+      padding-bottom: 2rem;
+      padding-top: 1rem;
+
+      &--heading {
+        padding-bottom: .5rem;
+        padding-top: 0;
+
+        @media screen and (max-width: $breakpoint-medium) {
+          display: none;
+        }
+      }
+    }
+
+
+    &__footer {
+      @extend %clearfix;
+      margin: 0;
+
+      @media screen and (min-width: $breakpoint-medium) {
+        padding-top: 1rem;
+      }
     }
   }
 }

--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -36,6 +36,7 @@
     @media (min-width: $breakpoint-navigation-threshold + 1) {
       .p-navigation__links--right {
         margin-left: auto; // align to right in flexbox parent
+        margin-right: 20px; // align with the grid
       }
     }
 

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -19,7 +19,7 @@
 {% block content %}
   <div class="p-strip--light is-shallow">
     <div class="row">
-      <div class="col-5">
+      <div class="col-4">
         <div class="p-snap-heading">
           {% if icon_url %}
             <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
@@ -54,10 +54,13 @@
           </p>
         </div>
       </div>
-      <div class="col-2">
+      <div class="col-3 p-snap-install__versions">
+        <button class="p-button--neutral js-open-channel-map">Show all versions</button>
       </div>
     </div>
   </div>
+
+  {% include "snap-details/_channel_map.html" %}
 
   {% if screenshots %}
     <div class="p-strip is-shallow">
@@ -142,6 +145,15 @@
         }
       {% endif %}
 
+      {% if channel_map %}
+        try {
+          snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }});
+        } catch(e) {
+          Raven.captureException(e);
+          document.querySelector('.js-open-channel-map').style.display = 'none';
+        }
+      {% endif %}
+
       var ctrlDown = false;
 
       function keyDown(e) {
@@ -178,8 +190,8 @@
         snapInstall.addEventListener('keydown', keyDown);
       }
 
-      if (ClipboardJS) {
-        var copy = new ClipboardJS('#copy');
+      if (typeof ClipboardJS !== 'undefined') {
+        var copy = new ClipboardJS('.js-clipboard-copy');
 
         copy.on('success', function () {
           if (typeof ga !== 'undefined') {

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -2,14 +2,16 @@
   <div class="row">
     <div class="col-3">
       <form>
-        <label for="js-channel-map-track-select">Architecture</label>
-        <select id="js-channel-map-architecture-select">
-          <option value="amd64">amd64</option>
-        </select>
-        <label for="js-channel-map-track-select">Track</label>
-        <select id="js-channel-map-track-select">
-          <option value="latest">Latest</option>
-        </select>
+        <div class="js-channel-map-arch-field">
+          <label for="js-channel-map-track-select">Architecture</label>
+          <select id="js-channel-map-architecture-select">
+          </select>
+        </div>
+        <div class="js-channel-map-track-field">
+          <label for="js-channel-map-track-select">Track</label>
+          <select id="js-channel-map-track-select">
+          </select>
+        </div>
       </form>
     </div>
 
@@ -26,7 +28,7 @@
 
       <div id="js-channel-map-stable" class="p-channel-map__row">
         <div class="col-2">
-          Stable
+          <span class="js-channel-name">stable</span>
         </div>
         <div class="col-5">
           <div class="p-code-snippet">
@@ -49,7 +51,7 @@
 
       <div id="js-channel-map-candidate" class="p-channel-map__row">
         <div class="col-2">
-          Candidate
+          <span class="js-channel-name">candidate</span>
         </div>
         <div class="col-5">
           <div class="p-code-snippet">
@@ -72,7 +74,7 @@
 
       <div id="js-channel-map-beta" class="p-channel-map__row">
         <div class="col-2">
-          Beta
+          <span class="js-channel-name">beta</span>
         </div>
         <div class="col-5">
           <div class="p-code-snippet">
@@ -95,7 +97,7 @@
 
       <div id="js-channel-map-edge" class="p-channel-map__row">
         <div class="col-2">
-          Edge
+          <span class="js-channel-name">edge</span>
         </div>
         <div class="col-5">
           <div class="p-code-snippet">

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -1,0 +1,132 @@
+<div id='js-channel-map' class="p-strip--light p-channel-map" style="display: none">
+  <div class="row">
+    <div class="col-3">
+      <form>
+        <label for="js-channel-map-track-select">Architecture</label>
+        <select id="js-channel-map-architecture-select">
+          <option value="amd64">amd64</option>
+        </select>
+        <label for="js-channel-map-track-select">Track</label>
+        <select id="js-channel-map-track-select">
+          <option value="latest">Latest</option>
+        </select>
+      </form>
+    </div>
+
+    <div class="col-7">
+
+      <div class="p-channel-map__row p-channel-map__row--heading">
+        <div class="col-2">
+          Channel
+        </div>
+        <div class="col-5">
+          Install instructions
+        </div>
+      </div>
+
+      <div id="js-channel-map-stable" class="p-channel-map__row">
+        <div class="col-2">
+          Stable
+        </div>
+        <div class="col-5">
+          <div class="p-code-snippet">
+            <input
+              class="p-code-snippet__input"
+              id="snap-install-stable"
+              value="sudo snap install {{ package_name }}"
+              readonly="readonly"
+            />
+            <button
+              class="p-code-snippet__action js-clipboard-copy"
+              data-clipboard-target="#snap-install-stable">
+              Copy to clipboard
+            </button>
+          </div>
+          <p class="p-form-help-text">
+          </p>
+        </div>
+      </div>
+
+      <div id="js-channel-map-candidate" class="p-channel-map__row">
+        <div class="col-2">
+          Candidate
+        </div>
+        <div class="col-5">
+          <div class="p-code-snippet">
+            <input
+              class="p-code-snippet__input"
+              id="snap-install-candidate"
+              value="sudo snap install {{ package_name }} --candidate"
+              readonly="readonly"
+            />
+            <button
+              class="p-code-snippet__action js-clipboard-copy"
+              data-clipboard-target="#snap-install-candidate">
+              Copy to clipboard
+            </button>
+          </div>
+          <p class="p-form-help-text">
+          </p>
+        </div>
+      </div>
+
+      <div id="js-channel-map-beta" class="p-channel-map__row">
+        <div class="col-2">
+          Beta
+        </div>
+        <div class="col-5">
+          <div class="p-code-snippet">
+            <input
+              class="p-code-snippet__input"
+              id="snap-install-beta"
+              value="sudo snap install {{ package_name }} --beta"
+              readonly="readonly"
+            />
+            <button
+              class="p-code-snippet__action js-clipboard-copy"
+              data-clipboard-target="#snap-install-candidate">
+              Copy to clipboard
+            </button>
+          </div>
+          <p class="p-form-help-text">
+          </p>
+        </div>
+      </div>
+
+      <div id="js-channel-map-edge" class="p-channel-map__row">
+        <div class="col-2">
+          Edge
+        </div>
+        <div class="col-5">
+          <div class="p-code-snippet">
+            <input
+              class="p-code-snippet__input"
+              id="snap-install-edge"
+              value="sudo snap install {{ package_name }} --edge"
+              readonly="readonly"
+            />
+            <button
+              class="p-code-snippet__action js-clipboard-copy"
+              data-clipboard-target="#snap-install-edge">
+              Copy to clipboard
+            </button>
+          </div>
+          <p class="p-form-help-text">
+          </p>
+        </div>
+      </div>
+
+      <div class="p-channel-map__footer">
+        <div class="col-2"></div>
+        <div class="col-5">
+      <p class="p-form-help-text">
+        To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
+      </p>
+    </div>
+  </div>
+  </div>
+  <div class="p-channel-map__hide">
+    <button class="p-button--neutral js-hide-channel-map">Hide versions</button>
+  </div>
+  </div>
+</div>


### PR DESCRIPTION
Fixes #528 

Adds channel map to snap details page.

### QA
- ./run
- go to details page of any snap (try some featured ones or some mentioned in https://github.com/CanonicalLtd/snapcraft-design/issues/424)
- 'Show all version' button should be visible next to install instuctions
- click it
- channel map should open
- try to change architecture/track if available
- click 'Hide versions' to close
- make sure there are no JS errors in console

<img width="1034" alt="screen shot 2018-04-26 at 14 42 54" src="https://user-images.githubusercontent.com/83575/39306486-9d10155e-4960-11e8-9feb-bee061cd7c3b.png">
<img width="1028" alt="screen shot 2018-04-26 at 14 43 09" src="https://user-images.githubusercontent.com/83575/39306485-9ce25e98-4960-11e8-8ea1-1c8a66e460a1.png">
<img width="1027" alt="screen shot 2018-04-26 at 14 43 30" src="https://user-images.githubusercontent.com/83575/39306484-9cb5e3ea-4960-11e8-91fa-9778f426b66d.png">
