### PR TITLE
Reduce spacing at the top my snaps page

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -6,7 +6,7 @@ My snaps — Linux software in the Snap Store
 
 {% block content %}
 {% include "publisher/_beta-notification.html" %}
-<section class="p-strip">
+<section class="p-strip is-shallow">
   <div class="row">
     <div class="col-12">
       <h1 class="p-heading--three u-float--left">My snaps</h1>


### PR DESCRIPTION
# Done

Fixes https://github.com/canonicalltd/snapcraft-design/issues/417

- Added `is-shallow` to `p-strip`

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps with 1 new snap uploaded
- Ensure the spacing is smaller

# Screenshot

![screenshot-2018-5-15 my snaps linux software in the snap store](https://user-images.githubusercontent.com/479384/40048460-35f739dc-582a-11e8-9eb9-d1e2cdf0b0bf.png)
