### PR TITLE
Add help tooltips to channel map

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -148,4 +148,20 @@
       opacity: 0;
     }
   }
+
+  // because of Vanilla `* + *` top margin
+  .p-tooltip__message {
+    margin: 0;
+  }
+
+  // positioning fixes for track tooltip
+  .p-tooltip.is-icon {
+    .p-tooltip__message {
+      left: -3rem; // position in bottom-left under the label and icon
+
+      &::before {
+        left: 3rem; // reposition arrow correctly under the icon
+      }
+    }
+  }
 }

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -3,12 +3,21 @@
     <div class="col-3">
       <form>
         <div class="js-channel-map-arch-field">
-          <label for="js-channel-map-track-select">Architecture</label>
+          <label for="js-channel-map-track-select">
+            Architecture
+          </label>
           <select id="js-channel-map-architecture-select">
           </select>
         </div>
         <div class="js-channel-map-track-field">
-          <label for="js-channel-map-track-select">Track</label>
+          <label for="js-channel-map-track-select">
+            Track
+            <span class="p-tooltip is-icon" aria-describedby="tooltip-track">
+              <i class="p-icon--information"></i>
+              <span class="p-tooltip__message" role="tooltip" id="tooltip-track">This application has alternate series or 'tracks'
+where you can install and get updates from.</span>
+            </span>
+          </label>
           <select id="js-channel-map-track-select">
           </select>
         </div>
@@ -20,6 +29,12 @@
       <div class="p-channel-map__row p-channel-map__row--heading">
         <div class="col-2">
           Channel
+          <span class="p-tooltip p-tooltip--btm-center" aria-describedby="tooltip-channel">
+            <i class="p-icon--information"></i>
+            <span class="p-tooltip__message" role="tooltip" id="tooltip-channel">Install this application from ‘channels’ of varying stability.
+For example, Edge is used for development and testing, whereas
+Stable is used for well tested and production ready versions.</span>
+          </span>
         </div>
         <div class="col-5">
           Install instructions


### PR DESCRIPTION
Fixes #529 

Adds Vanilla help tooltips to explain what 'Architectures' 'Tracks' and 'Channels' are to channel map.

### QA
- ./run or http://snapcraft.io-pr-606.run.demo.haus/
- go to a public page of a snap (ideally one with several tracks) like skype or webstorm
- open channel map (by clicking on 'Show all versions')
- help icons should be visible next to 'Track' and 'Channel' labels
- hovering these icons should reveal tooltip with explanation

<img width="1033" alt="screen shot 2018-04-30 at 11 18 58" src="https://user-images.githubusercontent.com/83575/39421316-befbe584-4c68-11e8-97e4-568cfe06ca59.png">
<img width="1041" alt="screen shot 2018-04-30 at 11 18 51" src="https://user-images.githubusercontent.com/83575/39421317-bf2009dc-4c68-11e8-9229-9486281c7258.png">
