### PR TITLE
Remove hr below snap list table if only 1 snap

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -151,7 +151,9 @@ My published snaps — Linux software in the Snap Store
   {% if registered_snaps %}
     <div class="row">
       <div class="col-12">
-        <hr />
+        {% if snaps|length > 1 %}
+          <hr />
+        {% endif %}
         <h4>My registered snap names</h4>
       </div>
     </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/599

If there's more than 1 snap in the table, show the hr above the Registered names table, otherwise don't show the hr.

This issue only affects those with registered names but only 1 published snap.

# Screenshot

![screenshot-2018-5-22 my published snaps linux software in the snap store](https://user-images.githubusercontent.com/479384/40360684-d3ae5680-5dbe-11e8-92fb-466b7f354561.png)
