### PR TITLE
Vanilla home page updates

### DIFF
--- a/static/sass/_patterns_logo-list.scss
+++ b/static/sass/_patterns_logo-list.scss
@@ -20,6 +20,10 @@
       @media screen and (min-width: $breakpoint-small) {
         width: 15.04854%; // col-2
       }
+
+      img {
+        align-self: auto; // override vanilla default align-self: flex-start
+      }
     }
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -117,7 +117,7 @@
       <p>Snapcraft is available on <a href="https://docs.snapcraft.io/core/install">most popular Linux systems</a>.</p>
     </div>
     <div class="col-6">
-      <ul class="p-list u-no-margin">
+      <ul class="p-list">
         <li class="p-list__item is-ticked">Simple to package leveraging your existing tools</li>
         <li class="p-list__item is-ticked">Automatic updates for everyone</li>
         <li class="p-list__item is-ticked">Reach tens of millions of Linux systems</li>
@@ -142,73 +142,73 @@
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/4890ee03-icon-prepackaged-apps.png" alt=""/>
         </header>
-        <p class="u-no-margin">Pre-built apps</p>
+        <span>Pre-built apps</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/c">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/ae5902bf-logo-cpp.png" alt=""/>
         </header>
-        <p class="u-no-margin">C/C++</p>
+        <span>C/C++</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/go">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/53990c77-logo-go.png" alt=""/>
         </header>
-        <p class="u-no-margin">Go</p>
+        <span>Go</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/java">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/4fb34568-logo-java.png" alt=""/>
         </header>
-        <p class="u-no-margin">Java</p>
+        <span>Java</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/node">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/81c3c76e-logo-node.png" alt=""/>
         </header>
-        <p class="u-no-margin">Node.js</p>
+        <span>Node.js</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/electron">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/6ee78042-logo-electron.png" alt=""/>
         </header>
-        <p class="u-no-margin">Electron</p>
+        <span>Electron</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/python">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/27e2a770-logo-python.png" alt=""/>
         </header>
-        <p class="u-no-margin">Python</p>
+        <span>Python</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ruby">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/1ce42763-logo-ruby.png" alt=""/>
         </header>
-        <p class="u-no-margin">Ruby</p>
+        <span>Ruby</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/rust">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/387bfca8-logo-rust.png" alt=""/>
         </header>
-        <p class="u-no-margin">Rust</p>
+        <span>Rust</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/moos">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/b24fda67-logo-moos.png" alt=""/>
         </header>
-        <p class="u-no-margin">MOOS</p>
+        <span>MOOS</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/b7079097-logo-ros.png" alt=""/>
         </header>
-        <p class="u-no-margin">ROS</p>
+        <span>ROS</span>
       </a>
       <a class="p-logo-link p-card" href="https://docs.snapcraft.io/build-snaps/ros2">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/788b4b66-logo-ros2.png" alt=""/>
         </header>
-        <p class="u-no-margin">ROS 2</p>
+        <span>ROS 2</span>
       </a>
     </div>
   </div>
@@ -299,7 +299,7 @@
               {% else %}
                 <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
               {% endif %}
-              <h5 class="u-no-margin">{{ snap.title }}</h5>
+              <h4>{{ snap.title }}</h4>
             </a>
           </div>
         </div>
@@ -321,7 +321,7 @@
       <h3>Not sure yet?</h3>
     </div>
     <div class="col-6">
-      <ul class="p-list u-no-margin">
+      <ul class="p-list">
         <li class="p-list__item"><a href="https://docs.snapcraft.io/build-snaps/">Learn more</a> about snaps and Snapcraft</li>
         <li class="p-list__item"><a href="https://forum.snapcraft.io/categories">Ask on the forum</a> if you have any questions</li>
       </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
   <div class="row">
     <div class="col-12">
       <p class="p-heading--two">Deliver and update all apps for Linux and IoT</p>
-      <p class="p-heading--five">Snaps auto-update and are safe to run</p>
+      <p>Snaps auto-update and are safe to run</p>
       <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Build your first snap</a>
       <a href="https://build.snapcraft.io" class="p-button--neutral">Get started using GitHub</a>
     </div>
@@ -60,11 +60,11 @@
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-6">
-      <h2>Installable across Linux distributions</h2>
+      <h3>Installable across Linux distributions</h3>
     </div>
     <div class="col-6">
-      <p class="p-heading--five">Snaps are available for any Linux OS running snapd, the service that runs and manages snaps.</p>
-      <p class="p-heading--five"><a href="https://docs.snapcraft.io/core/install">Enable snaps on your OS</a></p>
+      <p>Snaps are available for any Linux OS running snapd, the service that runs and manages snaps.</p>
+      <p><a href="https://docs.snapcraft.io/core/install">Enable snaps on your OS</a></p>
     </div>
   </div>
   <div class="row">
