### PR TITLE
Update channel map layout

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -8,6 +8,7 @@
   .p-snap-heading {
     display: flex;
 
+
     &__icon {
       align-self: flex-start;
       flex-shrink: 0;
@@ -63,6 +64,8 @@
   .p-channel-map {
     box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
     left: 0;
+    padding-bottom: $sp-medium;
+    padding-top: $sp-medium;
     position: absolute;
     right: 0;
     top: 0;
@@ -78,38 +81,20 @@
       transform: translateY(-1111px); // should be high enough to hide it on mobile
     }
 
-    // align hide button with stable install instructions
-    &__hide {
-      text-align: right;
-
-      @media screen and (min-width: $breakpoint-medium) {
-        float: right;
-        margin-left: $sp-x-small;
-        margin-top: 49px; // align with install instructions
-      }
-    }
-
-
     &__row {
       @extend %clearfix;
-      border-bottom: 1px solid $color-mid-light;
       margin: 0;
-      padding-bottom: 2rem;
-      padding-top: 1rem;
+      padding-bottom: $sp-x-large;
 
       // hide install instructions when no release in channel
       &--closed {
         .p-code-snippet {
           display: none;
         }
-
-        .p-form-help-text {
-          margin-top: .125rem; // align with channel name
-        }
       }
 
       &--heading {
-        padding-bottom: .5rem;
+        padding-bottom: $sp-small;
         padding-top: 0;
 
         @media screen and (max-width: $breakpoint-medium) {
@@ -118,14 +103,39 @@
       }
     }
 
+    // align track select with candidate input
+    &__track-field {
+      margin-top: $sp-large;
+    }
 
-    &__footer {
-      @extend %clearfix;
-      margin: 0;
+    &__channel-name {
+      display: inline-block;
+      font-weight: 400;
+      padding-top: $sp-x-small;
+    }
 
-      @media screen and (min-width: $breakpoint-medium) {
-        padding-top: 1rem;
+    .p-tabs {
+      background: transparent; // remove default white background
+      border-bottom: 1px solid $color-mid-light;
+      position: relative; // for close button;
+
+      &::before {
+        display: none; // hide mobile arror thingy
       }
+
+      .p-tabs__list {
+        padding: 0; // remove left padding
+      }
+    }
+
+    &__hide {
+      background-color: transparent;
+      background-size: $sp-medium $sp-medium;
+      border: 0;
+      padding: $sp-small;
+      position: absolute;
+      right: $sp-small;
+      top: $sp-small;
     }
   }
 

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -1,5 +1,18 @@
 <div id='js-channel-map' class="p-strip--light p-channel-map is-closed">
   <div class="row">
+    <div class="col-12">
+      <nav class="p-tabs">
+        <ul class="p-tabs__list" role="tablist">
+          <li class="p-tabs__item" role="presentation">
+            <span class="p-tabs__link" role="tab" aria-selected="true">All versions</span>
+          </li>
+        </ul>
+        <button class="p-channel-map__hide p-icon--close js-hide-channel-map" aria-label="Hide all versions">Hide</button>
+      </nav>
+    </div>
+  </div>
+
+  <div class="row">
     <div class="col-3">
       <form>
         <div class="js-channel-map-arch-field">
@@ -9,7 +22,7 @@
           <select id="js-channel-map-architecture-select">
           </select>
         </div>
-        <div class="js-channel-map-track-field">
+        <div class="p-channel-map__track-field js-channel-map-track-field">
           <label for="js-channel-map-track-select">
             Track
             <span class="p-tooltip is-icon" aria-describedby="tooltip-track">
@@ -24,11 +37,11 @@ where you can install and get updates from.</span>
       </form>
     </div>
 
-    <div class="col-7">
+    <div class="col-9">
 
       <div class="p-channel-map__row p-channel-map__row--heading">
-        <div class="col-2">
-          Channel
+        <div class="col-8">
+          Command line install
           <span class="p-tooltip p-tooltip--btm-center" aria-describedby="tooltip-channel">
             <i class="p-icon--information"></i>
             <span class="p-tooltip__message" role="tooltip" id="tooltip-channel">Install this application from ‘channels’ of varying stability.
@@ -36,16 +49,13 @@ For example, Edge is used for development and testing, whereas
 Stable is used for well tested and production ready versions.</span>
           </span>
         </div>
-        <div class="col-5">
-          Install instructions
-        </div>
       </div>
 
       <div id="js-channel-map-stable" class="p-channel-map__row">
         <div class="col-2">
-          <span class="js-channel-name">stable</span>
+          <span class="p-channel-map__channel-name js-channel-name">stable</span>
         </div>
-        <div class="col-5">
+        <div class="col-6">
           <div class="p-code-snippet">
             <input
               class="p-code-snippet__input"
@@ -66,9 +76,9 @@ Stable is used for well tested and production ready versions.</span>
 
       <div id="js-channel-map-candidate" class="p-channel-map__row">
         <div class="col-2">
-          <span class="js-channel-name">candidate</span>
+          <span class="p-channel-map__channel-name js-channel-name">candidate</span>
         </div>
-        <div class="col-5">
+        <div class="col-6">
           <div class="p-code-snippet">
             <input
               class="p-code-snippet__input"
@@ -89,9 +99,9 @@ Stable is used for well tested and production ready versions.</span>
 
       <div id="js-channel-map-beta" class="p-channel-map__row">
         <div class="col-2">
-          <span class="js-channel-name">beta</span>
+          <span class="p-channel-map__channel-name js-channel-name">beta</span>
         </div>
-        <div class="col-5">
+        <div class="col-6">
           <div class="p-code-snippet">
             <input
               class="p-code-snippet__input"
@@ -112,9 +122,9 @@ Stable is used for well tested and production ready versions.</span>
 
       <div id="js-channel-map-edge" class="p-channel-map__row">
         <div class="col-2">
-          <span class="js-channel-name">edge</span>
+          <span class="p-channel-map__channel-name js-channel-name">edge</span>
         </div>
-        <div class="col-5">
+        <div class="col-6">
           <div class="p-code-snippet">
             <input
               class="p-code-snippet__input"
@@ -133,18 +143,7 @@ Stable is used for well tested and production ready versions.</span>
         </div>
       </div>
 
-      <div class="p-channel-map__footer">
-        <div class="col-2"></div>
-        <div class="col-5">
-      <p class="p-form-help-text">
-        To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
-      </p>
     </div>
-  </div>
-  </div>
-  <div class="p-channel-map__hide">
-    <button class="p-button--neutral js-hide-channel-map">Hide versions</button>
-  </div>
   </div>
 </div>
 <div class="p-channel-map-overlay" style="display: none"></div>


### PR DESCRIPTION
Fixes #618

Updates channel map layout for upcoming tabs and install button.
Install button on separate tab is part of another PR, not in scope of this issue.

### QA

- ./run or http://snapcraft.io-pr-641.run.demo.haus/
- go to detail pages of some snaps ([android-studio](http://snapcraft.io-pr-641.run.demo.haus/android-studio) [webstorm](http://snapcraft.io-pr-641.run.demo.haus/webstorm))
- open channel map
- it should have updated layout, X close icon, bigger cli install instructions

<img width="1068" alt="screen shot 2018-05-09 at 13 34 45" src="https://user-images.githubusercontent.com/83575/39812708-001112e8-538e-11e8-9d5e-8416321de61f.png">
