### PR TITLE
Add webapp environment variable to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ RUN test -n "${COMMIT_ID}"
 RUN echo "${COMMIT_ID}" > version-info.txt
 ENV COMMIT_ID "${COMMIT_ID}"
 
+# Set which webapp configuration to load
+ARG WEBAPP
+RUN test -n "${WEBAPP}"
+ENV WEBAPP "${WEBAPP}"
+
 # Setup commands to run server
 ENTRYPOINT ["talisker.gunicorn", "webapp.app:create_app()", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
 CMD ["0.0.0.0:80"]


### PR DESCRIPTION
# Summary

Add webapp environment var to dockerfile

# QA

- `docker build --build-arg COMMIT_ID=test --build-arg WEBAPP=snapcraft --tag test-sio .`
- `docker run --rm -p 80:80 -it -e SECRET_KEY=adsf test-sio`