### PR TITLE
Remove logic from view account snaps endpoint

### DIFF
--- a/modules/publisher/logic.py
+++ b/modules/publisher/logic.py
@@ -1,0 +1,19 @@
+def get_snaps_account_info(account_info):
+    """Get snaps from the account information of a user
+
+    :param account_info The account informations
+
+    :return A list of snaps
+    :return A list of registred snaps
+    """
+    user_snaps = {}
+    registered_snaps = {}
+    if '16' in account_info['snaps']:
+        snaps = account_info['snaps']['16']
+        for snap in snaps.keys():
+            if not snaps[snap]['latest_revisions']:
+                registered_snaps[snap] = snaps[snap]
+            else:
+                user_snaps[snap] = snaps[snap]
+
+    return user_snaps, registered_snaps

--- a/tests/tests_publisher_logic.py
+++ b/tests/tests_publisher_logic.py
@@ -1,0 +1,91 @@
+import unittest
+import modules.publisher.logic as logic
+
+
+class PublisherLogicTest(unittest.TestCase):
+
+    # get_snaps_account_info
+    # ===
+    def test_empty_snaps(self):
+        account_info = {
+            'snaps': {}
+        }
+        user_snaps, registered_snaps = logic.get_snaps_account_info(
+            account_info)
+
+        self.assertEqual(user_snaps, {})
+        self.assertEqual(registered_snaps, {})
+
+    def test_only_uploaded_snaps(self):
+        account_info = {
+            'snaps': {
+                '16': {
+                    'snap1': {
+                        'latest_revisions': 'revision'
+                    }
+                }
+            }
+        }
+        user_snaps, registered_snaps = logic.get_snaps_account_info(
+            account_info)
+
+        expected_user_snaps = {
+            'snap1': {
+                'latest_revisions': 'revision'
+            }
+        }
+
+        self.assertEqual(user_snaps, expected_user_snaps)
+        self.assertEqual(registered_snaps, {})
+
+    def test_only_registred_snaps(self):
+        account_info = {
+            'snaps': {
+                '16': {
+                    'snap1': {
+                        'latest_revisions': None
+                    }
+                }
+            }
+        }
+        user_snaps, registered_snaps = logic.get_snaps_account_info(
+            account_info)
+
+        expected_registered_snaps = {
+            'snap1': {
+                'latest_revisions': None
+            }
+        }
+
+        self.assertEqual(user_snaps, {})
+        self.assertEqual(registered_snaps, expected_registered_snaps)
+
+    def test_all_snaps(self):
+        account_info = {
+            'snaps': {
+                '16': {
+                    'snap1': {
+                        'latest_revisions': 'revision'
+                    },
+                    'snap2': {
+                        'latest_revisions': None
+                    }
+                }
+            }
+        }
+        user_snaps, registered_snaps = logic.get_snaps_account_info(
+            account_info)
+
+        expected_user_snaps = {
+            'snap1': {
+                'latest_revisions': 'revision'
+            }
+        }
+        expected_registered_snaps = {
+            'snap2': {
+                'latest_revisions': None
+            }
+        }
+
+        self.assertEqual(user_snaps, expected_user_snaps)
+        self.assertEqual(registered_snaps, expected_registered_snaps)


### PR DESCRIPTION
# Summary

- Remove logic from view in account snaps endpoint
Fixes #550 

# QA

- `./run`
- http://127.0.0.1:8004/account/snaps
- Should work as usual