### PR TITLE
Use blueprints

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,6 @@ import modules.public.views as public_views
 import modules.publisher.views as publisher_views
 import modules.publisher.api as publisher_api
 import template_functions
-from decorators import login_required
 from modules.macaroon import (
     MacaroonRequest,
     MacaroonResponse,
@@ -81,6 +80,10 @@ app.config['SENTRY_CONFIG'] = {
     'release': COMMIT_ID,
     'environment': ENVIRONMENT
 }
+
+
+app.register_blueprint(public_views.store_pages)
+app.register_blueprint(publisher_views.publisher_pages, url_prefix='/account')
 
 
 @app.context_processor
@@ -250,128 +253,6 @@ def logout():
     return flask.redirect('/')
 
 
-# Normal views
-# ===
-@app.route('/')
-def homepage():
-    return public_views.homepage()
-
-
 @app.route('/status')
 def status():
     return 'alive'
-
-
-@app.route('/store')
-def store():
-    return public_views.store()
-
-
-@app.route('/discover')
-def discover():
-    return flask.redirect('/store')
-
-
-@app.route('/snaps')
-def snaps():
-    return flask.redirect('/store')
-
-
-@app.route('/search')
-def search_snap():
-    return public_views.search_snap()
-
-
-@app.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
-def snap_details(snap_name):
-    return public_views.snap_details(snap_name)
-
-
-# Publisher views
-# ===
-@app.route('/account')
-@login_required
-def get_account():
-    return flask.redirect('/account/snaps')
-
-
-@app.route('/account/details')
-@login_required
-def get_account_details():
-    return publisher_views.get_account_details()
-
-
-@app.route('/account/snaps')
-@login_required
-def get_account_snaps():
-    return publisher_views.get_account_snaps()
-
-
-@app.route('/account/agreement')
-@login_required
-def get_agreement():
-    return publisher_views.get_agreement()
-
-
-@app.route('/account/agreement', methods=['POST'])
-@login_required
-def post_agreement():
-    return publisher_views.post_agreement()
-
-
-@app.route('/account/username')
-@login_required
-def get_account_name():
-    return publisher_views.get_account_name()
-
-
-@app.route('/account/username', methods=['POST'])
-@login_required
-def post_account_name():
-    return publisher_views.post_account_name()
-
-
-@app.route('/account/snaps/<snap_name>/metrics')
-@login_required
-def publisher_snap_metrics(snap_name):
-    return publisher_views.publisher_snap_metrics(snap_name)
-
-
-@app.route('/account/snaps/<snap_name>/listing', methods=['GET'])
-@login_required
-def get_listing_snap(snap_name):
-    return publisher_views.get_listing_snap(snap_name)
-
-
-@app.route('/account/snaps/<snap_name>/listing', methods=['POST'])
-@login_required
-def post_listing_snap(snap_name):
-    return publisher_views.post_listing_snap(snap_name)
-
-
-@app.route('/account/snaps/<snap_name>/market')
-@login_required
-def get_market_snap(snap_name):
-    return flask.redirect(
-        "/account/snaps/{snap_name}/listing".format(
-            snap_name=snap_name))
-
-
-@app.route('/account/snaps/<snap_name>/measure')
-@login_required
-def get_measure_snap(snap_name):
-    return flask.redirect(
-        "/account/snaps/{snap_name}/metrics".format(
-            snap_name=snap_name))
-
-
-@app.route('/account/register-name')
-@login_required
-def get_register_name():
-    return publisher_views.get_register_name()
-
-
-@app.route('/account/register-name', methods=['POST'])
-@login_required
-def post_register_name():
-    return publisher_views.post_register_name()

--- a/app.py
+++ b/app.py
@@ -363,3 +363,15 @@ def get_measure_snap(snap_name):
     return flask.redirect(
         "/account/snaps/{snap_name}/metrics".format(
             snap_name=snap_name))
+
+
+@app.route('/account/register-name')
+@login_required
+def get_register_name():
+    return publisher_views.get_register_name()
+
+
+@app.route('/account/register-name', methods=['POST'])
+@login_required
+def post_register_name():
+    return publisher_views.post_register_name()

--- a/modules/public/views.py
+++ b/modules/public/views.py
@@ -17,6 +17,10 @@ from modules.exceptions import (
 from urllib.parse import quote_plus
 
 
+store_pages = flask.Blueprint(
+    'store_pages', __name__, template_folder='/templates')
+
+
 def _handle_errors(api_error: ApiError):
     status_code = 502
     error = {
@@ -38,6 +42,7 @@ def _handle_errors(api_error: ApiError):
     return status_code, error
 
 
+@store_pages.route('/')
 def homepage():
     featured_snaps = []
     error_info = {}
@@ -56,6 +61,17 @@ def homepage():
     ), status_code
 
 
+@store_pages.route('/discover')
+def discover():
+    return flask.redirect('/store')
+
+
+@store_pages.route('/snaps')
+def snap_redirect():
+    return flask.redirect('/store')
+
+
+@store_pages.route('/store')
 def store():
     featured_snaps = []
     error_info = {}
@@ -93,6 +109,7 @@ def snaps():
     ), status_code
 
 
+@store_pages.route('/search')
 def search_snap():
     status_code = 200
     snap_searched = flask.request.args.get('q', default='', type=str)
@@ -143,6 +160,7 @@ def search_snap():
     )
 
 
