### PR TITLE
Fix icon size and rotation when dropdown is open

### DIFF
--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -68,15 +68,17 @@
       }
 
       .p-icon--chevron {
-        height: $sp-small;
-        margin-top: -($sp-small / 2); // half of the height
+        $chevron-size: map-get($icon-sizes, accordion);
+
+        height: $chevron-size;
+        margin-top: -($chevron-size / 2); // half of the height
         position: absolute;
-        right: $sp-small;
+        right: $chevron-size;
         top: 50%;
-        width: $sp-small;
+        width: $chevron-size;
       }
 
-      &[aria-expanded="true"] {
+      [aria-expanded="true"] {
         .p-icon--chevron {
           transform: rotate(180deg);
         }


### PR DESCRIPTION
**NOTE:** this is PR against Vanilla 1.7 branch, will not go live until other issues from https://github.com/CanonicalLtd/snap-squad/issues/563 are fixed

Fixes #747 

Uses new `$icon-sizes` to correct size of navigation dropdown chevron.
Also fixes rotation of the arrow when dropdown is open.

### QA

- ./run or http://snapcraft.io-pr-766.run.demo.haus/
- sign in
- Dropdown arrow should be as big as on current snapcraft.io (.75rem)
- When dropdown is open arrow should rotate

<img width="1041" alt="screen shot 2018-06-18 at 16 40 07" src="https://user-images.githubusercontent.com/83575/41542977-4fd4e2da-7316-11e8-8ef1-3e77b2fc1b9b.png">
