### PR TITLE
Add register name endpoint with basic template

### DIFF
--- a/app.py
+++ b/app.py
@@ -363,3 +363,15 @@ def get_measure_snap(snap_name):
     return flask.redirect(
         "/account/snaps/{snap_name}/metrics".format(
             snap_name=snap_name))
+
+
+@app.route('/account/register-name')
+@login_required
+def get_register_name():
+    return publisher_views.get_register_name()
+
+
+@app.route('/account/register-name', methods=['POST'])
+@login_required
+def post_register_name():
+    return publisher_views.post_register_name()

--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -49,6 +49,11 @@ SNAP_INFO_URL = ''.join([
     'snaps/info/{snap_name}',
 ])
 
+REGISTER_NAME_URL = ''.join([
+    DASHBOARD_API,
+    'register-name/'
+])
+
 
 def process_response(response):
     try:
@@ -176,6 +181,35 @@ def get_publisher_metrics(session, json):
         raise MacaroonRefreshRequired()
 
     return process_response(metrics_response)
+
+
+def post_register_name(
+        session, snap_name,
+        registrant_comment=None, is_private=False, store=None):
+
+    json = {
+        'snap_name': snap_name,
+    }
+
+    if registrant_comment:
+        json['registrant_comment'] = registrant_comment
+
+    if is_private:
+        json['is_private'] = is_private
+
+    if store:
+        json['store'] = store
+
+    response = cache.get(
+        REGISTER_NAME_URL,
+        headers=get_authorization_header(session),
+        json=json,
+        method='POST')
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired()
+
+    return process_response(response)
 
 
 def get_snap_info(snap_name, session):

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -288,6 +288,42 @@ def get_listing_snap(snap_name):
     )
 
 
+def get_register_name():
+    return flask.render_template(
+        'publisher/register-name.html')
+
+
+def post_register_name():
+    snap_name = flask.request.form.get('snap-name')
+
+    if not snap_name:
+        return flask.redirect('/account/register-name')
+
+    store = flask.request.form.get('store')
+    is_private = flask.request.form.get('is_private') == 'on'
+    registrant_comment = flask.request.form.get('registrant_comment')
+
+    try:
+        api.post_register_name(
+            session=flask.session,
+            snap_name=snap_name,
+            is_private=is_private,
+            store=store,
+            registrant_comment=registrant_comment)
+    except ApiResponseErrorList as api_response_error_list:
+        context = {
+            'errors': api_response_error_list.errors,
+        }
+
+        return flask.render_template(
+            'publisher/register-name.html',
+            **context)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    return flask.redirect('/account/register-name')
+
+
 def post_listing_snap(snap_name):
     changes = None
     changed_fields = flask.request.form.get('changes')

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -1,0 +1,70 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+Register new Snap name
+{% endblock %}
+
+{% block content %}
+<div class="p-strip">
+
+  <div class="row">
+    <h1>Register a snap name</h1>
+  </div>
+  {% if errors %}
+      <div class="row">
+        <div class="col-12">
+          {% for error in errors %}
+            <div class="p-notification--negative">
+              <p class="p-notification__response">
+                  {{ error.message }}
+              </p>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+  {% endif %}
+
+  <form method="POST">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-form-validation">
+          <label for="snap-title">Snap-name:</label>
+          <div class="p-form-validation__field">
+            <input class="p-form-validation__input" type="text" name="snap-name" required maxlength="64"/>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-form-validation">
+          <label for="snap-title">Is Private:</label>
+          <div class="p-form-validation__field">
+            <input name="is_private" class="p-form-validation__input" type="checkbox">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-form-validation">
+          <label for="snap-title">Registrant Comment:</label>
+          <div class="p-form-validation__field">
+            <textarea class="p-form-validation__input u-no-margin" name="registrant_comment" rows="10"></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-4">
+        <input type="submit" class="p-button--positive" value="Register"/>
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/tests/tests_register_name.py
+++ b/tests/tests_register_name.py
@@ -1,0 +1,199 @@
+import responses
+from tests.endpoint_testing import BaseTestCases
+
+
+class GetRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+        super().setUp(
+            snap_name=None,
+            endpoint_url=endpoint_url)
+
+
+class GetRegisterNamePage(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+        super().setUp(
+            snap_name=None,
+            api_url=None,
+            endpoint_url=endpoint_url)
+
+    @responses.activate
+    def test_register_name_logged_in(self):
+        self._log_in(self.client)
+        response = self.client.get(self.endpoint_url)
+
+        assert response.status_code == 200
+        self.assert_template_used('publisher/register-name.html')
+
+
+class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+
+        super().setUp(
+            snap_name=None,
+            endpoint_url=endpoint_url,
+            method_endpoint='POST')
+
+
+class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'register-name/')
+
+        data = {
+            'snap-name': 'test-snap'
+        }
+
+        super().setUp(
+            snap_name=None,
+            api_url=api_url,
+            endpoint_url=endpoint_url,
+            method_api='POST',
+            method_endpoint='POST',
+            data=data)
+
+    @responses.activate
+    def test_post_no_data(self):
+        response = self.client.post(
+            self.endpoint_url,
+        )
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_snap_name(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"snap_name": "test-snap"}',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_store(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        self.data['store'] = 'store'
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertIn(
+            b'"snap_name": "test-snap"',
+            called.request.body)
+        self.assertIn(
+            b'"store": "store"',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_private(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        self.data['is_private'] = 'on'
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertIn(
+            b'"snap_name": "test-snap"',
+            called.request.body)
+        self.assertIn(
+            b'"is_private": true',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_registrant_comment(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        self.data['registrant_comment'] = 'comment'
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertIn(
+            b'"snap_name": "test-snap"',
+            called.request.body)
+        self.assertIn(
+            b'"registrant_comment": "comment"',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_error_from_api(self):
+        payload = {
+            'error_list': [
+                {
+                    'code': 'error-code'
+                },
+            ]
+        }
+        responses.add(
+            responses.POST, self.api_url,
+            json=payload, status=400)
+
+        self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assert_template_used('publisher/register-name.html')
+        self.assert_context('errors', payload['error_list'])


### PR DESCRIPTION
# Summary

Add register name endpoint with basic template
Fixes https://github.com/CanonicalLtd/snappy-design-squad/issues/481

# QA

- `./run`
- http://127.0.0.1:8004/account/register-name
- Try to register a snap
- Go on my snaps and check if name is well registered