### PR TITLE
Convert gunicorn worked to a async gevent worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/d3-geo/build/d3-geo.min.js static/js/modules && cp node_modules/topojson-client/dist/topojson-client.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/moment/min/moment.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-transpile": "rollup -c",
-    "serve": "talisker.gunicorn webapp.app:create_app\\(\\) --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "talisker.gunicorn.gevent webapp.app:create_app\\(\\) --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ responses==0.9.0
 talisker==0.9.8
 Flask-Testing==0.6.2
 canonicalwebteam.snapstoreapi==0.3
+gunicorn[gevent]


### PR DESCRIPTION
This converts the sync gunicorn worker to the async gevent
worker class. This is to prevent blocking of long requests.
Talisker provides a useful entrypoint when using gevent,
as HTTPS requests are required to be monkeypatched before
any other code is loaded.

## QA

`./run` as normal, it should say starting it is using worker gevent.
Click around a bunch, and we can test on staging further.

If you would like to do some heavier testing, I recommend installing `siege` and running this command on master and this branch:
```
siege http://localhost:8004 --concurrent 5 --reps 
```

It should be small number but show a relatively big improvement.
On my computer, the longest transaction went from 1.42 seconds to 0.36