### PR TITLE
Add demo brand store header

### DIFF
--- a/templates/_header-brandstore.html
+++ b/templates/_header-brandstore.html
@@ -1,0 +1,29 @@
+<header id="navigation" class="p-navigation">
+  <div class="row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="/">
+              {{ webapp_config['STORE_NAME'] }}
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav" role="menubar">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link" role="menuitem">
+          <a
+            {% if page_slug == 'store' %}
+              class="is-selected"
+            {% endif %}
+            href="/store">
+            Store
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -42,7 +42,7 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    {% include "_header.html" %}
+    {% include "_header-brandstore.html" %}
 
     {% block content %}{% endblock %}
 


### PR DESCRIPTION
Adds an example brand store header to layout.

### QA
- add a new config that uses _layout--brandstore
- run project with new config
- there should be a brand new header

<img width="1055" alt="screen shot 2018-06-15 at 15 44 04" src="https://user-images.githubusercontent.com/83575/41471909-28d37236-70b5-11e8-9623-0bdaa9599a9e.png">