+@store_pages.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
 def snap_details(snap_name):
     """
     A view to display the snap details page for specific snaps.

--- a/modules/publisher/api.py
+++ b/modules/publisher/api.py
@@ -49,6 +49,11 @@ SNAP_INFO_URL = ''.join([
     'snaps/info/{snap_name}',
 ])
 
+REGISTER_NAME_URL = ''.join([
+    DASHBOARD_API,
+    'register-name/'
+])
+
 
 def process_response(response):
     try:
@@ -176,6 +181,35 @@ def get_publisher_metrics(session, json):
         raise MacaroonRefreshRequired()
 
     return process_response(metrics_response)
+
+
+def post_register_name(
+        session, snap_name,
+        registrant_comment=None, is_private=False, store=None):
+
+    json = {
+        'snap_name': snap_name,
+    }
+
+    if registrant_comment:
+        json['registrant_comment'] = registrant_comment
+
+    if is_private:
+        json['is_private'] = is_private
+
+    if store:
+        json['store'] = store
+
+    response = cache.get(
+        REGISTER_NAME_URL,
+        headers=get_authorization_header(session),
+        json=json,
+        method='POST')
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired()
+
+    return process_response(response)
 
 
 def get_snap_info(snap_name, session):

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -4,6 +4,7 @@ import modules.metrics.helper as metrics_helper
 import modules.metrics.metrics as metrics
 import modules.publisher.api as api
 import modules.publisher.logic as logic
+from decorators import login_required
 from json import loads
 from modules.exceptions import (
     AgreementNotSigned,
@@ -13,6 +14,10 @@ from modules.exceptions import (
     MacaroonRefreshRequired,
     MissingUsername
 )
+
+
+publisher_pages = flask.Blueprint(
+    'publisher_pages', __name__, template_folder='/templates')
 
 
 def refresh_redirect(path):
@@ -46,6 +51,8 @@ def _handle_error_list(errors):
     return flask.abort(502, error_messages)
 
 
+@publisher_pages.route('/details')
+@login_required
 def get_account_details():
     try:
         # We don't use the data from this endpoint.
@@ -71,6 +78,14 @@ def get_account_details():
     )
 
 
+@publisher_pages.route('/')
+@login_required
+def get_account():
+    return flask.redirect('/account/snaps')
+
+
+@publisher_pages.route('/snaps')
+@login_required
 def get_account_snaps():
     try:
         account = api.get_account(flask.session)
@@ -95,10 +110,14 @@ def get_account_snaps():
     )
 
 
+@publisher_pages.route('/agreement')
+@login_required
 def get_agreement():
     return flask.render_template('developer_programme_agreement.html')
 
 
+@publisher_pages.route('/agreement', methods=['POST'])
+@login_required
 def post_agreement():
     agreed = flask.request.form.get('i_agree')
     if agreed == 'on':
@@ -116,10 +135,14 @@ def post_agreement():
         return flask.redirect('/account/agreement')
 
 
+@publisher_pages.route('/username')
+@login_required
 def get_account_name():
     return flask.render_template('username.html')
 
 
+@publisher_pages.route('/username', methods=['POST'])
+@login_required
 def post_account_name():
     username = flask.request.form.get('username')
 
@@ -144,6 +167,16 @@ def post_account_name():
         return flask.redirect('/account/username')
 
 
+@publisher_pages.route('/snaps/<snap_name>/measure')
+@login_required
+def get_measure_snap(snap_name):
+    return flask.redirect(
+        "/account/snaps/{snap_name}/metrics".format(
+            snap_name=snap_name))
+
+
+@publisher_pages.route('/snaps/<snap_name>/metrics')
+@login_required
 def publisher_snap_metrics(snap_name):
     """
     A view to display the snap metrics page for specific snaps.
