### PR TITLE
Remove logic listing page

### DIFF
--- a/modules/publisher/logic.py
+++ b/modules/publisher/logic.py
@@ -174,3 +174,21 @@ def get_number_territories(country_data):
             territories_total += 1
 
     return territories_total
+
+
+def is_snap_on_stable(channel_maps_list):
+    """Checks if the snap in on a stable channel
+
+    :param channel_maps_list: The channel maps list of a snap
+
+    :return: True is stable, False if not
+    """
+    is_on_stable = False
+    for series in channel_maps_list:
+        for series_map in series['map']:
+            is_on_stable = is_on_stable or \
+                'channel' in series_map and \
+                series_map['channel'] == 'stable' and \
+                series_map['info']
+
+    return is_on_stable

--- a/tests/tests_publisher_logic.py
+++ b/tests/tests_publisher_logic.py
@@ -89,3 +89,50 @@ class PublisherLogicTest(unittest.TestCase):
 
         self.assertEqual(user_snaps, expected_user_snaps)
         self.assertEqual(registered_snaps, expected_registered_snaps)
+
+    # is_snap_on_stable
+    # ===
+    def test_snap_not_stable(self):
+        channel_maps_list = [
+            {
+                'map': [
+                    {
+                        'channel': 'not stable',
+                        'info': None
+                    }
+                ]
+            }
+        ]
+
+        result = logic.is_snap_on_stable(channel_maps_list)
+        self.assertFalse(result)
+
+    def test_snap_stable_not_info(self):
+        channel_maps_list = [
+            {
+                'map': [
+                    {
+                        'channel': 'stable',
+                        'info': None
+                    }
+                ]
+            }
+        ]
+
+        result = logic.is_snap_on_stable(channel_maps_list)
+        self.assertFalse(result)
+
+    def test_snap_stable(self):
+        channel_maps_list = [
+            {
+                'map': [
+                    {
+                        'channel': 'stable',
+                        'info': 'info'
+                    }
+                ]
+            }
+        ]
+
+        result = logic.is_snap_on_stable(channel_maps_list)
+        self.assertTrue(result)


### PR DESCRIPTION
# Summary

- Remove logic listing page (get)
Fixes #552 

# QA

- `./run`
- http://127.0.0.1:8004/account/snaps/toto/listing
- Test on snaps not on stable