### PR TITLE
Adds install tab to channel map overlay

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -152,7 +152,7 @@ export default function initChannelMap(el, packageName, channelMapData) {
   const channelMapEl = document.querySelector(el);
   const channelOverlayEl = document.querySelector('.p-channel-map-overlay');
 
-  const defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls=channel-map-tab-versions]');
+  const defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls=channel-map-tab-install]');
   initTabs(channelMapEl);
 
   let closeTimeout;

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -123,7 +123,31 @@ function initTabs(el) {
   });
 }
 
+function initOpenSnapButtons() {
+  document.addEventListener('click', (event) => {
+    const openButton = event.target.closest('.js-open-snap-button');
+
+    if (openButton) {
+      const name = openButton.dataset.snap;
+      let iframe = document.querySelector('.js-snap-open-frame');
+
+      if (iframe) {
+        iframe.parentNode.removeChild(iframe);
+      }
+
+      iframe = document.createElement('iframe');
+      iframe.className = 'js-snap-open-frame';
+      iframe.style.position = 'absolute';
+      iframe.style.top = '-9999px';
+      iframe.style.left = '-9999px';
+      iframe.src = `snap://${name}`;
+      document.body.appendChild(iframe);
+    }
+  });
+}
+
 export default function initChannelMap(el, packageName, channelMapData) {
+  initOpenSnapButtons();
 
   const channelMapEl = document.querySelector(el);
   const channelOverlayEl = document.querySelector('.p-channel-map-overlay');

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -101,15 +101,46 @@ function setArchitecture(arch, packageName, channelMapData) {
   setTrack(arch, track, packageName, channelMap);
 }
 
+function selectTab(tabEl, tabsWrapperEl) {
+  const selected = tabEl.getAttribute('aria-selected');
+  if (!selected) {
+    tabsWrapperEl.querySelector('.p-channel-map__tab.is-open').classList.remove('is-open');
+    tabsWrapperEl.querySelector('.p-tabs__link[aria-selected]').removeAttribute('aria-selected');
+
+    document.getElementById(tabEl.getAttribute('aria-controls')).classList.add('is-open');
+    tabEl.setAttribute('aria-selected', "true");
+  }
+}
+
+function initTabs(el) {
+  el.addEventListener('click', (event) => {
+    const target = event.target.closest('.p-tabs__link');
+
+    if (target) {
+      event.preventDefault();
+      selectTab(target, el);
+    }
+  });
+}
+
 export default function initChannelMap(el, packageName, channelMapData) {
+
   const channelMapEl = document.querySelector(el);
   const channelOverlayEl = document.querySelector('.p-channel-map-overlay');
+
+  const defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls=channel-map-tab-versions]');
+  initTabs(channelMapEl);
+
   let closeTimeout;
 
   // init open/hide buttons
   const openChannelMap = () => {
     // clear hiding animation if it's still running
     clearTimeout(closeTimeout);
+
+    // select default tab before opening
+    selectTab(defaultTab, channelMapEl);
+
     // make sure overlay is displayed before CSS transitions are triggered
     channelOverlayEl.style.display = 'block';
     setTimeout(() => channelMapEl.classList.remove('is-closed'), 10);

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -65,10 +65,6 @@
     margin-top: $sp-x-small;
   }
 
-  .p-form-help-text.is-condensed {
-    margin-top: $sp-xx-small;
-  }
-
   .p-channel-map {
     box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
     left: 0;

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -60,11 +60,18 @@
     }
   }
 
+  .p-view-store-button,
+  .p-cli-install {
+    margin-top: $sp-x-small;
+  }
+
+  .p-form-help-text.is-condensed {
+    margin-top: $sp-xx-small;
+  }
 
   .p-channel-map {
     box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
     left: 0;
-    padding-bottom: $sp-medium;
     padding-top: $sp-medium;
     position: absolute;
     right: 0;
@@ -136,6 +143,14 @@
       position: absolute;
       right: $sp-small;
       top: $sp-small;
+    }
+  }
+
+  .p-channel-map__tab {
+    display: none;
+
+    &.is-open {
+      display: block;
     }
   }
 

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -44,7 +44,7 @@
 {% block content %}
   <div class="p-strip--light is-shallow">
     <div class="row">
-      <div class="col-4">
+      <div class="col-5">
         <div class="p-snap-heading">
           {% if icon_url %}
             <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
@@ -78,12 +78,12 @@
           </p>
         </div>
       </div>
-      <div class="col-3 p-snap-install__versions">
-        <button class="p-button--neutral js-open-channel-map">Show all versions</button>
+      <div class="col-2 p-snap-install__versions">
+        <button class="p-button--neutral js-open-channel-map">Install…</button>
       </div>
     </div>
   </div>
-  
+
   {% include "snap-details/_channel_map.html" %}
 
   {% if screenshots %}

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -4,18 +4,18 @@
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
           <li class="p-tabs__item" role="presentation">