@@ -241,6 +274,16 @@ def publisher_snap_metrics(snap_name):
         **context)
 
 
+@publisher_pages.route('/snaps/<snap_name>/market')
+@login_required
+def get_market_snap(snap_name):
+    return flask.redirect(
+        "/account/snaps/{snap_name}/listing".format(
+            snap_name=snap_name))
+
+
+@publisher_pages.route('/snaps/<snap_name>/listing', methods=['GET'])
+@login_required
 def get_listing_snap(snap_name):
     try:
         snap_details = api.get_snap_info(snap_name, flask.session)
@@ -287,11 +330,15 @@ def get_listing_snap(snap_name):
     )
 
 
+@publisher_pages.route('/register-name')
+@login_required
 def get_register_name():
     return flask.render_template(
         'publisher/register-name.html')
 
 
+@publisher_pages.route('/register-name', methods=['POST'])
+@login_required
 def post_register_name():
     snap_name = flask.request.form.get('snap-name')
 
@@ -323,6 +370,8 @@ def post_register_name():
     return flask.redirect('/account/register-name')
 
 
+@publisher_pages.route('/snaps/<snap_name>/listing', methods=['POST'])
+@login_required
 def post_listing_snap(snap_name):
     changes = None
     changed_fields = flask.request.form.get('changes')

--- a/modules/publisher/views.py
+++ b/modules/publisher/views.py
@@ -287,6 +287,42 @@ def get_listing_snap(snap_name):
     )
 
 
