### PR TITLE
Equal footer padding above and below

### DIFF
--- a/static/sass/_snapcraft_footer.scss
+++ b/static/sass/_snapcraft_footer.scss
@@ -7,7 +7,6 @@
   }
 
   .p-footer {
-    padding-bottom: $sp-xx-large;
 
     p {
       max-width: 100%;


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/748

- Remove snapcraft override

# QA

- Pull the branch
- `./run`
- Visit a page and compare the footer to snapcraft.io