### PR TITLE
Get list of articles from API

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -2,4 +2,7 @@
 
 {% block content %}
 <h1>Blog is coming</h1>
+
+{{ articles }}
+
 {% endblock %}

--- a/webapp/blog/api.py
+++ b/webapp/blog/api.py
@@ -1,0 +1,10 @@
+from canonicalwebteam.snapstoreapi import cache
+
+API_URL = 'https://admin.insights.ubuntu.com/wp-json/wp/v2'
+
+
+def get_articles():
+    url = API_URL + '/posts?tag=snappy'
+    response = cache.get(url, {})
+
+    return response.json()

--- a/webapp/blog/blog.py
+++ b/webapp/blog/blog.py
@@ -1,5 +1,9 @@
 import flask
 
+from canonicalwebteam.snapstoreapi.exceptions import ApiError
+
+from webapp.blog import api
+
 blog_page = flask.Blueprint(
     'blog_page', __name__,
     template_folder='/templates', static_folder='/static')
@@ -7,4 +11,13 @@ blog_page = flask.Blueprint(
 
 @blog_page.route('/')
 def homepage():
-    return flask.render_template('blog/index.html')
+    try:
+        articles = api.get_articles()
+    except ApiError as api_error:
+        return flask.abort(502, str(api_error))
+
+    context = {
+        'articles': articles,
+    }
+
+    return flask.render_template('blog/index.html', **context)


### PR DESCRIPTION
# Summary

Fixes #699 
Get list of articles from insights API
Pass to the template 

# QA

- `./run`
- http://127.0.0.1:8004/blog
- Should see a long list of articles in JSON format