+def get_register_name():
+    return flask.render_template(
+        'publisher/register-name.html')
+
+
+def post_register_name():
+    snap_name = flask.request.form.get('snap-name')
+
+    if not snap_name:
+        return flask.redirect('/account/register-name')
+
+    store = flask.request.form.get('store')
+    is_private = flask.request.form.get('is_private') == 'on'
+    registrant_comment = flask.request.form.get('registrant_comment')
+
+    try:
+        api.post_register_name(
+            session=flask.session,
+            snap_name=snap_name,
+            is_private=is_private,
+            store=store,
+            registrant_comment=registrant_comment)
+    except ApiResponseErrorList as api_response_error_list:
+        context = {
+            'errors': api_response_error_list.errors,
+        }
+
+        return flask.render_template(
+            'publisher/register-name.html',
+            **context)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    return flask.redirect('/account/register-name')
+
+
 def post_listing_snap(snap_name):
     changes = None
     changed_fields = flask.request.form.get('changes')

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -1,0 +1,50 @@
+{% extends "_layout.html" %}
+
+{% block title %}
+Register new Snap name
+{% endblock %}
+
+{% block content %}
+<div id="main-content" class="u-no-margin--top">
+  <form method="POST">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-form-validation">
+          <label for="snap-title">Snap-name:</label>
+          <div class="p-form-validation__field">
+            <input class="p-form-validation__input" type="text" name="snap-name" required maxlength="64"/>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-form-validation">
+          <label for="snap-title">Is Private:</label>
+          <div class="p-form-validation__field">
+            <input name="is_private" class="p-form-validation__input" type="checkbox">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-form-validation">
+          <label for="snap-title">Registrant Comment:</label>
+          <div class="p-form-validation__field">
+            <textarea class="p-form-validation__input u-no-margin" name="registrant_comment" rows="10" required></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-4">
+      <input type="submit" class="p-button--positive" value="Register"/>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/tests/tests_register_name.py
+++ b/tests/tests_register_name.py
@@ -1,0 +1,199 @@
+import responses
+from tests.endpoint_testing import BaseTestCases
+
+
+class GetRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+        super().setUp(
+            snap_name=None,
+            endpoint_url=endpoint_url)
+
+
+class GetRegisterNamePage(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+        super().setUp(
+            snap_name=None,
+            api_url=None,
+            endpoint_url=endpoint_url)
+
+    @responses.activate
+    def test_register_name_logged_in(self):
+        self._log_in(self.client)
+        response = self.client.get(self.endpoint_url)
+
+        assert response.status_code == 200
+        self.assert_template_used('publisher/register-name.html')
+
+
+class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+
+        super().setUp(
+            snap_name=None,
+            endpoint_url=endpoint_url,
+            method_endpoint='POST')
+
+
+class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
+        endpoint_url = '/account/register-name'
+        api_url = (
+            'https://dashboard.snapcraft.io/dev/api/'
+            'register-name/')
+
+        data = {
+            'snap-name': 'test-snap'
+        }
+
+        super().setUp(
+            snap_name=None,
+            api_url=api_url,
+            endpoint_url=endpoint_url,
+            method_api='POST',
+            method_endpoint='POST',
+            data=data)
+
+    @responses.activate
+    def test_post_no_data(self):
+        response = self.client.post(
+            self.endpoint_url,
+        )
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_snap_name(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            b'{"snap_name": "test-snap"}',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_store(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        self.data['store'] = 'store'
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertIn(
+            b'"snap_name": "test-snap"',
+            called.request.body)
+        self.assertIn(
+            b'"store": "store"',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_private(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        self.data['is_private'] = 'on'
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertIn(
+            b'"snap_name": "test-snap"',
+            called.request.body)
+        self.assertIn(
+            b'"is_private": true',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_post_registrant_comment(self):
+        responses.add(
+            responses.POST, self.api_url,
+            json={}, status=200)
+
+        self.data['registrant_comment'] = 'comment'
+        response = self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        self.assertIn(
+            b'"snap_name": "test-snap"',
+            called.request.body)
+        self.assertIn(
+            b'"registrant_comment": "comment"',
+            called.request.body)
+
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_error_from_api(self):
+        payload = {
+            'error_list': [
+                {
+                    'code': 'error-code'
+                },
+            ]
+        }
+        responses.add(
+            responses.POST, self.api_url,
+            json=payload, status=400)
+
+        self.client.post(
+            self.endpoint_url,
+            data=self.data,
+        )
+
+        self.assert_template_used('publisher/register-name.html')
+        self.assert_context('errors', payload['error_list'])


### PR DESCRIPTION
# Summary

Instead of having all the routes at the "root" file `app.py`, every URL should be in it's own module. To do this [Blueprints](http://flask.pocoo.org/docs/1.0/blueprints/) provided by Flask Framework are really useful. This can help us create an app modularized.

## Technical
In a module we can set the url to be really simple. For example in publisher pages:
```python
# modules/publisher/views.py
@publisher_pages.route('/details')
def get_account_details():
  return 'details'
```

When we create the blueprint in the configuration file of the entire app, we can prefix all the endpoints of that particular blueprint:

```python
# app.py
app.register_blueprint(
  publisher_views.publisher_pages, url_prefix='/account')
```
In this case this will mean that every enpoint of the publisher pages are going to be prefixed by `/account` so the endpoint previously made can be called at `/account/details`

## UX
In this optic it could be really interesting to create 3 modules of our app: homepage, store and publisher. So that in the future if we want to provide a deployable snapcraft.io to other companies it's gonna be reallly easy for them to choose what blueprints they want to use, or to display as a first page for example (why not having directly the store as homepage? :smile: )

## Advantages

- Easy to set up
- Application modular, easy to make changes
- We start using the real advantages of Flask
- Less code redundancy

## To go further 

Here are some little thoughs I had (not planned)
- Why not transforming into proper module and publish them, In our case this could mean having 4 projects:
  - One that creates the app (snapcraft.io)
  - Our homepage (snapcraft-io-homepage)
  - The store (snapcraft-io-store)
  - The Publisher pages (snapcraft-io-publisher)
- All those modules could be independant, why not runnable on their own (technicly all the configuration should be in the function [`create_app`](http://flask.pocoo.org/docs/1.0/patterns/appfactories/) provided by Flask. This means that the module would provide a blueprint and an app factory
- Login handler as a module for other modules that need to have logged in endpoints, it will be required by all the modules that require it, not anymore in the "main" project
- Having a page that explains how to deploy your own store
- Continue to dream :moon: 

# Not done yet

In flask.redirect (s) use function `url_for` instead of absolute path

# QA

- `./run`
- Make sure that every page works as usual