### PR TITLE
Toggle snap privacy on listing page

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -169,10 +169,12 @@ function initForm(config, initialState, errors) {
 
     // update state based on data of all inputs
     updateState(state, formData);
+
     // checkboxes are tricky,
     // make sure to update state based on their 'checked' status
     updateState(state, {
-      'public_metrics_enabled': marketForm['public_metrics_enabled'].checked
+      'public_metrics_enabled': marketForm['public_metrics_enabled'].checked,
+      'private': marketForm['private'].value === 'private'
     });
 
     checkForm();

--- a/static/js/publisher/market/state.js
+++ b/static/js/publisher/market/state.js
@@ -5,6 +5,7 @@ const allowedKeys = [
   'images',
   'website',
   'contact',
+  'private',
   'public_metrics_enabled',
   'public_metrics_blacklist'
 ];

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -124,7 +124,7 @@
             <div class="col-2">
               <label>Snap name: </label>
             </div>
-            <div class="col-8">
+            <div class="col-4">
                 {{ snap_name }}
             </div>
           </div>
@@ -135,6 +135,40 @@
             </div>
             <div class="col-8">
                 {{ publisher_name }}
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-2">
+              <label>
+                Privacy
+              </label>
+            </div>
+            <div class="col-8">
+              <div class="row">
+                <input
+                  type="radio"
+                  name="private"
+                  id="is-public"
+                  {% if not private %}
+                    checked="checked"
+                  {% endif %}
+                  value="public" />
+                <label class="u-no-margin--top" for="is-public">Public</label>
+              </div>
+              <div class="row" style="margin-top: 1rem;">
+                <input
+                  type="radio"
+                  name="private"
+                  id="is-private"
+                  {% if private %}
+                    checked="checked"
+                  {% endif %}
+                  value="private" />
+                <label class="u-no-margin--top" for="is-private">Private
+                  <span class="p-form-help-text">Snap is hidden in stores and only accessible by the publisher and collaborators</span>
+                </label>
+              </div>
             </div>
           </div>
 

--- a/webapp/publisher/logic.py
+++ b/webapp/publisher/logic.py
@@ -220,6 +220,7 @@ def filter_changes_data(changes):
         'keywords',
         'license',
         'price',
+        'private',
         'blacklist_countries',
         'whitelist_countries',
         'public_metrics_enabled',
@@ -232,7 +233,7 @@ def filter_changes_data(changes):
     }
 
 
-def invalid_filed_errors(errors):
+def invalid_field_errors(errors):
     """Split errors in invalid fields and other errors
 
     :param erros: List of errors

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -404,6 +404,7 @@ def post_listing_snap(snap_name):
                 return _handle_errors(api_error)
 
         body_json = logic.filter_changes_data(changes)
+
         if body_json:
             if 'public_metrics_blacklist' in body_json:
                 converted_metrics = logic.convert_metrics_blacklist(
@@ -441,7 +442,7 @@ def post_listing_snap(snap_name):
             details_metrics_enabled = snap_details['public_metrics_enabled']
             details_blacklist = snap_details['public_metrics_blacklist']
 
-            field_errors, other_errors = logic.invalid_filed_errors(error_list)
+            field_errors, other_errors = logic.invalid_field_errors(error_list)
 
             is_on_stable = logic.is_snap_on_stable(
                 snap_details['channel_maps_list'])


### PR DESCRIPTION
# Done

- Added `Private` toggle to listings page with some help text

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/snap_name/listing or http://snapcraft.io-pr-705.run.demo.haus/account/snaps/snap_name/listing
- Look at the `Private` section

# Screenshot

![screenshot_2018-06-05 listing details for lukotron](https://user-images.githubusercontent.com/479384/40977490-07429f0a-68c9-11e8-9048-2e808bd2f001.png)
