### PR TITLE
Use factories to launch snapcraft

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
 DEVEL=True
-WEBPAPP=snapcraft.io
+WEBAPP=snapcraft.io

--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
 DEVEL=True
-FACTORY=create_snapcraft
+WEBPAPP=snapcraft.io

--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
 DEVEL=True
+FACTORY=create_snapcraft

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/d3-geo/build/d3-geo.min.js static/js/modules && cp node_modules/topojson-client/dist/topojson-client.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/moment/min/moment.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-transpile": "rollup -c",
-    "serve": "talisker.gunicorn webapp.app:app --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "talisker.gunicorn webapp.app:${FACTORY}\\(\\) --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/d3-geo/build/d3-geo.min.js static/js/modules && cp node_modules/topojson-client/dist/topojson-client.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/moment/min/moment.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-transpile": "rollup -c",
-    "serve": "talisker.gunicorn webapp.app:${FACTORY}\\(\\) --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "talisker.gunicorn webapp.app:create_app\\(\\) --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",

--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -15,7 +15,6 @@ class BlogPage(TestCase):
 
     def create_app(self):
         app = create_app(testing=True)
-        app.testing = True
 
         return app
 

--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -1,7 +1,7 @@
 import responses
 import requests
 
-from webapp.app import create_snapcraft
+from webapp.app import create_app
 from flask_testing import TestCase
 
 
@@ -14,7 +14,7 @@ class BlogPage(TestCase):
     render_templates = False
 
     def create_app(self):
-        app = create_snapcraft(testing=True)
+        app = create_app(testing=True)
         app.testing = True
 
         return app

--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -1,7 +1,7 @@
 import responses
 import requests
 
-from webapp.app import app
+from webapp.app import create_snapcraft
 from flask_testing import TestCase
 
 
@@ -14,10 +14,10 @@ class BlogPage(TestCase):
     render_templates = False
 
     def create_app(self):
-        my_app = app
-        my_app.testing = True
+        app = create_snapcraft(testing=True)
+        app.testing = True
 
-        return my_app
+        return app
 
     @responses.activate
     def test_index(self):

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -32,7 +32,6 @@ class BaseTestCases:
         def create_app(self):
             app = create_app(testing=True)
             app.config['WTF_CSRF_METHODS'] = []
-            app.testing = True
 
             return app
 

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -3,7 +3,7 @@ import requests
 import pymacaroons
 import responses
 
