### PR TITLE
Add brandstore configuration

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
 DEVEL=True
-WEBAPP=snapcraft.io
+WEBAPP=snapcraft

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}404: Page not found{% endblock %}
 

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -1,0 +1,96 @@
+<!doctype html>
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
+
+    <title>{% block meta_title %}{{ webapp_config['STORE_NAME'] }} - Snaps are universal Linux packages{% endblock %}</title>
+
+    {% block meta %}
+      <meta property="og:title" content="{{ self.meta_title() }}"/>
+      <meta property="og:site_name" content="Snapcraft"/>
+      <meta property="og:type" content="website"/>
+      <meta property="og:description" content="{{ self.meta_description() }}"/>
+      <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png{% endblock %}" />
+      <meta property="og:url" content="https://snapcraft.io{% block meta_path %}{{ path }}{% endblock %}" />
+      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:site" content="@snapcraftio" />
+      <meta property="twitter:creator" content="@snapcraftio" />
+      <meta property="twitter:url" content="https://snapcraft.io{{ self.meta_path() }}" />
+    {% endblock %}
+
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
+
+    <link rel="stylesheet" href="{{ static_url('minified/styles.css') }}" />
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KCGXHQS');</script>
+    <!-- End Google Tag Manager -->
+  </head>
+
+  <body class="has-sticky-footer">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KCGXHQS"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    {% include "_header.html" %}
+
+    {% block content %}{% endblock %}
+
+    {% include "_footer.html" %}
+
+    {% block scripts_modules %}{% endblock %}
+    <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
+    <script>
+      Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
+        whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
+        release: '{{ COMMIT_ID }}',
+        environment: '{{ ENVIRONMENT }}'
+      }).install();
+    </script>
+
+    <script src="{{ static_url('js/dist/base.js') }}"></script>
+    {% block scripts %}{% endblock %}
+
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org/",
+        "@id": "https://snapcraft.io/#organization",
+        "@type": "Organization",
+        "name": "Snapcraft",
+        "logo": "https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
+        "url": "https://snapcraft.io",
+        "sameAs": [
+          "https://developer.ubuntu.com/snapcraft",
+          "https://github.com/snapcore/snapcraft",
+          "https://en.wikipedia.org/wiki/Snappy_(package_manager)",
+          "https://twitter.com/snapcraftio",
+          "https://www.facebook.com/snapcraftio/",
+          "https://plus.google.com/+SnapcraftIo",
+          "https://www.youtube.com/snapcraftio"
+        ]
+      }
+    </script>
+
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@id": "https://snapcraft.io/#website",
+        "@type": "WebPage",
+        "name": "Snapcraft",
+        "url": "https://snapcraft.io{{ self.meta_path() }}"
+      }
+    </script>
+
+    {% block meta_schema %}{% endblock %}
+  </body>
+</html>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}{{ article.title.rendered|safe }} | Snapcraft{% endblock %}
 {% block meta_description %}{{ article.excerpt.raw }}{% endblock %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}Blog | Snapcraft{% endblock %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block content %}
 <div id="main-content" class="p-strip--image is-deep snapcraft-banner-background">

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}
 Account details — Linux software in the Snap Store

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}
 My published snaps — Linux software in the Snap Store

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}
   Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}
 Publisher metrics for {{ snap_title }}

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block title %}
 Register new Snap name

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}
   {% if query %}

--- a/templates/snap-details.html
+++ b/templates/snap-details.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}Install {{ snap_title }} for Linux, Linux apps in seconds | Snap Store{% endblock %}
 

--- a/templates/store.html
+++ b/templates/store.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}Install Linux apps in seconds | Snap Store{% endblock %}
 

--- a/templates/username.html
+++ b/templates/username.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}
 Choose username — Linux software in the Snap Store

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,7 +44,6 @@ def create_app(testing=False):
 
     if not testing:
         talisker.flask.register(app)
-        print(app.config['SENTRY_CONFIG'])
 
         prometheus_flask_exporter.PrometheusMetrics(
             app,
@@ -55,9 +54,10 @@ def create_app(testing=False):
 
         init_extensions(app)
 
+    app.config.from_object('webapp.configs.' + app.config['WEBAPP'])
     set_handlers(app)
 
-    if app.config['WEBAPP'] == 'snapcraft.io':
+    if app.config['WEBAPP'] == 'snapcraft':
         init_snapcraft(app)
     else:
         init_brandstore(app)

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -23,4 +23,4 @@ SENTRY_CONFIG = {
     'environment': ENVIRONMENT
 }
 
-WEBAPP = os.getenv('WEBAPP', 'snapcraft.io')
+WEBAPP = os.getenv('WEBAPP', 'snapcraft')

--- a/webapp/configs/snapcraft.py
+++ b/webapp/configs/snapcraft.py
@@ -1,0 +1,4 @@
+WEBAPP_CONFIG = {
+    'LAYOUT': '_layout.html',
+    'STORE_NAME': 'Snap store'
+}

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -35,6 +35,7 @@ def set_handlers(app):
             'page_slug': page_slug,
             'user_name': user_name,
             'VERIFIED_PUBLISHER': 'verified',
+            'webapp_config': app.config['WEBAPP_CONFIG'],
 
             # Functions
             'contains': template_utils.contains,


### PR DESCRIPTION
# Summary

Fixes #531
- Add configuration for brandstore.
- For each store we will have a config file in `webapp/configs/<brandstore>.py`
- `_layout_brandstore.html` will be the layout for brandstores, for now it is just a copy/paste from `_layout.html`

# QA

- `./run`
- Should have snapcraft as usual
- create file `brandstore.py`:

```python
WEBAPP_CONFIG = {
    'LAYOUT': '_layout-brandstore.html',
    'STORE_NAME': 'Super store'
}
```
- in `.env` change : `WEBAPP=snapcraft` to `WEBAPP=brandstore`
- `./run`
- Homepage should be `store` page
- You can add this somewhere in a template: `{{ webap_config['STORE_NAME'] }}`
- Super store should be displayed