### PR TITLE
Make Install more prominent and remove duplication #666

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -1,3 +1,5 @@
+/* global ga */
+
 const LATEST = 'latest';
 
 function setTrack(arch, track, packageName, channelMap) {
@@ -142,6 +144,15 @@ function initOpenSnapButtons() {
       iframe.style.left = '-9999px';
       iframe.src = `snap://${name}`;
       document.body.appendChild(iframe);
+
+      if (typeof ga !== 'undefined') {
+        ga('gtm1.send', {
+          hitType: 'event',
+          eventCategory: 'Snap details',
+          eventAction: 'Click view in desktop store button',
+          eventLabel: `Click view in desktop store for ${name} snap`
+        });
+      }
     }
   });
 }
@@ -178,6 +189,15 @@ export default function initChannelMap(el, packageName, channelMapData) {
 
       window.addEventListener('keyup', hideOnEscape);
       document.addEventListener('click', hideOnClick);
+
+      if (typeof ga !== 'undefined') {
+        ga('gtm1.send', {
+          hitType: 'event',
+          eventCategory: 'Snap details',
+          eventAction: 'Open install dialog',
+          eventLabel: `Open ${openTabName} dialog tab for ${packageName} snap`
+        });
+      }
     }
   };
 

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -152,28 +152,33 @@ export default function initChannelMap(el, packageName, channelMapData) {
   const channelMapEl = document.querySelector(el);
   const channelOverlayEl = document.querySelector('.p-channel-map-overlay');
 
-  var defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls=channel-map-tab-install]');
   initTabs(channelMapEl);
 
   let closeTimeout;
 
   // init open/hide buttons
-  const openChannelMap = (openedTab) => {
-    // clear hiding animation if it's still running
-    clearTimeout(closeTimeout);
-    
-    if (openedTab)
-      defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls='+openedTab+']');
+  const openChannelMap = (event) => {
+    const openButton = event.target.closest('.js-open-channel-map');
 
-    // select default tab before opening
-    selectTab(defaultTab, channelMapEl);
+    if (openButton) {
+      // open tab based on button click (or install tab by default)
+      const openTabName = openButton.getAttribute('aria-controls') || 'channel-map-tab-install';
 
-    // make sure overlay is displayed before CSS transitions are triggered
-    channelOverlayEl.style.display = 'block';
-    setTimeout(() => channelMapEl.classList.remove('is-closed'), 10);
+      // clear hiding animation if it's still running
+      clearTimeout(closeTimeout);
 
-    window.addEventListener('keyup', hideOnEscape);
-    document.addEventListener('click', hideOnClick);
+      const openTab = channelMapEl.querySelector(`.p-tabs__link[aria-controls=${openTabName}]`);
+
+      // select default tab before opening
+      selectTab(openTab, channelMapEl);
+
+      // make sure overlay is displayed before CSS transitions are triggered
+      channelOverlayEl.style.display = 'block';
+      setTimeout(() => channelMapEl.classList.remove('is-closed'), 10);
+
+      window.addEventListener('keyup', hideOnEscape);
+      document.addEventListener('click', hideOnClick);
+    }
   };
 
   const hideChannelMap = () => {
@@ -200,13 +205,7 @@ export default function initChannelMap(el, packageName, channelMapData) {
   };
 
   // show/hide when clicking on buttons
-  Array.from(document.querySelectorAll('.js-open-channel-map')).forEach(
-    button => {
-      button.addEventListener('click', ()=> {
-        openChannelMap(button.getAttribute('name'));
-      });
-    }
-  );
+  document.addEventListener('click', openChannelMap);
   document.querySelector('.js-hide-channel-map').addEventListener('click', hideChannelMap);
 
   // get architectures from data

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -152,15 +152,18 @@ export default function initChannelMap(el, packageName, channelMapData) {
   const channelMapEl = document.querySelector(el);
   const channelOverlayEl = document.querySelector('.p-channel-map-overlay');
 
-  const defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls=channel-map-tab-install]');
+  var defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls=channel-map-tab-install]');
   initTabs(channelMapEl);
 
   let closeTimeout;
 
   // init open/hide buttons
