### PR TITLE
Replace Gentoo on the home page with Raspbian.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -34,8 +34,8 @@
       <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-linux-mint">
         <img src="https://assets.ubuntu.com/v1/2ce868d9-mint.png" alt="" />
       </a>
-      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-gentoo">
-        <img src="https://assets.ubuntu.com/v1/439fa9d5-gentuu.png" alt="" />
+      <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-raspbian">
+        <img src="https://assets.ubuntu.com/v1/eccf1818-raspberrypi.png" alt="" />
       </a>
       <a class="p-logo-link" href="https://docs.snapcraft.io/core/install-arch-linux">
         <img src="https://assets.ubuntu.com/v1/44789cf1-arch.png" alt="" />


### PR DESCRIPTION
This pull request replaces the Gentoo entry on the snapcraft.io home page with Raspbian. Gentoo is not well supported and should not be so prominently promoted until we've helped improve that situation.