### PR TITLE
Add rss feeds for blog

### DIFF
--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -176,3 +176,33 @@ class BlogPage(TestCase):
 
         assert response.status_code == 404
         self.assert_template_used('404.html')
+
+    @responses.activate
+    def test_get_feed(self):
+        url = (
+            'https://admin.insights.ubuntu.com/?tag=Snap&feed=rss'
+        )
+
+        responses.add(
+            responses.GET, url,
+            body='xml', status=200)
+
+        response = self.client.get('/blog/feed')
+
+        assert response.status_code == 200
+        self.assertEqual(response.data, b'xml')
+
+    @responses.activate
+    def test_timeout_get_feed(self):
+        url = (
+            'https://admin.insights.ubuntu.com/?tag=Snap&feed=rss'
+        )
+
+        responses.add(
+            responses.GET, url,
+            body=requests.exceptions.Timeout(),
+            status=504)
+
+        response = self.client.get('/blog/feed')
+
+        assert response.status_code == 502

--- a/webapp/blog/api.py
+++ b/webapp/blog/api.py
@@ -41,3 +41,14 @@ def get_media(media_id):
         return None
 
     return response.json()
+
+
+def get_feed():
+    """"""
+    response = cache.get(
+        'https://admin.insights.ubuntu.com/?tag=Snap&feed=rss', {})
+
+    if not response.ok:
+        return None
+
+    return response.text

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -41,3 +41,17 @@ def transform_article(article, featured_image=None):
             article['excerpt']['raw'] = article['excerpt']['raw'] + ' […]'
 
     return article
+
+
+def change_url(feed, host):
+    """Change insights urls to snapcraft.io/blog
+
+    :param feed: String with urls
+
+    :returns: A string with converted urls
+    """
+    url_regex = re.compile(
+        'https:\/\/admin.insights.ubuntu.com(\/\d{4}\/\d{2}\/\d{2})?')
+    updated_feed = re.sub(url_regex, host, feed)
+
+    return updated_feed

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -37,6 +37,18 @@ def homepage():
     return flask.render_template('blog/index.html', **context)
 
 
+@blog.route('/feed')
+def feed():
+    try:
+        feed = api.get_feed()
+    except ApiError:
+        return flask.abort(502)
+
+    right_urls = logic.change_url(
+        feed, flask.request.base_url.replace('/feed', ''))
+    return flask.Response(right_urls, mimetype='text/xml')
+
+
 @blog.route('/<slug>')
 def post(slug):
     try:


### PR DESCRIPTION
# Summary

Fixes #703 
- Add rss feeds for s.io

# QA

- `./run`
- http://127.0.0.1:8004/blog/feed
- Make sure all links are redrecting to snapcraft.io instead of insights