### PR TITLE
Only use lightbox if on a larger screen

### DIFF
--- a/static/js/libs/mobile.js
+++ b/static/js/libs/mobile.js
@@ -1,0 +1,9 @@
+function isMobile() {
+  // If the mobile menu button is visible, we're on mobile
+  const mobileMenuButton = document.querySelector('.p-navigation__toggle--open');
+
+  // Use offsetWidth and offsetHeight to figure out if an element is visibile
+  return !(mobileMenuButton.offsetWidth === 0 && mobileMenuButton.offsetHeight === 0);
+}
+
+export { isMobile };

--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -1,4 +1,5 @@
 import lightbox from './../../publisher/market/lightbox';
+import { isMobile } from '../../libs/mobile';
 
 export default function initScreenshots(screenshotsId) {
   const screenshotsEl = document.querySelector(screenshotsId);
@@ -13,7 +14,12 @@ export default function initScreenshots(screenshotsId) {
     const url = event.target.src;
 
     if (url) {
-      lightbox.openLightbox(url, images);
+      if (isMobile()) {
+        window.open(url, '_blank');
+        window.focus();
+      } else {
+        lightbox.openLightbox(url, images);
+      }
     }
   });
 


### PR DESCRIPTION
# Done
Fixes https://github.com/canonicalltd/snap-squad/issues/581

If the screenshots previous button is not visible when attempting to open the lightbox, open in a new tab instead.
This works because on mobile we rely on the horizontal scrolling, so the previous/ next buttons aren't loaded.

# QA
- Pull the branch
- `./run`
- View a snap detail page on desktop, click an image to open in the lightbox, it should work
- View a snap detail page on mobile, click an image and it should open in another tab