### PR TITLE
Limit intent GA to first click

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -126,6 +126,8 @@ function initTabs(el) {
 }
 
 function initOpenSnapButtons() {
+  let attempt = 1;
+
   document.addEventListener('click', (event) => {
     const openButton = event.target.closest('.js-open-snap-button');
 
@@ -146,13 +148,26 @@ function initOpenSnapButtons() {
       document.body.appendChild(iframe);
 
       if (typeof ga !== 'undefined') {
+        // The first attempt should be counted towards the 'intent'
+        let label = 'Snap install intent';
+        let value = `${name}`;
+
+        // Subsequent attempts should still be tracked, but not as 'intent'
+        if (attempt > 1) {
+          label = 'Snap install click';
+          value += ` - click ${attempt}`;
+        }
+
         ga('gtm1.send', {
           hitType: 'event',
           eventCategory: 'Snap details',
           eventAction: 'Click view in desktop store button',
-          eventLabel: `Click view in desktop store for ${name} snap`
+          eventLabel: label,
+          eventValue: value
         });
       }
+
+      attempt += 1;
     }
   });
 }


### PR DESCRIPTION
# Done

A quick fix after looking at some stats with Greg. Each time the install button is clicked we send an event, however, if the button didn't work and a user perceives this as "oh, it didn't work I need to press it again maybe?" we'll get 2 events when really there was only a single intent.

# QA

You might want to install the browser extension 'Google analytics debugger' for your browser

- Pull the branch
- `./run`
- Visit a snap details page
- Open the overlay and click the 'View in Desktop store' button
- See the GA event being fired
- Click the 'View in Desktop store' button again
- See that another GA event isn't being sent
- Repeat until your mouse breaks or you get RSI.