### PR TITLE
Make sure nodejs shows up on the store

### DIFF
--- a/modules/public/api.py
+++ b/modules/public/api.py
@@ -14,7 +14,7 @@ SNAPCRAFT_IO_API = os.getenv(
 SNAP_DETAILS_URL = ''.join([
     SNAPCRAFT_IO_API,
     'snaps/details/{snap_name}',
-    '?channel=stable',
+    '?channel={snap_channel}',
     '&fields=snap_id,package_name,title,summary,description,license,contact,',
     'website,publisher,prices,media,',
     # Released (stable) revision fields will eventually be replaced by
@@ -124,9 +124,11 @@ def get_searched_snaps(snap_searched, size, page):
     return process_response(searched_response)
 
 
-def get_snap_details(snap_name):
+def get_snap_details(snap_name, snap_channel):
     details_response = cache.get(
-        SNAP_DETAILS_URL.format(snap_name=snap_name),
+        SNAP_DETAILS_URL.format(
+            snap_name=snap_name,
+            snap_channel=snap_channel),
         headers=DETAILS_QUERY_HEADERS
     )
 

--- a/modules/public/logic.py
+++ b/modules/public/logic.py
@@ -166,3 +166,18 @@ def convert_channel_maps(channel_maps_list):
                 channel_maps[arch][track].append(channel)
 
     return channel_maps
+
+
+def get_default_channel(snap_name):
+    """
+    Get's the default channel of 'stable' unless the snap_name is node.
+
+    This is a temporary* hack to get around nodejs not using 'latest'
+    as their default.
+
+    * depending on snapd and store work (not in the 18.10 cycle)
+    """
+    if snap_name == 'node':
+        return '10/stable'
+
+    return 'stable'

--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -153,8 +153,11 @@ def snap_details(snap_name):
     """
 
     error_info = {}
+    default_channel = logic.get_default_channel(snap_name)
+
     try:
-        details = api.get_snap_details(snap_name)
+        details = api.get_snap_details(
+                snap_name, default_channel)
     except ApiTimeoutError as api_timeout_error:
         flask.abort(504, str(api_timeout_error))
     except ApiResponseDecodeError as api_response_decode_error:
@@ -239,6 +242,7 @@ def snap_details(snap_name):
         'summary': details['summary'],
         'description_paragraphs': formatted_paragraphs,
         'channel_map': channel_maps_list,
+        'default_channel': default_channel,
 
         # Transformed API data
         'filesize': humanize.naturalsize(details['binary_filesize']),

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -39,7 +39,7 @@
             <input
               class="p-code-snippet__input"
               id="snap-install"
-              value="sudo snap install {{ package_name }}"
+              value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
               readonly="readonly"
             />
             <button
@@ -58,7 +58,7 @@
       </div>
     </div>
   </div>
-
+  
   {% include "snap-details/_channel_map.html" %}
 
   {% if screenshots %}


### PR DESCRIPTION
# Done

Semi-temporary hack to ensure the latest nodejs shows on snapcraft.io.

## Why?

Node don't use the 'Latest' track for their stable track, instead they use `:version:/stable` (currently '10/stable'). This is temporary until default tracks are implemented in the store.

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/node or http://snapcraft.io-pr-636.run.demo.haus/node
- Ensure the page loads