-            <a href="#install" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-install">{{ snap_title }} {{ version }}</a>
+            <a href="#install" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-install" aria-selected="true">{{ snap_title }} {{ version }}</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#versions" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-versions" aria-selected="true">All versions</a>
+            <a href="#versions" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-versions">All versions</a>
           </li>
         </ul>
         <button class="p-channel-map__hide p-icon--close js-hide-channel-map" aria-label="Hide all versions">Hide</button>
       </nav>
     </div>
   </div>
-  <div class="row p-channel-map__tab" id="channel-map-tab-install">
-    <div class="col-6">
+  <div class="row p-channel-map__tab is-open" id="channel-map-tab-install">
+    <div class="col-5">
       <p>Ubuntu 16.04 or later?</p>
       <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
       <p class="p-form-help-text">Make sure you have a Desktop store installed.</p>
@@ -40,7 +40,7 @@
       </p>
     </div>
   </div>
-  <div class="row p-channel-map__tab is-open" id="channel-map-tab-versions">
+  <div class="row p-channel-map__tab" id="channel-map-tab-versions">
     <div class="col-3">
       <form>
         <div class="js-channel-map-arch-field">

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -18,10 +18,10 @@
     <div class="col-5">
       <p>Ubuntu 16.04 or later?</p>
       <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
-      <p class="p-form-help-text">Make sure you have a Desktop store installed.</p>
+      <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
     </div>
     <div class="col-5">
-      <p>Install with snapd:</p>
+      <p>Install with snapd</p>
       <div class="p-code-snippet p-cli-install">
         <input
           class="p-code-snippet__input"

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -4,15 +4,44 @@
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
           <li class="p-tabs__item" role="presentation">
-            <span class="p-tabs__link" role="tab" aria-selected="true">All versions</span>
+            <a href="#install" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-install">{{ snap_title }} {{ version }}</a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#versions" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-versions" aria-selected="true">All versions</a>
           </li>
         </ul>
         <button class="p-channel-map__hide p-icon--close js-hide-channel-map" aria-label="Hide all versions">Hide</button>
       </nav>
     </div>
   </div>
-
-  <div class="row">
+  <div class="row p-channel-map__tab" id="channel-map-tab-install">
+    <div class="col-6">
+      <p>Ubuntu 16.04 or later?</p>
+      <p class="p-form-help-text is-condensed">(Or a snap enabled store)</p>
+      <button class="p-view-store-button">View in store</button>
+    </div>
+    <div class="col-5">
+      <p>Got snapd installed?</p>
+      <p class="p-form-help-text  is-condensed">(Or just prefer the command line)</p>
+      <div class="p-code-snippet p-cli-install">
+        <input
+          class="p-code-snippet__input"
+          id="snap-install"
+          value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
+          readonly="readonly"
+        />
+        <button
+          class="p-code-snippet__action js-clipboard-copy"
+          data-clipboard-target="#snap-install">
+          Copy to clipboard
+        </button>
+      </div>
+      <p class="p-form-help-text">
+        Don't have snapd? <a href="https://docs.snapcraft.io/core/install">Get set up for snaps</a>.
+      </p>
+    </div>
+  </div>
+  <div class="row p-channel-map__tab is-open" id="channel-map-tab-versions">
     <div class="col-3">
       <form>
         <div class="js-channel-map-arch-field">

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -17,12 +17,11 @@
   <div class="row p-channel-map__tab" id="channel-map-tab-install">
     <div class="col-6">
       <p>Ubuntu 16.04 or later?</p>
-      <p class="p-form-help-text is-condensed">(Or a snap enabled store)</p>
-      <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in store</button>
+      <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
+      <p class="p-form-help-text">Make sure you have a Desktop store installed.</p>
     </div>
     <div class="col-5">
-      <p>Got snapd installed?</p>
-      <p class="p-form-help-text  is-condensed">(Or just prefer the command line)</p>
+      <p>Install with snapd:</p>
       <div class="p-code-snippet p-cli-install">
         <input
           class="p-code-snippet__input"

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -18,7 +18,7 @@
     <div class="col-6">
       <p>Ubuntu 16.04 or later?</p>
       <p class="p-form-help-text is-condensed">(Or a snap enabled store)</p>
-      <button class="p-view-store-button">View in store</button>
+      <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in store</button>
     </div>
     <div class="col-5">
       <p>Got snapd installed?</p>


### PR DESCRIPTION
Fixes #619 

Adds new tab to channel map overlay with install instructions for stable version and 'View in store' install button, that on supported system will open native store application.

### QA

- ./run or http://snapcraft.io-pr-653.run.demo.haus/
- go to details page of any snap
- open channel map via 'Show all versions' button
- on top there is a new tab with snap name and current version
- click it to open install tab
- you should see CLI install instructions for stable version (same as on snap details page)
- you should see 'View in store' button
- if you are on supported system clicking on a button should open store app for given snap

<img width="1081" alt="screen shot 2018-05-14 at 15 01 51" src="https://user-images.githubusercontent.com/83575/39998934-e42231c2-5787-11e8-932a-d721603ac257.png">

<img width="1073" alt="screen shot 2018-05-14 at 15 02 09" src="https://user-images.githubusercontent.com/83575/39998932-e406a7d6-5787-11e8-9d51-2a6a05bb069e.png">

