### PR TITLE
Add spinner to save button (when saving)

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -197,6 +197,12 @@ function initForm(config, initialState, errors) {
 
       // make sure we don't warn user about leaving the page when submitting
       ignoreChangesOnUnload = true;
+
+      // disable button and show spinner when loading is long
+      disableSubmit();
+      setTimeout(() => {
+        submitButton.classList.add('has-spinner');
+      }, 2000);
     } else {
       event.preventDefault();
     }

--- a/static/sass/_patterns_button_spinner.scss
+++ b/static/sass/_patterns_button_spinner.scss
@@ -1,0 +1,23 @@
+@mixin p-button-spinner {
+  .has-spinner {
+    position: relative;
+  }
+
+
+  // fighting with Vanilla specificity
+  [class*="p-button-"] .p-button__spinner {
+    display: none;
+    left: calc(50% - 8px);
+    position: absolute;
+    top: calc(50% - 8px);
+
+  }
+
+  .has-spinner .p-button__spinner {
+    display: block;
+  }
+
+  .has-spinner .p-button__text {
+    opacity: 0;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -57,6 +57,9 @@ $color-navigation-background: #252525;
 @import 'patterns_table-key-value';
 @include vf-p-table-key-value;
 
+@import 'patterns_button_spinner';
+@include p-button-spinner;
+
 @import 'map';
 @include snap-details-map;
 

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -34,7 +34,16 @@
               <div class="col-5">
                 <div class="u-align--right">
                   <a class="p-button--neutral js-market-revert" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
-                  <input type="submit" class="u-no-margin--top p-button--positive js-market-submit" name="submit_apply" value="Save"/>
+                  <button type="submit" class="u-no-margin--top p-button--positive p-button-spinner js-market-submit" name="submit_apply" value="Save">
+                    {#
+                      to force dark icon variant we need a fake --dark class name:
+                      https://github.com/vanilla-framework/vanilla-framework/issues/1817
+                    #}
+                    <span class="p-button__spinner vanilla-workaround--dark">
+                      <i class="p-icon--spinner u-animation--spin"></i>
+                    </span>
+                    <span class="p-button__text">Save</span>
+                  </button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixes #602

Makes 'Save' button disabled when submit/upload is in progress. Also adds spinner to the button when loading takes more then 2 seconds.

### QA

- ./run or http://snapcraft.io-pr-664.run.demo.haus/
- go to listing page of any snap
- 'Save' button should be disabled until any change is made
- modify something (and possibly add some screenshots to upload)
- 'Save' button should become enabled
- click 'Save'
- 'Save' should become disabled
- after 2 seconds if save/upload didn't finish spinner should appear on button

<img width="1072" alt="screen shot 2018-05-16 at 12 20 05" src="https://user-images.githubusercontent.com/83575/40112072-21177de8-5905-11e8-80f7-4273be504dc9.png">
