### PR TITLE
Upgrade api to version 0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ requests-cache==0.4.13
 responses==0.9.0
 talisker==0.9.8
 Flask-Testing==0.6.2
-canonicalwebteam.snapstoreapi==0.2.1
+canonicalwebteam.snapstoreapi==0.3


### PR DESCRIPTION
# Summary

Fixes #665 
- Upgrade api to v0.3
- Fixes problem for raising exceptions when macaroon is epxired

# QA

- `./run`
- Make sure apis calls still work :)