### PR TITLE
Vertically align developer contact fields

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -219,7 +219,7 @@
           <div class="row">
             <div class="col-8">
               <div class="p-form-validation {% if field_errors and field_errors['website'] %}is-error{% endif %}">
-                <label class="p-label--grid-baseline">Developer website: </label>
+                <label>Developer website: </label>
                 <div class="p-form-validation__field">
                   <input
                     class="p-form-validation__input"
@@ -230,9 +230,9 @@
                     placeholder="https://snapcraft.io" />
                 </div>
                 {% if field_errors and field_errors['website'] %}
-                <p class="p-form-validation__message">
-                  <strong>Error:</strong> {{ field_errors['website'] }}
-                </p>
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['website'] }}
+                  </p>
                 {% endif %}
                 <p class="p-form-help-text">
                   Please include a valid http:// or https:// link
@@ -244,7 +244,7 @@
           <div class="row">
             <div class="col-8">
               <div class="p-form-validation {% if field_errors and field_errors['contact'] %}is-error{% endif %}">
-                <label class="p-label--grid-baseline">Contact {{ publisher_name }}: </label>
+                <label>Contact {{ publisher_name }}: </label>
                 <div class="p-form-validation__field">
                   <input
                     class="p-form-validation__input"
@@ -255,9 +255,9 @@
                     placeholder="mailto:example@example.com" />
                 </div>
                 {% if field_errors and field_errors['contact'] %}
-                <p class="p-form-validation__message">
-                  <strong>Error:</strong> {{ field_errors['contact'] }}
-                </p>
+                  <p class="p-form-validation__message">
+                    <strong>Error:</strong> {{ field_errors['contact'] }}
+                  </p>
                 {% endif %}
                 <p class="p-form-help-text">
                   Please include a valid http://, https:// or mailto: link

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -217,11 +217,9 @@
           </div>
 
           <div class="row">
-            <div class="col-2">
-              <label class="p-label--grid-baseline">Developer website: </label>
-            </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['website'] %}is-error{% endif %}">
+              <div class="p-form-validation {% if field_errors and field_errors['website'] %}is-error{% endif %}">
+                <label class="p-label--grid-baseline">Developer website: </label>
                 <div class="p-form-validation__field">
                   <input
                     class="p-form-validation__input"
@@ -232,9 +230,9 @@
                     placeholder="https://snapcraft.io" />
                 </div>
                 {% if field_errors and field_errors['website'] %}
-                  <p class="p-form-validation__message">
-                    <strong>Error:</strong> {{ field_errors['website'] }}
-                  </p>
+                <p class="p-form-validation__message">
+                  <strong>Error:</strong> {{ field_errors['website'] }}
+                </p>
                 {% endif %}
                 <p class="p-form-help-text">
                   Please include a valid http:// or https:// link
@@ -244,11 +242,9 @@
           </div>
 
           <div class="row">
-            <div class="col-2">
-              <label class="p-label--grid-baseline">Contact {{ publisher_name }}: </label>
-            </div>
             <div class="col-8">
-              <div class="p-form-validation u-no-margin {% if field_errors and field_errors['contact'] %}is-error{% endif %}">
+              <div class="p-form-validation {% if field_errors and field_errors['contact'] %}is-error{% endif %}">
+                <label class="p-label--grid-baseline">Contact {{ publisher_name }}: </label>
                 <div class="p-form-validation__field">
                   <input
                     class="p-form-validation__input"
@@ -259,9 +255,9 @@
                     placeholder="mailto:example@example.com" />
                 </div>
                 {% if field_errors and field_errors['contact'] %}
-                  <p class="p-form-validation__message">
-                    <strong>Error:</strong> {{ field_errors['contact'] }}
-                  </p>
+                <p class="p-form-validation__message">
+                  <strong>Error:</strong> {{ field_errors['contact'] }}
+                </p>
                 {% endif %}
                 <p class="p-form-help-text">
                   Please include a valid http://, https:// or mailto: link


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/676

- Made 'Developer website' and 'Contact <% publisher_name %>' stacked

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/<% snap_name %>/listing
- Scroll down to see the stacked labels and inputs

# Screenshot
![screenshot-2018-5-22 listing details for fabulous peesh](https://user-images.githubusercontent.com/479384/40362716-4125873c-5dc5-11e8-85a5-005b7c42b885.png)