-  const openChannelMap = () => {
+  const openChannelMap = (openedTab) => {
     // clear hiding animation if it's still running
     clearTimeout(closeTimeout);
+    
+    if (openedTab)
+      defaultTab = channelMapEl.querySelector('.p-tabs__link[aria-controls='+openedTab+']');
 
     // select default tab before opening
     selectTab(defaultTab, channelMapEl);
@@ -197,7 +200,13 @@ export default function initChannelMap(el, packageName, channelMapData) {
   };
 
   // show/hide when clicking on buttons
-  document.querySelector('.js-open-channel-map').addEventListener('click', openChannelMap);
+  Array.from(document.querySelectorAll('.js-open-channel-map')).forEach(
+    button => {
+      button.addEventListener('click', ()=> {
+        openChannelMap(button.getAttribute('name'));
+      });
+    }
+  );
   document.querySelector('.js-hide-channel-map').addEventListener('click', hideChannelMap);
 
   // get architectures from data

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -46,7 +46,7 @@
   .p-snap-install {
 
     &__versions {
-      margin-top: 73px; // align with install instructions
+      margin-top: 68px; // align with install instructions
       text-align: right;
     }
 

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -43,21 +43,9 @@
     }
   }
 
-  .p-snap-install {
-
-    &__versions {
-      margin-top: 68px; // align with install instructions
-      text-align: right;
-    }
-
-    .p-code-snippet {
-      font-size: 1rem;
-      margin-top: $sp-x-small;
-    }
-
-    @media screen and (min-width: $breakpoint-medium) {
-      margin-top: 41px; // align with channel map
-    }
+  .p-snap-install-buttons {
+    margin-top: 68px; // align with snap name (60px icon + 8px margin)
+    text-align: right;
   }
 
   .p-view-store-button,

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -58,7 +58,7 @@
         </div>
       </div>
       <div class="col-5 p-snap-install__versions">
-        <button class="p-button--positive js-open-channel-map" name="channel-map-tab-install">Install…</button>
+        <button class="p-button--positive js-open-channel-map" name="channel-map-tab-install">Install</button>
         <button class="p-button--neutral js-open-channel-map" name="channel-map-tab-versions">All versions</button>
       </div>
     </div>
@@ -98,27 +98,7 @@
           <p{% if website %} class="u-no-margin--top"{% endif %}>
             <a href="{{ contact }}">Contact {{ publisher }}</a>
           </p>
-        {% endif %}
-
-        <div class="p-snap-install">
-          <p>Install stable version</p>
-          <div class="p-code-snippet">
-            <input
-              class="p-code-snippet__input"
-              id="snap-install"
-              value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
-              readonly="readonly"
-            />
-            <button
-              class="p-code-snippet__action js-clipboard-copy"
-              data-clipboard-target="#snap-install">
-              Copy to clipboard
-            </button>
-          </div>
-          <p class="p-form-help-text">
-            To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
-          </p>
-        </div>        
+        {% endif %}       
       </div>
       <div class="col-4">
         <table class="p-table-key-value">

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -57,7 +57,7 @@
           </div>
         </div>
       </div>
-      <div class="col-5 p-snap-install__versions">
+      <div class="col-5 p-snap-install-buttons">
         <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
         <button class="p-button--neutral js-open-channel-map" aria-controls="channel-map-tab-versions">All versions</button>
       </div>

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -58,8 +58,8 @@
         </div>
       </div>
       <div class="col-5 p-snap-install__versions">
-        <button class="p-button--positive js-open-channel-map" name="channel-map-tab-install">Install</button>
-        <button class="p-button--neutral js-open-channel-map" name="channel-map-tab-versions">All versions</button>
+        <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
+        <button class="p-button--neutral js-open-channel-map" aria-controls="channel-map-tab-versions">All versions</button>
       </div>
     </div>
   </div>
@@ -98,13 +98,13 @@
           <p{% if website %} class="u-no-margin--top"{% endif %}>
             <a href="{{ contact }}">Contact {{ publisher }}</a>
           </p>
-        {% endif %}       
+        {% endif %}
       </div>
       <div class="col-4">
         <table class="p-table-key-value">
           <tr><th>License</th><td>{{ license }}</td></tr>
           <tr><th>Size</th><td>{{ filesize }}</td></tr>
-          <tr><th width="100">Version</th><td>{{ version }}</td></tr>          
+          <tr><th width="100">Version</th><td>{{ version }}</td></tr>
         </table>
       </div>
     </div>

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -44,7 +44,7 @@
 {% block content %}
   <div class="p-strip--light is-shallow">
     <div class="row">
-      <div class="col-5">
+      <div class="col-7">
         <div class="p-snap-heading">
           {% if icon_url %}
             <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
@@ -57,29 +57,9 @@
           </div>
         </div>
       </div>
-      <div class="col-5">
-        <div class="p-snap-install">
-          <p>Install stable version</p>
-          <div class="p-code-snippet">
-            <input
-              class="p-code-snippet__input"
-              id="snap-install"
-              value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
-              readonly="readonly"
-            />
-            <button
-              class="p-code-snippet__action js-clipboard-copy"
-              data-clipboard-target="#snap-install">
-              Copy to clipboard
-            </button>
-          </div>
-          <p class="p-form-help-text">
-            To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
-          </p>
-        </div>
-      </div>
-      <div class="col-2 p-snap-install__versions">
-        <button class="p-button--neutral js-open-channel-map">Install…</button>
+      <div class="col-5 p-snap-install__versions">
+        <button class="p-button--positive js-open-channel-map" name="channel-map-tab-install">Install…</button>
+        <button class="p-button--neutral js-open-channel-map" name="channel-map-tab-versions">All versions</button>
       </div>
     </div>
   </div>
@@ -119,12 +99,32 @@
             <a href="{{ contact }}">Contact {{ publisher }}</a>
           </p>
         {% endif %}
+
+        <div class="p-snap-install">
+          <p>Install stable version</p>
+          <div class="p-code-snippet">
+            <input
+              class="p-code-snippet__input"
+              id="snap-install"
+              value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
+              readonly="readonly"
+            />
+            <button
+              class="p-code-snippet__action js-clipboard-copy"
+              data-clipboard-target="#snap-install">
+              Copy to clipboard
+            </button>
+          </div>
+          <p class="p-form-help-text">
+            To run snaps on your system you'll need to <a href="https://docs.snapcraft.io/core/install">install snapd</a>.
+          </p>
+        </div>        
       </div>
       <div class="col-4">
         <table class="p-table-key-value">
-          <tr><th width="100">Version</th><td>{{ version }}</td></tr>
-          <tr><th>Size</th><td>{{ filesize }}</td></tr>
           <tr><th>License</th><td>{{ license }}</td></tr>
+          <tr><th>Size</th><td>{{ filesize }}</td></tr>
+          <tr><th width="100">Version</th><td>{{ version }}</td></tr>          
         </table>
       </div>
     </div>


### PR DESCRIPTION
# Done

Fixes #666  

- Move `command-line instructions` from the header to below the snap description
- Make `Install` a primary call to action
- Reduce copy from `Show All Versions` to `All Versions`
- `Install` and `All versions` open their relevant tabs on the Channel map

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/vlc
- Ensure copy and layout is updated
- Ensure `Install` and `All versions` open the relevant tabs on the channel map

# Screenshot

![image](https://user-images.githubusercontent.com/8167677/40164793-6a832e0c-59b2-11e8-9616-26b9484834fb.png)
