### PR TITLE
Missing url from schema

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -68,6 +68,7 @@
         "@type": "Organization",
         "name": "Snapcraft",
         "logo": "https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
+        "url": "https://snapcraft.io",
         "sameAs": [
           "https://developer.ubuntu.com/snapcraft",
           "https://github.com/snapcore/snapcraft",


### PR DESCRIPTION
Now that the SEO stuff is live, **NOW** the google checker says that URL is required for an organization.

This adds the URL field.