### PR TITLE
Highlight store on snap and search page navigation

### DIFF
--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -29,6 +29,12 @@
       }
     }
 
+    @media (max-width: $breakpoint-navigation-threshold) {
+      .p-navigation__link .is-selected {
+        background: $color-light;
+      }
+    }
+
     // right aligned sign-in navigation
     .p-navigation__links--right {
       @extend .p-navigation__links; // sass-lint:disable-line placeholder-in-extend

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -16,7 +16,7 @@
       <ul class="p-navigation__links" role="menu">
         <li class="p-navigation__link" role="menuitem">
           <a
-            {% if path and path.startswith('/store') %} class="is-selected"{% endif %}
+            {% if (path and (path.startswith('/store') or path.startswith('/search'))) or snap_title %} class="is-selected"{% endif %}
             href="/store">Store
           </a>
         </li>


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/658

- Added logic to check for search pages and snap pages to the header

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store, http://0.0.0.0:8004/search?q=git, http://0.0.0.0:8004/spotify and see that 'Store' is highlighted in the navigation

# Screenshots

![screenshot_2018-06-06 install linux apps in seconds snap store](https://user-images.githubusercontent.com/479384/41028919-56946396-6972-11e8-9953-c80a772c5f38.png)
![screenshot_2018-06-06 install spotify for linux linux apps in seconds snap store](https://user-images.githubusercontent.com/479384/41028920-56b6bb26-6972-11e8-9655-5159646a5bf9.png)
![screenshot_2018-06-06 snap search results for](https://user-images.githubusercontent.com/479384/41028921-56da703e-6972-11e8-9702-7f059dbbf73b.png)
