### PR TITLE
Add publisher blueprint

### DIFF
--- a/tests/tests_agreement.py
+++ b/tests/tests_agreement.py
@@ -86,7 +86,7 @@ class PostAgreementPage(BaseTestCases.EndpointLoggedIn):
 
         self.assertEqual(302, response.status_code)
         self.assertEqual(
-            'http://localhost/account',
+            'http://localhost/account/',
             response.location)
 
     @responses.activate

--- a/tests/tests_publisher.py
+++ b/tests/tests_publisher.py
@@ -134,7 +134,7 @@ class PublisherPage(TestCase):
 
         self.assertEqual(302, response.status_code)
         self.assertEqual(
-            'http://localhost/account',
+            'http://localhost/account/',
             response.location)
 
     @responses.activate

--- a/tests/tests_register_name.py
+++ b/tests/tests_register_name.py
@@ -110,7 +110,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, 'http://localhost/account')
+        self.assertEqual(response.location, 'http://localhost/account/')
 
     @responses.activate
     def test_post_store(self):
@@ -139,7 +139,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, 'http://localhost/account')
+        self.assertEqual(response.location, 'http://localhost/account/')
 
     @responses.activate
     def test_post_private(self):
@@ -168,7 +168,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, 'http://localhost/account')
+        self.assertEqual(response.location, 'http://localhost/account/')
 
     @responses.activate
     def test_post_registrant_comment(self):
@@ -197,7 +197,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, 'http://localhost/account')
+        self.assertEqual(response.location, 'http://localhost/account/')
 
     @responses.activate
     def test_error_from_api(self):
@@ -268,4 +268,4 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         )
 
         assert response.status_code == 302
-        self.assertEqual(response.location, 'http://localhost/account')
+        self.assertEqual(response.location, 'http://localhost/account/')

--- a/tests/tests_username.py
+++ b/tests/tests_username.py
@@ -81,7 +81,7 @@ class PostUsernamePage(BaseTestCases.EndpointLoggedIn):
 
         self.assertEqual(302, response.status_code)
         self.assertEqual(
-            'http://localhost/account',
+            'http://localhost/account/',
             response.location)
 
     @responses.activate

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -30,7 +30,7 @@ from canonicalwebteam.snapstoreapi import authentication
 from canonicalwebteam.snapstoreapi import publisher_api
 from webapp.blog.blog import blog_page
 from webapp.public.views import store_page
