### PR TITLE
Remove - from distro labels

### DIFF
--- a/modules/public/logic.py
+++ b/modules/public/logic.py
@@ -196,7 +196,7 @@ def build_os_info(series):
         if distro['values'][0]:
             name = distro['name'].replace('/-', '')
             oses.append({
-                'name': name.replace('/', ' - '),
+                'name': name.replace('/', ' '),
                 'value': distro['values'][-1]
             })
 

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -112,7 +112,7 @@
           <div class="snapcraft-distro-chart">
             <div class="snapcraft-distro-chart__names">
               {% for distro in normalized_os %}
-                <div class="snapcraft-distro-chart__name">{{ distro.name }}</div>
+              <div class="snapcraft-distro-chart__name" title="{{ distro.name }}">{{ distro.name }}</div>
               {% endfor %}
             </div>
             <div class="snapcraft-distro-chart__bars">

--- a/tests/tests_public_logic.py
+++ b/tests/tests_public_logic.py
@@ -97,7 +97,7 @@ class PublicLogicTest(unittest.TestCase):
         result = logic.build_os_info(oses)
         expected_result = [
             {
-                'name': 'test2 - test',
+                'name': 'test2 test',
                 'value': '0.9'
             },
             {


### PR DESCRIPTION
On snap details pages, for the distro graph we currently show:
`distro - version`
nobody uses this format to describe their version, this PR changes it to:
`distro version`