### PR TITLE
Better registration

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -7,11 +7,26 @@ My published snaps — Linux software in the Snap Store
 {% block content %}
 {% include "publisher/_beta-notification.html" %}
 <section class="p-strip is-shallow">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      {% for message in messages %}
+        <div class="row">
+          <div class="col-12">
+            <div class="p-notification--positive">
+              <p class="p-notification__response">
+                <span class="p-notification__status">Success:</span> {{ message|safe }}
+              </p>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
   <div class="row">
     <div class="col-12">
       <h1 class="p-heading--three u-float--left">My published snaps</h1>
       {% if snaps %}
-        <a href="https://docs.snapcraft.io/build-snaps/" class="p-link--external u-float--right">How to create a snap</a>
+        <a href="/account/register-name" class="p-button--neutral u-no-margin--top u-float--right">Register name</a>
       {% endif %}
     </div>
   </div>

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -7,22 +7,42 @@ Register new Snap name
 {% block content %}
 <div class="p-strip">
 
-  <div class="row">
+  {% if conflict %}
+    <div class="row">
       <div class="col-8 push-2">
-        <h1 class="p-heading--three">Register a snap name</h1>
+        <h1 class="p-heading--three">{{ snap_name }} is already taken</h1>
       </div>
-  </div>
+    </div>
+  {% else %}
+    <div class="row">
+        <div class="col-8 push-2">
+          <h1 class="p-heading--three">Register a snap name</h1>
+        </div>
+    </div>
+  {% endif %}
 
   {% if conflict %}
       <div class="row">
         <div class="col-8 push-2">
             <div class="p-notification--caution">
               <p class="p-notification__response">
-                <b>{{ snap_name }}</b> has already been registered by another publisher. You can request a transfer of ownership, which will be reviewed by the store administrators, or <a href="/account/register-name">register a different name</a>
+                Another publisher already registered {{ snap_name }}. You can <a href="https://dashboard.snapcraft.io/register-snap/" class="p-link--external" target="_blank">file a dispute</a> to request a transfer of ownership or register a new name below.
               </p>
             </div>
         </div>
       </div>
+  {% endif %}
+
+  {% if already_owned %}
+    <div class="row">
+      <div class="col-8 push-2">
+        <div class="p-notification--caution">
+          <p class="p-notification__response">
+            You already own '<a href="/account/snaps/{{ snap_name }}/listing">{{ snap_name }}</a>'.
+          </p>
+        </div>
+      </div>
+    </div>
   {% endif %}
 
   {% if not conflict %}
@@ -50,42 +70,26 @@ Register new Snap name
   <form method="POST" action="/account/register-name" class="u-no-margin--top">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-    {% if conflict %}
-      <div class="row">
-        <div class="col-8 push-2">
-          <div class="p-form-validation">
-            <label for="snap-name">Please provide a reason as to why you would like to own this name:</label>
-            <div class="p-form-validation__field">
-              <textarea class="p-form-validation__input u-no-margin" name="registrant_comment" rows="10" required>{{ registrant_comment }}</textarea>
-            </div>
+   <div class="row">
+      <div class="col-8 push-2">
+        <div class="p-form-validation">
+          <label for="snap-name">Snap name</label>
+          <div class="p-form-validation__field">
+            <input class="p-form-validation__input" type="text" name="snap-name" id="snap-name" required maxlength="64" value="{{ snap_name }}" />
+          </div>
+        </div>
+        <div class="p-form-validation">
+          <label for="public">Snap privacy</label>
+          <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
+          <div class="p-form-validation__field">
+            <input type="radio" name="is_private" value="public" class="p-form-validation__input" id="public" {% if not is_private %} checked {% endif %}>
+            <label for="public">Public</label>
+            <input type="radio" name="is_private" value="private" class="p-form-validation__input" id="private" {% if is_private %} checked {% endif %}>
+            <label for="private">Private <span class="p-form-help-text">Snap is hidden in stores and only accessible by the publisher and collaborators</span></label>
           </div>
         </div>
       </div>
-
-      <input type="hidden" name="snap-name" value="{{ snap_name }}"/>
-      <input type="hidden" name="is_private" value="{% if is_private %} private {% else %} public {% endif %}"/>
-    {% else %}
-      <div class="row">
-        <div class="col-8 push-2">
-          <div class="p-form-validation">
-            <label for="snap-name">Snap name</label>
-            <div class="p-form-validation__field">
-              <input class="p-form-validation__input" type="text" name="snap-name" id="snap-name" required maxlength="64" value="{{ snap_name }}" />
-            </div>
-          </div>
-          <div class="p-form-validation">
-            <label for="public">Snap privacy</label>
-            <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
-            <div class="p-form-validation__field">
-              <input type="radio" name="is_private" value="public" class="p-form-validation__input" id="public" {% if not is_private %} checked {% endif %}>
-              <label for="public">Public</label>
-              <input type="radio" name="is_private" value="private" class="p-form-validation__input" id="private" {% if is_private %} checked {% endif %}>
-              <label for="private">Private</label>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% endif %}
+    </div>
 
     <div class="row u-no-margin--top">
       <div class="col-8 push-2">
@@ -98,11 +102,7 @@ Register new Snap name
         <div class="u-align--right">
 
           <a class="p-button--neutral" href="/account/snaps">Cancel</a>
-          {% if conflict %}
-            <input type="submit" class="p-button--positive u-no-margin--top" value="Request name"/>
-          {% else %}
-            <input type="submit" class="p-button--positive u-no-margin--top" value="Register"/>
-          {% endif %}
+          <input type="submit" class="p-button--positive u-no-margin--top" value="Register"/>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/693

- Removed supporting message box and link to dashboard.snapcraft.io form instead
- Updated messaging at the top of the page
- Added flash message to top of snap list page when name successfully registered

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/
- Click the 'Register name' at the top right of the snap list
- Try registering a name that you already have access to, make sure a message is displayed
- Try and register a name that is registered to someone else 'toto' for example, make sure a message is displayed with a link to the dashboard form
- Register a new name, that is not taken (prefixed with `test-`), make sure a message is displayed when you return to the snap list