### PR TITLE
Close channel map when clicking outside or on Escape

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -107,19 +107,43 @@ export default function initChannelMap(el, packageName, channelMapData) {
   let closeTimeout;
 
   // init open/hide buttons
-  document.querySelector('.js-open-channel-map').addEventListener('click', () => {
+  const openChannelMap = () => {
     // clear hiding animation if it's still running
     clearTimeout(closeTimeout);
     // make sure overlay is displayed before CSS transitions are triggered
     channelOverlayEl.style.display = 'block';
     setTimeout(() => channelMapEl.classList.remove('is-closed'), 10);
-  });
 
-  document.querySelector('.js-hide-channel-map').addEventListener('click', () => {
+    window.addEventListener('keyup', hideOnEscape);
+    document.addEventListener('click', hideOnClick);
+  };
+
+  const hideChannelMap = () => {
     channelMapEl.classList.add('is-closed');
     // hide overlay after CSS transition is finished
     closeTimeout = setTimeout(() => channelOverlayEl.style.display = 'none', 500);
-  });
+
+    window.removeEventListener('keyup', hideOnEscape);
+    document.removeEventListener('click', hideOnClick);
+  };
+
+  const hideOnEscape = (event) => {
+    if (event.key === "Escape" && !channelMapEl.classList.contains('is-closed')) {
+      hideChannelMap();
+    }
+  };
+
+  const hideOnClick = (event) => {
+    // when channel map is not closed and clicking outside of it, close it
+    if (!channelMapEl.classList.contains('is-closed') &&
+        !event.target.closest(el)) {
+      hideChannelMap();
+    }
+  };
+
+  // show/hide when clicking on buttons
+  document.querySelector('.js-open-channel-map').addEventListener('click', openChannelMap);
+  document.querySelector('.js-hide-channel-map').addEventListener('click', hideChannelMap);
 
   // get architectures from data
   const architectures = Object.keys(channelMapData);


### PR DESCRIPTION
Fixes #646

Adds possibility to close channel map overlay by clicking anywhere outside of channel map (top navigation bar or dark overlay) or by pressing Escape key.

### QA
- ./run or http://snapcraft.io-pr-648.run.demo.haus/
- go to snap details page of any snap
- open channel map with 'Show all versions' button
- close it by clicking anywhere outside
- open again
- close it by pressing Esc
- open again
- close it by clicking X button in top right
- open again
- try to click around channel map (dropdowns, copy instructions) - it should not be closed by accident when using it