-from webapp.app import app
+from webapp.app import create_snapcraft
 from flask_testing import TestCase
 
 from canonicalwebteam.snapstoreapi.authentication import (
@@ -30,6 +30,7 @@ class BaseTestCases:
             self.endpoint_url = endpoint_url
 
         def create_app(self):
+            app = create_snapcraft(testing=True)
             app.config['WTF_CSRF_METHODS'] = []
             app.testing = True
 

--- a/tests/endpoint_testing.py
+++ b/tests/endpoint_testing.py
@@ -3,7 +3,7 @@ import requests
 import pymacaroons
 import responses
 
-from webapp.app import create_snapcraft
+from webapp.app import create_app
 from flask_testing import TestCase
 
 from canonicalwebteam.snapstoreapi.authentication import (
@@ -30,7 +30,7 @@ class BaseTestCases:
             self.endpoint_url = endpoint_url
 
         def create_app(self):
-            app = create_snapcraft(testing=True)
+            app = create_app(testing=True)
             app.config['WTF_CSRF_METHODS'] = []
             app.testing = True
 

--- a/tests/tests_public.py
+++ b/tests/tests_public.py
@@ -2,7 +2,7 @@ import unittest
 
 import responses
 
-from webapp.app import create_snapcraft
+from webapp.app import create_app
 from flask_testing import TestCase
 
 
@@ -15,7 +15,7 @@ class PublicPage(TestCase):
     render_templates = False
 
     def create_app(self):
-        app = create_snapcraft(testing=True)
+        app = create_app(testing=True)
         app.testing = True
 
         return app

--- a/tests/tests_public.py
+++ b/tests/tests_public.py
@@ -2,7 +2,7 @@ import unittest
 
 import responses
 
-from webapp.app import app
+from webapp.app import create_snapcraft
 from flask_testing import TestCase
 
 
@@ -15,10 +15,10 @@ class PublicPage(TestCase):
     render_templates = False
 
     def create_app(self):
-        my_app = app
-        my_app.testing = True
+        app = create_snapcraft(testing=True)
+        app.testing = True
 
-        return my_app
+        return app
 
     @responses.activate
     def test_index(self):

--- a/tests/tests_public.py
+++ b/tests/tests_public.py
@@ -16,7 +16,6 @@ class PublicPage(TestCase):
 
     def create_app(self):
         app = create_app(testing=True)
-        app.testing = True
 
         return app
 

--- a/tests/tests_publisher.py
+++ b/tests/tests_publisher.py
@@ -3,7 +3,7 @@ import unittest
 import pymacaroons
 import responses
 
-from webapp.app import app
+from webapp.app import create_snapcraft
 from flask_testing import TestCase
 from canonicalwebteam.snapstoreapi.authentication import (
     get_authorization_header)
@@ -18,6 +18,7 @@ class PublisherPage(TestCase):
     render_templates = False
 
     def create_app(self):
+        app = create_snapcraft(testing=True)
         app.config['WTF_CSRF_METHODS'] = []
         app.testing = True
 

--- a/tests/tests_publisher.py
+++ b/tests/tests_publisher.py
@@ -3,7 +3,7 @@ import unittest
 import pymacaroons
 import responses
 
-from webapp.app import create_snapcraft
+from webapp.app import create_app
 from flask_testing import TestCase
 from canonicalwebteam.snapstoreapi.authentication import (
     get_authorization_header)
@@ -18,7 +18,7 @@ class PublisherPage(TestCase):
     render_templates = False
 
     def create_app(self):
-        app = create_snapcraft(testing=True)
+        app = create_app(testing=True)
         app.config['WTF_CSRF_METHODS'] = []
         app.testing = True
 

--- a/tests/tests_publisher.py
+++ b/tests/tests_publisher.py
@@ -20,7 +20,6 @@ class PublisherPage(TestCase):
     def create_app(self):
         app = create_app(testing=True)
         app.config['WTF_CSRF_METHODS'] = []
-        app.testing = True
 
         return app
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,18 +6,11 @@ The web frontend for the snap store.
 
 # Core packages
 import os
-import socket
-from urllib.parse import (
-    unquote,
-    urlparse,
-    urlunparse,
-)
 
 # Third-party packages
 import flask
 import talisker.flask
 import prometheus_flask_exporter
-from canonicalwebteam.snapstoreapi import authentication
 from flask_wtf.csrf import CSRFProtect
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
@@ -25,32 +18,13 @@ from werkzeug.debug import DebuggedApplication
 
 # Local webapp
 import webapp.helpers as helpers
-import webapp.template_functions as template_functions
+from webapp.handlers import set_handlers
 from webapp.blog.views import blog
 from webapp.public.views import store
 from webapp.publisher.views import account
 from webapp.snapcraft.views import snapcraft
 from webapp.login.views import login
 
-app = flask.Flask(
-    __name__, template_folder='../templates', static_folder='../static')
-talisker.flask.register(app)
-app.wsgi_app = ProxyFix(app.wsgi_app)
-if app.debug:
-    app.wsgi_app = DebuggedApplication(app.wsgi_app)
-app.secret_key = os.environ['SECRET_KEY']
-app.url_map.strict_slashes = False
-app.url_map.converters['regex'] = helpers.RegexConverter
-sentry = Sentry(app)
-
-metrics = prometheus_flask_exporter.PrometheusMetrics(
-    app,
-    group_by_endpoint=True,
-    buckets=[0.25, 0.5, 0.75, 1, 2],
-    path=None
-)
-
-csrf = CSRFProtect(app)
 
 SENTRY_PUBLIC_DSN = os.getenv('SENTRY_PUBLIC_DSN', '').strip()
 LOGIN_URL = os.getenv(
@@ -67,106 +41,63 @@ COMMIT_ID = os.getenv(
     'commit_id'
 )
 
-app.config['SENTRY_CONFIG'] = {
-    'release': COMMIT_ID,
-    'environment': ENVIRONMENT
-}
+
+csrf = CSRFProtect()
+sentry = Sentry()
 
 
-@app.context_processor
-def utility_processor():
-    """
-    This defines the set of properties and functions that will be added
-    to the default context for processing templates. All these items
-    can be used in all templates
-    """
+def create_app():
+    app = flask.Flask(
+        __name__, template_folder='../templates', static_folder='../static')
 
-    if authentication.is_authenticated(flask.session):
-        user_name = flask.session['openid']['fullname']
-    else:
-        user_name = None
+    talisker.flask.register(app)
 
-    return {
-        # Variables
-        'LOGIN_URL': LOGIN_URL,
-        'SENTRY_PUBLIC_DSN': SENTRY_PUBLIC_DSN,
-        'COMMIT_ID': COMMIT_ID,
-        'ENVIRONMENT': ENVIRONMENT,
-        'path': flask.request.path,
-        'user_name': user_name,
-        'VERIFIED_PUBLISHER': 'verified',
+    app.wsgi_app = ProxyFix(app.wsgi_app)
+    if app.debug:
+        app.wsgi_app = DebuggedApplication(app.wsgi_app)
 
-        # Functions
-        'contains': template_functions.contains,
-        'join': template_functions.join,
-        'static_url': template_functions.static_url,
-        'format_number': template_functions.format_number,
+    app.secret_key = os.environ['SECRET_KEY']
+    app.url_map.strict_slashes = False
+    app.url_map.converters['regex'] = helpers.RegexConverter
+
+    app.config['SENTRY_CONFIG'] = {
+        'release': COMMIT_ID,
+        'environment': ENVIRONMENT
     }
 
+    prometheus_flask_exporter.PrometheusMetrics(
+        app,
+        group_by_endpoint=True,
+        buckets=[0.25, 0.5, 0.75, 1, 2],
+        path=None
+    )
 
-# Error handlers
-# ===
-@app.errorhandler(404)
-def page_not_found(error):
-    """
-    For 404 pages, display the 404.html template,
-    passing through the error description.
-    """
+    init_extensions(app)
+    set_handlers(app, LOGIN_URL, SENTRY_PUBLIC_DSN, COMMIT_ID, ENVIRONMENT)
 
-    return flask.render_template(
-        '404.html', error=error.description
-    ), 404
+    return app
 
 
-# Global tasks for all requests
-# ===
-@app.before_request
-def clear_trailing():
-    """
-    Remove trailing slashes from all routes
-    We like our URLs without slashes
-    """
+def create_snapstore():
+    app = create_app()
+    app.register_blueprint(store)
 
-    parsed_url = urlparse(unquote(flask.request.url))
-    path = parsed_url.path
-
-    if path != '/' and path.endswith('/'):
-        new_uri = urlunparse(
-            parsed_url._replace(path=path[:-1])
-        )
-
-        return flask.redirect(new_uri)
+    return app
 
 
-@app.after_request
-def add_headers(response):
-    """
-    Generic rules for headers to add to all requests
+def create_snapcraft():
+    app = create_app()
 
-    - X-Hostname: Mention the name of the host/pod running the application
-    - Cache-Control: Add cache-control headers for public and private pages
-    """
+    app.register_blueprint(snapcraft)
+    app.register_blueprint(login)
+    csrf.exempt('webapp.login.views.login_handler')
+    app.register_blueprint(store)
+    app.register_blueprint(account, url_prefix='/account')
+    app.register_blueprint(blog, url_prefix='/blog')
 
-    response.headers["X-Hostname"] = socket.gethostname()
-
-    if response.status_code == 200:
-        if flask.session:
-            response.headers['Cache-Control'] = 'private'
-        else:
-            # Only add caching headers to successful responses
-            response.headers['Cache-Control'] = ', '.join({
-                'public',
-                'max-age=61',
-                'stale-while-revalidate=300',
-                'stale-if-error=86400',
-            })
-
-    return response
+    return app
 
 
-app.register_blueprint(snapcraft)
-app.register_blueprint(login)
-csrf.exempt('webapp.login.views.login_handler')
-app.register_blueprint(store)
-app.register_blueprint(account, url_prefix='/account')
-app.register_blueprint(blog, url_prefix='/blog')
+def init_extensions(app):
+    csrf.init_app(app)
+    sentry.init_app(app)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,7 +31,8 @@ def create_app(testing=False):
     app = flask.Flask(
         __name__, template_folder='../templates', static_folder='../static')
 
-    app.config.from_pyfile('config.py')
+    app.config.from_object('webapp.config')
+    app.testing = testing
 
     app.wsgi_app = ProxyFix(app.wsgi_app)
     if app.debug:

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,0 +1,26 @@
+import os
+
+
+SECRET_KEY = os.getenv('SECRET_KEY')
+
+LOGIN_URL = os.getenv(
+    'LOGIN_URL',
+    'https://login.ubuntu.com',
+)
+
+ENVIRONMENT = os.getenv(
+    'ENVIRONMENT',
+    'devel'
+)
+COMMIT_ID = os.getenv(
+    'COMMIT_ID',
+    'commit_id'
+)
+
+SENTRY_PUBLIC_DSN = os.getenv('SENTRY_PUBLIC_DSN', '').strip()
+SENTRY_CONFIG = {
+    'release': COMMIT_ID,
+    'environment': ENVIRONMENT
+}
+
+WEBAPP = os.getenv('WEBAPP', 'snapcraft.io')

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,0 +1,98 @@
+import flask
+import socket
+import webapp.template_functions as template_functions
+from urllib.parse import (
+    unquote,
+    urlparse,
+    urlunparse,
+)
+from canonicalwebteam.snapstoreapi import authentication
+
+
+def set_handlers(app, login_url, sentry_public_dsn, commit_id, env):
+    @app.context_processor
+    def utility_processor():
+        """
+        This defines the set of properties and functions that will be added
+        to the default context for processing templates. All these items
+        can be used in all templates
+        """
+
+        if authentication.is_authenticated(flask.session):
+            user_name = flask.session['openid']['fullname']
+        else:
+            user_name = None
+
+        return {
+            # Variables
+            'LOGIN_URL': login_url,
+            'SENTRY_PUBLIC_DSN': sentry_public_dsn,
+            'COMMIT_ID': commit_id,
+            'ENVIRONMENT': env,
+            'path': flask.request.path,
+            'user_name': user_name,
+            'VERIFIED_PUBLISHER': 'verified',
+
+            # Functions
+            'contains': template_functions.contains,
+            'join': template_functions.join,
+            'static_url': template_functions.static_url,
+            'format_number': template_functions.format_number,
+        }
+
+    # Error handlers
+    # ===
+    @app.errorhandler(404)
+    def page_not_found(error):
+        """
+        For 404 pages, display the 404.html template,
+        passing through the error description.
+        """
+
+        return flask.render_template(
+            '404.html', error=error.description
+        ), 404
+
+    # Global tasks for all requests
+    # ===
+    @app.before_request
+    def clear_trailing():
+        """
+        Remove trailing slashes from all routes
+        We like our URLs without slashes
+        """
+
+        parsed_url = urlparse(unquote(flask.request.url))
+        path = parsed_url.path
+
+        if path != '/' and path.endswith('/'):
+            new_uri = urlunparse(
+                parsed_url._replace(path=path[:-1])
+            )
+
+            return flask.redirect(new_uri)
+
+    @app.after_request
+    def add_headers(response):
+        """
+        Generic rules for headers to add to all requests
+
+        - X-Hostname: Mention the name of the host/pod running the application
+        - Cache-Control: Add cache-control headers for public and private pages
+        """
+
+        response.headers["X-Hostname"] = socket.gethostname()
+
+        if response.status_code == 200:
+            if flask.session:
+                response.headers['Cache-Control'] = 'private'
+            else:
+                # Only add caching headers to successful responses
+                response.headers['Cache-Control'] = ', '.join({
+                    'public',
+                    'max-age=61',
+                    'stale-while-revalidate=300',
+                    'stale-if-error=86400',
+                })
+
+        return response

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -9,7 +9,7 @@ from urllib.parse import (
 from canonicalwebteam.snapstoreapi import authentication
 
 
-def set_handlers(app, login_url, sentry_public_dsn, commit_id, env):
+def set_handlers(app):
     @app.context_processor
     def utility_processor():
         """
@@ -25,10 +25,10 @@ def set_handlers(app, login_url, sentry_public_dsn, commit_id, env):
 
         return {
             # Variables
-            'LOGIN_URL': login_url,
-            'SENTRY_PUBLIC_DSN': sentry_public_dsn,
-            'COMMIT_ID': commit_id,
-            'ENVIRONMENT': env,
+            'LOGIN_URL': app.config['LOGIN_URL'],
+            'SENTRY_PUBLIC_DSN': app.config['SENTRY_PUBLIC_DSN'],
+            'COMMIT_ID': app.config['COMMIT_ID'],
+            'ENVIRONMENT': app.config['ENVIRONMENT'],
             'path': flask.request.path,
             'user_name': user_name,
             'VERIFIED_PUBLISHER': 'verified',

--- a/webapp/public/views.py
+++ b/webapp/public/views.py
@@ -54,6 +54,7 @@ def discover():
         flask.url_for('.store_view'))
 
 
+@store.route('/')
 @store.route('/store')
 def store_view():
     featured_snaps = []


### PR DESCRIPTION
# Summary

To help launching the brandstores I added 2 factories to build the app:

- create_snapcraft
- create_brandstore

Those 2 factories uses the same base `create_app` but they instanciate different blueprints.
To help running the tests those factories have a testing parameter so that not all the extensions added to snapcraft are run (prometheus, sentry, csrf)

The functions used in all the project (context_processor, 404) are moved into it's own file.

# QA

- `./run`
- Should have access to the usual snapcraft website
- Edit `.env` and change `FACTORY=create_snapcraft` to `FACTORY=create_brandstore`
- `./run`
- The home page should be the search page (might need to `ctrl + shift + r` (because of cached pages)