-from webapp.publisher.views import account_page
+from webapp.publisher.views import account
 from webapp.macaroon import (
     MacaroonRequest,
     MacaroonResponse,
@@ -259,5 +259,5 @@ def logout():
 
 
 app.register_blueprint(store_page)
-app.register_blueprint(account_page, url_prefix='/account')
+app.register_blueprint(account, url_prefix='/account')
 app.register_blueprint(blog_page, url_prefix='/blog')

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -25,13 +25,12 @@ from werkzeug.debug import DebuggedApplication
 
 # Local webapp
 import webapp.helpers as helpers
-import webapp.publisher.views as publisher_views
 import webapp.template_functions as template_functions
 from canonicalwebteam.snapstoreapi import authentication
 from canonicalwebteam.snapstoreapi import publisher_api
-from webapp.public.views import store_page
 from webapp.blog.blog import blog_page
-from webapp.decorators import login_required
+from webapp.public.views import store_page
+from webapp.publisher.views import account_page
 from webapp.macaroon import (
     MacaroonRequest,
     MacaroonResponse,
@@ -259,101 +258,6 @@ def logout():
     return flask.redirect('/')
 
 
-# Publisher views
-# ===
-@app.route('/account')
-@login_required
-def get_account():
-    return flask.redirect('/account/snaps')
-
-
-@app.route('/account/details')
-@login_required
-def get_account_details():
-    return publisher_views.get_account_details()
-
-
-@app.route('/account/snaps')
-@login_required
-def get_account_snaps():
-    return publisher_views.get_account_snaps()
-
-
-@app.route('/account/agreement')
-@login_required
-def get_agreement():
-    return publisher_views.get_agreement()
-
-
-@app.route('/account/agreement', methods=['POST'])
-@login_required
-def post_agreement():
-    return publisher_views.post_agreement()
-
-
-@app.route('/account/username')
-@login_required
-def get_account_name():
-    return publisher_views.get_account_name()
-
-
-@app.route('/account/username', methods=['POST'])
-@login_required
-def post_account_name():
-    return publisher_views.post_account_name()
-
-
-@app.route('/account/snaps/<snap_name>/metrics')
-@login_required
-def publisher_snap_metrics(snap_name):
-    return publisher_views.publisher_snap_metrics(snap_name)
-
-
-@app.route('/account/snaps/<snap_name>/listing', methods=['GET'])
-@login_required
-def get_listing_snap(snap_name):
-    return publisher_views.get_listing_snap(snap_name)
-
-
-@app.route('/account/snaps/<snap_name>/listing', methods=['POST'])
-@login_required
-def post_listing_snap(snap_name):
-    return publisher_views.post_listing_snap(snap_name)
-
-
-@app.route('/account/snaps/<snap_name>/market')
-@login_required
-def get_market_snap(snap_name):
-    return flask.redirect(
-        "/account/snaps/{snap_name}/listing".format(
-            snap_name=snap_name))
-
-
-@app.route('/account/snaps/<snap_name>/measure')
-@login_required
-def get_measure_snap(snap_name):
-    return flask.redirect(
-        "/account/snaps/{snap_name}/metrics".format(
-            snap_name=snap_name))
-
-
-@app.route('/account/register-name')
-@login_required
-def get_register_name():
-    return publisher_views.get_register_name()
-
-
-@app.route('/account/reserve-name')
-@login_required
-def get_reserve_name():
-    return publisher_views.get_reserve_name()
-
-
-@app.route('/account/register-name', methods=['POST'])
-@login_required
-def post_register_name():
-    return publisher_views.post_register_name()
-
-
 app.register_blueprint(store_page)
+app.register_blueprint(account_page, url_prefix='/account')
 app.register_blueprint(blog_page, url_prefix='/blog')


### PR DESCRIPTION
# Summary

- Add publisher bluepirint
- Fix redirections with function `url_for` to avoid hardcoded urls
- Fix tests to apply with the new redirections (`url_for` adds automatically a `/` at the end of the url)

# QA

- `./run`
- Navigate in publiser pages and make sure everything works as usual
http://127.0.0.1:8004/account
http://127.0.0.1:8004/account/details
http://127.0.0.1:8004/account/snaps
http://127.0.0.1:8004/account/username
http://127.0.0.1:8004/account/agreement
http://127.0.0.1:8004/account/snaps/toto/listing
http://127.0.0.1:8004/account/snaps/toto/market
http://127.0.0.1:8004/account/snaps/toto/measure

List of the routes (by running `flask routes`
```
account_page.get_account             GET        /account/
account_page.get_account_details     GET        /account/details
account_page.get_account_name        GET        /account/username
account_page.get_account_snaps       GET        /account/snaps
account_page.get_agreement           GET        /account/agreement
account_page.get_listing_snap        GET        /account/snaps/<snap_name>/listing
account_page.get_market_snap         GET        /account/snaps/<snap_name>/market
account_page.get_measure_snap        GET        /account/snaps/<snap_name>/measure
account_page.get_register_name       GET        /account/register-name
account_page.post_account_name       POST       /account/username
account_page.post_agreement          POST       /account/agreement
account_page.post_listing_snap       POST       /account/snaps/<snap_name>/listing
account_page.post_register_name      POST       /account/register-name
account_page.publisher_snap_metrics  GET        /account/snaps/<snap_name>/metrics
```