### PR TITLE
Updated beta bar notification copy

### DIFF
--- a/templates/publisher/_beta-notification.html
+++ b/templates/publisher/_beta-notification.html
@@ -2,10 +2,10 @@
   <div class="row p-beta-notification">
     <div class="col-12">
       <p>
-        <span class="p-muted-heading"><b>Beta</b></span>
-        Snapcraft.io is in Beta. Can't find something?
-        <a href="https://dashboard.snapcraft.io/snaps" class="p-link--external">Go back to the old version</a> or
-        <a href="https://github.com/canonical-websites/snapcraft.io/issues" class="p-link--external">report an issue</a>.
+        Thanks for trying out these new pages.
+        <a href="https://dashboard.snapcraft.io/snaps" class="p-link--external"> Use dashboard for other functions</a>,
+        <a href="https://github.com/canonical-websites/snapcraft.io/issues" class="p-link--external">report an issue</a> or 
+        <a href="https://forum.snapcraft.io/categories" class="p-link--external">give us your feedback</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
# Done

Fixes #596 

- Updated beta bar notification from:
`BETA: Snapcraft.io is in Beta. Can't find something? Go back to the old version`(link to dashboard.snapcraft.io) 'or report an issue' (link to github snapcraft.io issues)
to:
`Thanks for trying out these new pages. Use dashboard for other functions` (link to dashboard.snapcraft.io) `report an issue` (link to github snapcraft.io issues) `or give us your feedback` (link to forum)

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/
- Ensure the copy is updated

# Screenshot

![image](https://user-images.githubusercontent.com/8167677/40009982-6772d37a-579b-11e8-86c4-8d420df2bf59.png)