@@ -112,18 +112,18 @@
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-6">
-      <h2>What is Snapcraft?</h2>
-      <p class="p-heading--five">Snapcraft is the command line tool for writing and publishing your software as a snap.</p>
-      <p class="p-heading--five">Snapcraft is available on <a href="https://docs.snapcraft.io/core/install">most popular Linux systems</a>.</p>
+      <h3>What is Snapcraft?</h3>
+      <p>Snapcraft is the command line tool for writing and publishing your software as a snap.</p>
+      <p>Snapcraft is available on <a href="https://docs.snapcraft.io/core/install">most popular Linux systems</a>.</p>
     </div>
     <div class="col-6">
       <ul class="p-list u-no-margin">
-        <li class="p-list__item is-ticked p-heading--five">Simple to package leveraging your existing tools</li>
-        <li class="p-list__item is-ticked p-heading--five">Automatic updates for everyone</li>
-        <li class="p-list__item is-ticked p-heading--five">Reach tens of millions of Linux systems</li>
-        <li class="p-list__item is-ticked p-heading--five">Roll back versions effortlessly</li>
-        <li class="p-list__item is-ticked p-heading--five">Integrate easily with build and CI infrastructure</li>
-        <li class="p-list__item is-ticked p-heading--five">Free for open and closed source projects</li>
+        <li class="p-list__item is-ticked">Simple to package leveraging your existing tools</li>
+        <li class="p-list__item is-ticked">Automatic updates for everyone</li>
+        <li class="p-list__item is-ticked">Reach tens of millions of Linux systems</li>
+        <li class="p-list__item is-ticked">Roll back versions effortlessly</li>
+        <li class="p-list__item is-ticked">Integrate easily with build and CI infrastructure</li>
+        <li class="p-list__item is-ticked">Free for open and closed source projects</li>
       </ul>
     </div>
   </div>
@@ -132,8 +132,8 @@
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2>Snapcraft integrates with your tools</h2>
-      <p class="p-heading--five">See how Snapcraft works with your language or framework to make packaging and installing your software easy.</p>
+      <h3>Snapcraft integrates with your tools</h3>
+      <p>See how Snapcraft works with your language or framework to make packaging and installing your software easy.</p>
     </div>
   </div>
   <div class="row">
@@ -217,7 +217,7 @@
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2>What people are saying about Snapcraft</h2>
+      <h3>What people are saying about Snapcraft</h3>
     </div>
   </div>
   <div class="row">
@@ -264,9 +264,9 @@
 <div class="p-strip is-deep is-bordered u-image-position">
   <div class="row u-vertically-center">
     <div class="col-6">
-      <h2>Auto-build from GitHub</h2>
-      <p class="p-heading--five">Automate your build process and publish software straight from your GitHub repos.</p>
-    <p><a class="p-button--neutral" href="https://build.snapcraft.io/auth/authenticate"><i class="p-icon--github"></i> Connect a GitHub repo</a></p>
+      <h3>Auto-build from GitHub</h3>
+      <p>Automate your build process and publish software straight from your GitHub repos.</p>
+      <p><a class="p-button--neutral" href="https://build.snapcraft.io/auth/authenticate"><i class="p-icon--github"></i> Connect a GitHub repo</a></p>
     </div>
     <div class="col-6">
       <img class="u-image-position--bottom" src="https://assets.ubuntu.com/v1/006db1f4-build-snapcraft-heroku.png" alt="" style="max-height: 95%;" />
@@ -277,10 +277,10 @@
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-6">
-      <h2>The Snap Store</h2>
+      <h3>The Snap Store</h3>
     </div>
     <div class="col-6">
-      <p class="p-heading--five">The Snap Store is enabled by default on tens of millions of Linux systems. It allows developers to release free or paid apps for multiple architectures, on multiple release channels from daily builds to stable releases.</p>
+      <p>The Snap Store is enabled by default on tens of millions of Linux systems. It allows developers to release free or paid apps for multiple architectures, on multiple release channels from daily builds to stable releases.</p>
     </div>
   </div>
   {% if featured_snaps %}
@@ -318,12 +318,12 @@
 <div class="p-strip is-deep">
   <div class="row">
     <div class="col-6">
-      <h2>Not sure yet?</h2>
+      <h3>Not sure yet?</h3>
     </div>
     <div class="col-6">
       <ul class="p-list u-no-margin">
-        <li class="p-list__item p-heading--five"><a href="https://docs.snapcraft.io/build-snaps/">Learn more</a> about snaps and Snapcraft</li>
-        <li class="p-list__item p-heading--five"><a href="https://forum.snapcraft.io/categories">Ask on the forum</a> if you have any questions</li>
+        <li class="p-list__item"><a href="https://docs.snapcraft.io/build-snaps/">Learn more</a> about snaps and Snapcraft</li>
+        <li class="p-list__item"><a href="https://forum.snapcraft.io/categories">Ask on the forum</a> if you have any questions</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Fixes #749 

Updates text size and weight on home page, removes unnecessary `u-no-margin` and fixes issue with logos alignment.

### QA

- ./run
- go to home page
- it should look nice

<img width="1045" alt="screen shot 2018-06-19 at 15 20 06" src="https://user-images.githubusercontent.com/83575/41600167-6b7d0caa-73d5-11e8-9cfb-7cc740f5fcac.png">
