### PR TITLE
Focusable screenshots in listing form

### DIFF
--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -8,13 +8,16 @@ const templates = {
 
   screenshot: (screenshot) => `
     <div class="col-2">
-      <div class="p-screenshot__holder ${screenshot.status === 'delete' ? 'is-deleted' : ''}">
+      <label
+        ${screenshot.status === 'delete' ? '' : 'tabindex="0"'}
+        class="p-screenshot ${screenshot.status === 'delete' ? 'is-deleted' : ''} ${screenshot.selected ? 'is-selected' : ''}">
+        <input class="p-screenshot__checkbox" tabindex="-1" type="checkbox" ${screenshot.selected ? 'checked="checked"' : ''} >
         <img
-          class="p-screenshot ${screenshot.selected ? 'selected' : ''}"
+          class="p-screenshot__image"
           src="${screenshot.url}"
           alt=""
         />
-      </div>
+      </label>
     </div>
   `,
 
@@ -183,9 +186,10 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
     }
 
     // clicking on screenshot to select it
-    if (event.target.classList.contains('p-screenshot')) {
+    if (event.target.closest('.p-screenshot')) {
       event.preventDefault();
-      selectScreenshot(event.target.src);
+      const img = event.target.closest('.p-screenshot').querySelector('.p-screenshot__image');
+      selectScreenshot(img.src);
       setTimeout(() => {
         render();
       }, 50);
@@ -195,8 +199,23 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
     render();
   });
 
+  screenshotsWrapper.addEventListener('keydown', (event) => {
+    if ((event.key === " " || event.key == "Spacebar") &&
+        event.target.closest('.p-screenshot')) {
+      event.preventDefault();
+      const img = event.target.closest('.p-screenshot').querySelector('.p-screenshot__image');
+      selectScreenshot(img.src);
+      setTimeout(() => {
+        render();
+        // after rendering find image with same src and focus it back
+        screenshotsWrapper.querySelector(`[src="${img.src}"]`).closest('.p-screenshot').focus();
+      }, 50);
+      return;
+    }
+  });
+
   document.addEventListener('dblclick', event => {
-    if (event.target.classList.contains('p-screenshot')) {
+    if (event.target.classList.contains('p-screenshot__image')) {
       event.preventDefault();
       let screenshot = state.images.filter(image => image.selected)[0];
 

--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -211,9 +211,10 @@ function initSnapScreenshotsEdit(screenshotsToolbarElId, screenshotsWrapperElId,
   });
 
   document.addEventListener('dblclick', event => {
-    if (event.target.classList.contains('p-screenshot__image')) {
+    if (event.target.closest('.p-screenshot')) {
       event.preventDefault();
-      let screenshot = state.images.filter(image => image.selected)[0];
+      const url = event.target.closest('.p-screenshot').querySelector('.p-screenshot__image').src;
+      const screenshot = state.images.filter(image => image.url === url)[0];
 
       if (screenshot) {
         lightbox.openLightbox(

--- a/static/js/publisher/market/screenshots.test.js
+++ b/static/js/publisher/market/screenshots.test.js
@@ -42,7 +42,7 @@ describe('templates', () => {
       const result = templates.screenshot(screenshot);
       wrapper.innerHTML = result;
 
-      expect(wrapper.querySelector('img').classList.contains('selected')).toBe(true);
+      expect(wrapper.querySelector('.p-screenshot').classList.contains('is-selected')).toBe(true);
     });
 
     it('should mark deleted screenshots', () => {
@@ -50,7 +50,7 @@ describe('templates', () => {
       const result = templates.screenshot(screenshot);
       wrapper.innerHTML = result;
 
-      expect(wrapper.querySelector('.p-screenshot__holder').classList.contains('is-deleted')).toBe(true);
+      expect(wrapper.querySelector('.p-screenshot').classList.contains('is-deleted')).toBe(true);
     });
   });
 

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -21,19 +21,30 @@
     text-align: center;
   }
 
-  .p-screenshot__holder {
-    .p-screenshot {
-      &.selected {
-        outline: 1px solid $color-focus;
-        outline-offset: 2px;
-      }
+  .p-screenshot {
+    position: relative;
+
+    &.is-selected {
+      outline: 1px solid $color-mid-light;
+      outline-offset: 2px;
     }
 
-    .p-screenshot[src^='blob'] {
-      & + .p-screenshot__delete,
-      & + .p-screenshot__revert {
-        display: none;
-      }
+
+    &:focus {
+      outline: 1px solid $color-focus;
+      outline-offset: 2px;
+    }
+
+    &__checkbox {
+      left: $sp-x-small;
+      pointer-events: none;
+      position: absolute;
+      top: $sp-x-small;
+    }
+
+    &__image {
+      display: block;
+      margin: 0;
     }
 
     &:hover {
@@ -43,15 +54,13 @@
     }
 
     &.is-deleted {
-      .p-screenshot__delete {
+      cursor: default;
+
+      .p-screenshot__checkbox {
         display: none;
       }
 
-      .p-screenshot__revert {
-        display: block;
-      }
-
-      .p-screenshot {
+      .p-screenshot__image {
         filter: grayscale(100%);
         opacity: .6;
       }

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -37,9 +37,14 @@
 
     &__checkbox {
       left: $sp-x-small;
+      opacity: 0; // only display when selected
       pointer-events: none;
       position: absolute;
       top: $sp-x-small;
+
+      &[checked] {
+        opacity: 1;
+      }
     }
 
     &__image {

--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -35,16 +35,20 @@
       outline-offset: 2px;
     }
 
+    &:focus,
+    &:hover,
+    &.is-selected {
+      .p-screenshot__checkbox {
+        opacity: 1;
+      }
+    }
+
     &__checkbox {
       left: $sp-x-small;
-      opacity: 0; // only display when selected
+      opacity: 0; // only display when selected or focused
       pointer-events: none;
       position: absolute;
       top: $sp-x-small;
-
-      &[checked] {
-        opacity: 1;
-      }
     }
 
     &__image {


### PR DESCRIPTION
Fixes #414

Makes screenshots in listing form focusable (also with keyboard).
Focused screenshot has blue border (just like any other focused input). To make screenshots selection visible checkboxes where added on top of screenshots, so that selected screenshots have checkbox checked.
Multiple screenshots can be selected (multiple checkboxes checked) and therefore multiple screenshots can be deleted at once (by selecting them and clicking delete button).

### QA

- ./run or  http://snapcraft.io-pr-623.run.demo.haus/
- go to listing page of any snap (ideally with screenshots already)
- use keyboard tab to tab through the form (and screenshots)
- once screenshot is focused hit space to select/unselect it
- use mouse to click on screenshots to select/unselect it
- select multiple screenshots and delete them
- make sure any other screenshots functionality (adding screenshots, full screen, removing screenshots before uploading, etc) is still working as before

#### Not selected, not focused
<img width="1023" alt="screen shot 2018-05-02 at 16 43 33" src="https://user-images.githubusercontent.com/83575/39530071-6f32ccc2-4e28-11e8-8ad2-d812d54e6ce1.png">
#### Focused
<img width="1025" alt="screen shot 2018-05-02 at 16 44 13" src="https://user-images.githubusercontent.com/83575/39530070-6f1358ba-4e28-11e8-8df3-360038242b5b.png">
#### Multiple selected
<img width="1044" alt="screen shot 2018-05-02 at 16 44 24" src="https://user-images.githubusercontent.com/83575/39530069-6ee6194a-4e28-11e8-8485-e25a3791f830.png">




