### PR TITLE
'My snaps' > 'Dashboard'; 'Dashboard' and 'Forum' external links

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -22,10 +22,12 @@
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
         <li class="p-navigation__link" role="menuitem">
-          <a class="{% if page_slug and page_slug == 'my-snaps' %} is-selected{% endif %}" href="/account/snaps">My snaps</a>
+          <a class="{% if page_slug and page_slug == 'my-snaps' %} is-selected{% endif %} p-link--external"
+          href="https://dashboard.snapcraft.io/snaps">Dashboard</a>
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
-        <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
+        <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories"
+        class="p-link--external">Forum</a></li>
       </ul>
 
       <ul class="p-navigation__links--right" role="menu">

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -22,7 +22,7 @@
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://build.snapcraft.io">Build</a></li>
         <li class="p-navigation__link" role="menuitem">
-          <a class="{% if page_slug and page_slug == 'my-snaps' %} is-selected{% endif %} p-link--external"
+          <a class="p-link--external"
           href="https://dashboard.snapcraft.io/snaps">Dashboard</a>
         </li>
         <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>


### PR DESCRIPTION
- Fixes #595: Changes “My snaps” back to “Dashboard”, linking to dashboard.snapcraft.io/snaps until snapcraft.io/account becomes more functional.
- Fixes #522: Styles both “Dashboard” and “Forum” as external links, since both are presented as different sites (different header navigation, sign-in sessions, etc.