### PR TITLE
Add store conf to have specific ubuntustore

### DIFF
--- a/.env
+++ b/.env
@@ -3,5 +3,4 @@ FLASK_DEBUG=true
 SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
 DEVEL=True
-WEBAPP=snapcraft
 BLOG_ENABLED=true

--- a/webapp/api/public.py
+++ b/webapp/api/public.py
@@ -55,9 +55,9 @@ PROMOTED_QUERY_URL = ''.join([
 class StoreApi:
     headers = {'X-Ubuntu-Series': '16'}
 
-    def __init__(self, store_query=None):
-        if store_query:
-            self.headers.update({'X-Ubuntu-Store': store_query})
+    def __init__(self, extra_headers=None):
+        if extra_headers:
+            self.headers.update(extra_headers)
 
     def process_response(self, response):
         try:

--- a/webapp/api/public.py
+++ b/webapp/api/public.py
@@ -55,9 +55,9 @@ PROMOTED_QUERY_URL = ''.join([
 class StoreApi:
     headers = {'X-Ubuntu-Series': '16'}
 
-    def __init__(self, extra_headers=None):
-        if extra_headers:
-            self.headers.update(extra_headers)
+    def __init__(self, store=None):
+        if store:
+            self.headers.update({'X-Ubuntu-Store': store})
 
     def process_response(self, response):
         try:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -17,10 +17,10 @@ from werkzeug.debug import DebuggedApplication
 import webapp.helpers as helpers
 from webapp.handlers import set_handlers
 from webapp.blog.views import blog
-from webapp.public.views import store
+from webapp.public.views import store_blueprint
 from webapp.publisher.views import account
 from webapp.publisher.snaps.views import publisher_snaps
-from webapp.snapcraft.views import snapcraft
+from webapp.snapcraft.views import snapcraft_blueprint
 from webapp.login.views import login
 
 
@@ -66,14 +66,15 @@ def create_app(testing=False):
 
 
 def init_brandstore(app):
-    app.register_blueprint(store)
+    store_query = app.config.get('WEBAPP_CONFIG').get('STORE_QUERY')
+    app.register_blueprint(store_blueprint(store_query))
 
 
 def init_snapcraft(app):
-    app.register_blueprint(snapcraft)
+    app.register_blueprint(snapcraft_blueprint())
     app.register_blueprint(login)
     csrf.exempt('webapp.login.views.login_handler')
-    app.register_blueprint(store)
+    app.register_blueprint(store_blueprint())
     app.register_blueprint(account, url_prefix='/account')
     app.register_blueprint(publisher_snaps, url_prefix='/account/snaps')
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -66,16 +66,15 @@ def create_app(testing=False):
 
 
 def init_brandstore(app):
-    extra_headers = app.config.get('WEBAPP_EXTRA_HEADERS')
-    app.register_blueprint(store_blueprint(extra_headers))
+    store = app.config.get('WEBAPP_CONFIG').get('STORE_QUERY')
+    app.register_blueprint(store_blueprint(store))
 
 
 def init_snapcraft(app):
-    extra_headers = app.config.get('WEBAPP_EXTRA_HEADERS')
-    app.register_blueprint(snapcraft_blueprint(extra_headers))
+    app.register_blueprint(snapcraft_blueprint())
     app.register_blueprint(login)
     csrf.exempt('webapp.login.views.login_handler')
-    app.register_blueprint(store_blueprint(extra_headers))
+    app.register_blueprint(store_blueprint())
     app.register_blueprint(account, url_prefix='/account')
     app.register_blueprint(publisher_snaps, url_prefix='/account/snaps')
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -66,15 +66,16 @@ def create_app(testing=False):
 
 
 def init_brandstore(app):
-    store_query = app.config.get('WEBAPP_CONFIG').get('STORE_QUERY')
-    app.register_blueprint(store_blueprint(store_query))
+    extra_headers = app.config.get('WEBAPP_EXTRA_HEADERS')
+    app.register_blueprint(store_blueprint(extra_headers))
 
 
 def init_snapcraft(app):
-    app.register_blueprint(snapcraft_blueprint())
+    extra_headers = app.config.get('WEBAPP_EXTRA_HEADERS')
+    app.register_blueprint(snapcraft_blueprint(extra_headers))
     app.register_blueprint(login)
     csrf.exempt('webapp.login.views.login_handler')
-    app.register_blueprint(store_blueprint())
+    app.register_blueprint(store_blueprint(extra_headers))
     app.register_blueprint(account, url_prefix='/account')
     app.register_blueprint(publisher_snaps, url_prefix='/account/snaps')
 

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -24,3 +24,4 @@ SENTRY_CONFIG = {
 }
 
 WEBAPP = os.getenv('WEBAPP', 'snapcraft')
+WEBAPP_EXTRA_HEADERS = {}

--- a/webapp/configs/brand.py
+++ b/webapp/configs/brand.py
@@ -1,4 +1,0 @@
-WEBAPP_CONFIG = {
-    'LAYOUT': '_layout-brandstore.html',
-    'STORE_NAME': 'brand store'
-}

--- a/webapp/configs/snapcraft.py
+++ b/webapp/configs/snapcraft.py
@@ -2,7 +2,7 @@ import os
 
 WEBAPP_CONFIG = {
     'LAYOUT': '_layout.html',
-    'STORE_NAME': 'Snap store'
+    'STORE_NAME': 'Snap store',
 }
 
 BLOG_ENABLED = os.getenv('BLOG_ENABLED', '').lower() == 'true'

--- a/webapp/public/views.py
+++ b/webapp/public/views.py
@@ -17,8 +17,8 @@ from webapp.api.exceptions import (
 from urllib.parse import quote_plus
 
 
-def store_blueprint(store_query=None):
-    api = StoreApi(store_query)
+def store_blueprint(extra_headers={}):
+    api = StoreApi(extra_headers)
 
     store = flask.Blueprint(
         'store', __name__,

--- a/webapp/public/views.py
+++ b/webapp/public/views.py
@@ -2,7 +2,7 @@ import flask
 import humanize
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
-import webapp.api.public as api
+from webapp.api.public import StoreApi
 import webapp.public.logic as logic
 from dateutil import parser
 from math import floor
@@ -16,241 +16,242 @@ from webapp.api.exceptions import (
 )
 from urllib.parse import quote_plus
 
-store = flask.Blueprint(
-    'store', __name__,
-    template_folder='/templates', static_folder='/static')
 
+def store_blueprint(store_query=None):
+    api = StoreApi(store_query)
 
-def _handle_errors(api_error: ApiError):
-    status_code = 502
-    error = {
-        'message': str(api_error)
-    }
+    store = flask.Blueprint(
+        'store', __name__,
+        template_folder='/templates', static_folder='/static')
 
-    if type(api_error) is ApiTimeoutError:
-        status_code = 504
-    elif type(api_error) is ApiResponseDecodeError:
+    def _handle_errors(api_error: ApiError):
         status_code = 502
-    elif type(api_error) is ApiResponseErrorList:
-        error['errors'] = api_error.errors
-        status_code = 502
-    elif type(api_error) is ApiResponseError:
-        status_code = 502
-    elif type(api_error) is ApiConnectionError:
-        status_code = 502
+        error = {
+            'message': str(api_error)
+        }
 
-    return status_code, error
+        if type(api_error) is ApiTimeoutError:
+            status_code = 504
+        elif type(api_error) is ApiResponseDecodeError:
+            status_code = 502
+        elif type(api_error) is ApiResponseErrorList:
+            error['errors'] = api_error.errors
+            status_code = 502
+        elif type(api_error) is ApiResponseError:
+            status_code = 502
+        elif type(api_error) is ApiConnectionError:
+            status_code = 502
 
+        return status_code, error
 
-@store.route('/snaps')
-def snaps_view():
-    return flask.redirect(
-        flask.url_for('.store_view'))
-
-
-@store.route('/discover')
-def discover():
-    return flask.redirect(
-        flask.url_for('.store_view'))
-
-
-@store.route('/')
-@store.route('/store')
-def store_view():
-    featured_snaps = []
-    error_info = {}
-    status_code = 200
-    try:
-        featured_snaps = logic.get_searched_snaps(
-            api.get_featured_snaps()
-        )
-    except ApiError as api_error:
-        status_code, error_info = _handle_errors(api_error)
-
-    return flask.render_template(
-        'store.html',
-        featured_snaps=featured_snaps,
-        error_info=error_info
-    ), status_code
-
-
-@store.route('/search')
-def search_snap():
-    status_code = 200
-    snap_searched = flask.request.args.get('q', default='', type=str)
-    if not snap_searched:
+    @store.route('/snaps')
+    def snaps_view():
         return flask.redirect(
             flask.url_for('.store_view'))
 
-    size = flask.request.args.get('limit', default=10, type=int)
-    offset = flask.request.args.get('offset', default=0, type=int)
-    try:
-        page = floor(offset / size) + 1
-    except ZeroDivisionError:
-        size = 10
-        page = floor(offset / size) + 1
+    @store.route('/discover')
+    def discover():
+        return flask.redirect(
+            flask.url_for('.store_view'))
 
-    error_info = {}
-    snaps_results = []
-    links = []
-    try:
-        searched_results = api.get_searched_snaps(
-            quote_plus(snap_searched),
-            size,
-            page
+    @store.route('/')
+    @store.route('/store')
+    def store_view():
+        featured_snaps = []
+        error_info = {}
+        status_code = 200
+        try:
+            featured_snaps = logic.get_searched_snaps(
+                api.get_featured_snaps()
+            )
+        except ApiError as api_error:
+            status_code, error_info = _handle_errors(api_error)
+
+        return flask.render_template(
+            'store.html',
+            featured_snaps=featured_snaps,
+            error_info=error_info
+        ), status_code
+
+    @store.route('/search')
+    def search_snap():
+        status_code = 200
+        snap_searched = flask.request.args.get('q', default='', type=str)
+        if not snap_searched:
+            return flask.redirect(
+                flask.url_for('.store_view'))
+
+        size = flask.request.args.get('limit', default=10, type=int)
+        offset = flask.request.args.get('offset', default=0, type=int)
+        try:
+            page = floor(offset / size) + 1
+        except ZeroDivisionError:
+            size = 10
+            page = floor(offset / size) + 1
+
+        error_info = {}
+        snaps_results = []
+        links = []
+        try:
+            searched_results = api.get_searched_snaps(
+                quote_plus(snap_searched),
+                size,
+                page
+            )
+
+            snaps_results = logic.get_searched_snaps(searched_results)
+            links = logic.get_pages_details(
+                flask.request.base_url,
+                (
+                    searched_results['_links']
+                    if '_links' in searched_results
+                    else []
+                )
+            )
+        except ApiError as api_error:
+            status_code, error_info = _handle_errors(api_error)
+
+        context = {
+            "query": snap_searched,
+            "snaps": snaps_results,
+            "links": links,
+            "error_info": error_info
+
+        }
+
+        return flask.render_template(
+            'search.html',
+            **context
         )
 
-        snaps_results = logic.get_searched_snaps(searched_results)
-        links = logic.get_pages_details(
-            flask.request.base_url,
-            (
-                searched_results['_links']
-                if '_links' in searched_results
-                else []
-            )
-        )
-    except ApiError as api_error:
-        status_code, error_info = _handle_errors(api_error)
+    @store.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
+    def snap_details(snap_name):
+        """
+        A view to display the snap details page for specific snaps.
 
-    context = {
-        "query": snap_searched,
-        "snaps": snaps_results,
-        "links": links,
-        "error_info": error_info
+        This queries the snapcraft API (api.snapcraft.io) and passes
+        some of the data through to the snap-details.html template,
+        with appropriate sanitation.
+        """
 
-    }
+        error_info = {}
+        default_channel = logic.get_default_channel(snap_name)
 
-    return flask.render_template(
-        'search.html',
-        **context
-    )
+        try:
+            details = api.get_snap_details(
+                    snap_name, default_channel)
+        except ApiTimeoutError as api_timeout_error:
+            flask.abort(504, str(api_timeout_error))
+        except ApiResponseDecodeError as api_response_decode_error:
+            flask.abort(502, str(api_response_decode_error))
+        except ApiResponseErrorList as api_response_error_list:
+            if api_response_error_list.status_code == 404:
+                flask.abort(404, 'No snap named {}'.format(snap_name))
+            else:
+                error_messages = ', '.join(
+                    api_response_error_list.errors.key())
+                flask.abort(502, error_messages)
+        except ApiResponseError as api_response_error:
+            flask.abort(502, str(api_response_error))
+        except ApiError as api_error:
+            flask.abort(502, str(api_error))
 
+        formatted_paragraphs = logic.split_description_into_paragraphs(
+            details['description'])
 
-@store.route('/<regex("[a-z0-9-]*[a-z][a-z0-9-]*"):snap_name>')
-def snap_details(snap_name):
-    """
-    A view to display the snap details page for specific snaps.
+        channel_maps_list = logic.convert_channel_maps(
+            details.get('channel_maps_list'))
 
-    This queries the snapcraft API (api.snapcraft.io) and passes
-    some of the data through to the snap-details.html template,
-    with appropriate sanitation.
-    """
+        end = metrics_helper.get_last_metrics_processed_date()
+        country_metric_name = 'weekly_installed_base_by_country_percent'
+        os_metric_name = 'weekly_installed_base_by_operating_system_normalized'
 
-    error_info = {}
-    default_channel = logic.get_default_channel(snap_name)
+        metrics_query_json = [
+            metrics_helper.get_filter(
+                metric_name=country_metric_name,
+                snap_id=details['snap_id'],
+                start=end,
+                end=end),
+            metrics_helper.get_filter(
+                metric_name=os_metric_name,
+                snap_id=details['snap_id'],
+                start=end,
+                end=end)]
 
-    try:
-        details = api.get_snap_details(
-                snap_name, default_channel)
-    except ApiTimeoutError as api_timeout_error:
-        flask.abort(504, str(api_timeout_error))
-    except ApiResponseDecodeError as api_response_decode_error:
-        flask.abort(502, str(api_response_decode_error))
-    except ApiResponseErrorList as api_response_error_list:
-        if api_response_error_list.status_code == 404:
-            flask.abort(404, 'No snap named {}'.format(snap_name))
-        else:
-            error_messages = ', '.join(api_response_error_list.errors.key())
-            flask.abort(502, error_messages)
-    except ApiResponseError as api_response_error:
-        flask.abort(502, str(api_response_error))
-    except ApiError as api_error:
-        flask.abort(502, str(api_error))
+        status_code = 200
+        try:
+            metrics_response = api.get_public_metrics(
+                snap_name,
+                metrics_query_json)
+        except ApiError as api_error:
+            status_code, error_info = _handle_errors(api_error)
 
-    formatted_paragraphs = logic.split_description_into_paragraphs(
-        details['description'])
+        oses = metrics_helper.find_metric(metrics_response, os_metric_name)
+        os_metrics = metrics.OsMetric(
+            name=oses['metric_name'],
+            series=oses['series'],
+            buckets=oses['buckets'],
+            status=oses['status'])
 
-    channel_maps_list = logic.convert_channel_maps(
-        details.get('channel_maps_list'))
+        territories = metrics_helper.find_metric(
+            metrics_response, country_metric_name)
+        country_devices = metrics.CountryDevices(
+            name=territories['metric_name'],
+            series=territories['series'],
+            buckets=territories['buckets'],
+            status=territories['status'],
+            private=False)
 
-    end = metrics_helper.get_last_metrics_processed_date()
-    country_metric_name = 'weekly_installed_base_by_country_percent'
-    os_metric_name = 'weekly_installed_base_by_operating_system_normalized'
+        # filter out banner and banner-icon images from screenshots
+        screenshots = [
+            m['url'] for m in details['media']
+            if m['type'] == "screenshot" and "banner" not in m['url']
+        ]
+        icons = [m['url'] for m in details['media'] if m['type'] == "icon"]
 
-    metrics_query_json = [
-        metrics_helper.get_filter(
-            metric_name=country_metric_name,
-            snap_id=details['snap_id'],
-            start=end,
-            end=end),
-        metrics_helper.get_filter(
-            metric_name=os_metric_name,
-            snap_id=details['snap_id'],
-            start=end,
-            end=end)]
+        context = {
+            # Data direct from details API
+            'snap_title': details['title'],
+            'package_name': details['package_name'],
+            'icon_url': icons[0] if icons else None,
+            'version': details['version'],
+            'revision': details['revision'],
+            'license': details['license'],
+            'publisher': details['publisher'],
+            'screenshots': screenshots,
+            'prices': details['prices'],
+            'contact': details.get('contact'),
+            'website': details.get('website'),
+            'summary': details['summary'],
+            'description_paragraphs': formatted_paragraphs,
+            'channel_map': channel_maps_list,
+            'default_channel': default_channel,
 
-    status_code = 200
-    try:
-        metrics_response = api.get_public_metrics(
-            snap_name,
-            metrics_query_json)
-    except ApiError as api_error:
-        status_code, error_info = _handle_errors(api_error)
+            # Transformed API data
+            'filesize': humanize.naturalsize(details['binary_filesize']),
+            'last_updated': (
+                humanize.naturaldate(
+                    parser.parse(details.get('last_updated'))
+                )
+            ),
+            'last_updated_raw': details.get('last_updated'),
 
-    oses = metrics_helper.find_metric(metrics_response, os_metric_name)
-    os_metrics = metrics.OsMetric(
-        name=oses['metric_name'],
-        series=oses['series'],
-        buckets=oses['buckets'],
-        status=oses['status'])
+            # Data from metrics API
+            'countries': country_devices.country_data,
+            'normalized_os': os_metrics.os,
 
-    territories = metrics_helper.find_metric(
-        metrics_response, country_metric_name)
-    country_devices = metrics.CountryDevices(
-        name=territories['metric_name'],
-        series=territories['series'],
-        buckets=territories['buckets'],
-        status=territories['status'],
-        private=False)
+            # Context info
+            'is_linux': (
+                'Linux' in flask.request.headers.get('User-Agent', '') and
+                'Android' not in flask.request.headers.get('User-Agent', '')
+            ),
 
-    # filter out banner and banner-icon images from screenshots
-    screenshots = [
-        m['url'] for m in details['media']
-        if m['type'] == "screenshot" and "banner" not in m['url']
-    ]
-    icons = [m['url'] for m in details['media'] if m['type'] == "icon"]
+            'error_info': error_info
+        }
 
-    context = {
-        # Data direct from details API
-        'snap_title': details['title'],
-        'package_name': details['package_name'],
-        'icon_url': icons[0] if icons else None,
-        'version': details['version'],
-        'revision': details['revision'],
-        'license': details['license'],
-        'publisher': details['publisher'],
-        'screenshots': screenshots,
-        'prices': details['prices'],
-        'contact': details.get('contact'),
-        'website': details.get('website'),
-        'summary': details['summary'],
-        'description_paragraphs': formatted_paragraphs,
-        'channel_map': channel_maps_list,
-        'default_channel': default_channel,
+        return flask.render_template(
+            'snap-details.html',
+            **context
+        ), status_code
 
-        # Transformed API data
-        'filesize': humanize.naturalsize(details['binary_filesize']),
-        'last_updated': (
-            humanize.naturaldate(
-                parser.parse(details.get('last_updated'))
-            )
-        ),
-        'last_updated_raw': details.get('last_updated'),
-
-        # Data from metrics API
-        'countries': country_devices.country_data,
-        'normalized_os': os_metrics.os,
-
-        # Context info
-        'is_linux': (
-            'Linux' in flask.request.headers.get('User-Agent', '') and
-            'Android' not in flask.request.headers.get('User-Agent', '')
-        ),
-
-        'error_info': error_info
-    }
-
-    return flask.render_template(
-        'snap-details.html',
-        **context
-    ), status_code
+    return store

--- a/webapp/public/views.py
+++ b/webapp/public/views.py
@@ -17,8 +17,8 @@ from webapp.api.exceptions import (
 from urllib.parse import quote_plus
 
 
-def store_blueprint(extra_headers={}):
-    api = StoreApi(extra_headers)
+def store_blueprint(store=None):
+    api = StoreApi(store)
 
     store = flask.Blueprint(
         'store', __name__,

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -1,6 +1,6 @@
 import flask
 
-import webapp.api.public as api
+from webapp.api.public import StoreApi
 from webapp.public import logic
 from webapp.api.exceptions import (
     ApiError,
@@ -11,66 +11,67 @@ from webapp.api.exceptions import (
     ApiConnectionError
 )
 
-snapcraft = flask.Blueprint(
-    'snapcraft', __name__,
-    template_folder='/templates', static_folder='/static')
 
+def snapcraft_blueprint():
+    api = StoreApi()
 
-def _handle_errors(api_error: ApiError):
-    status_code = 502
-    error = {
-        'message': str(api_error)
-    }
+    snapcraft = flask.Blueprint(
+        'snapcraft', __name__,
+        template_folder='/templates', static_folder='/static')
 
-    if type(api_error) is ApiTimeoutError:
-        status_code = 504
-    elif type(api_error) is ApiResponseDecodeError:
+    def _handle_errors(api_error: ApiError):
         status_code = 502
-    elif type(api_error) is ApiResponseErrorList:
-        error['errors'] = api_error.errors
-        status_code = 502
-    elif type(api_error) is ApiResponseError:
-        status_code = 502
-    elif type(api_error) is ApiConnectionError:
-        status_code = 502
-    return status_code, error
+        error = {
+            'message': str(api_error)
+        }
 
+        if type(api_error) is ApiTimeoutError:
+            status_code = 504
+        elif type(api_error) is ApiResponseDecodeError:
+            status_code = 502
+        elif type(api_error) is ApiResponseErrorList:
+            error['errors'] = api_error.errors
+            status_code = 502
+        elif type(api_error) is ApiResponseError:
+            status_code = 502
+        elif type(api_error) is ApiConnectionError:
+            status_code = 502
+        return status_code, error
 
-@snapcraft.route('/')
-def homepage():
-    featured_snaps = []
-    error_info = {}
-    status_code = 200
-    try:
-        featured_snaps = logic.get_searched_snaps(
-            api.get_featured_snaps()
-        )
-    except ApiError as api_error:
-        status_code, error_info = _handle_errors(api_error)
+    @snapcraft.route('/')
+    def homepage():
+        featured_snaps = []
+        error_info = {}
+        status_code = 200
+        try:
+            featured_snaps = logic.get_searched_snaps(
+                api.get_featured_snaps()
+            )
+        except ApiError as api_error:
+            status_code, error_info = _handle_errors(api_error)
 
-    return flask.render_template(
-        'index.html',
-        featured_snaps=featured_snaps,
-        error_info=error_info
-    ), status_code
+        return flask.render_template(
+            'index.html',
+            featured_snaps=featured_snaps,
+            error_info=error_info
+        ), status_code
 
+    @snapcraft.route('/docs', defaults={'path': ''})
+    @snapcraft.route('/docs/<path:path>')
+    def docs_redirect(path):
+        return flask.redirect('https://docs.snapcraft.io/' + path)
 
-@snapcraft.route('/docs', defaults={'path': ''})
-@snapcraft.route('/docs/<path:path>')
-def docs_redirect(path):
-    return flask.redirect('https://docs.snapcraft.io/' + path)
+    @snapcraft.route('/community')
+    def community_redirect():
+        return flask.redirect('/')
 
+    @snapcraft.route('/create')
+    def create_redirect():
+        return flask.redirect('https://docs.snapcraft.io/build-snaps')
 
-@snapcraft.route('/community')
-def community_redirect():
-    return flask.redirect('/')
+    @snapcraft.route('/favicon.ico')
+    def favicon():
+        return flask.redirect(
+            'https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png')
 
-
-@snapcraft.route('/create')
-def create_redirect():
-    return flask.redirect('https://docs.snapcraft.io/build-snaps')
-
-
-@snapcraft.route('/favicon.ico')
-def favicon():
-    return flask.redirect('https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png')
+    return snapcraft

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -12,8 +12,8 @@ from webapp.api.exceptions import (
 )
 
 
-def snapcraft_blueprint():
-    api = StoreApi()
+def snapcraft_blueprint(extra_headers):
+    api = StoreApi(extra_headers)
 
     snapcraft = flask.Blueprint(
         'snapcraft', __name__,

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -12,8 +12,8 @@ from webapp.api.exceptions import (
 )
 
 
-def snapcraft_blueprint(extra_headers):
-    api = StoreApi(extra_headers)
+def snapcraft_blueprint():
+    api = StoreApi()
 
     snapcraft = flask.Blueprint(
         'snapcraft', __name__,


### PR DESCRIPTION
# Summary

Fixes https://github.com/CanonicalLtd/snap-squad/issues/588
Add possiblity to store to add a header in the API calls with `X-Ubuntu-Store`.

To do this I had to refactor the code so that blueprints have a constructor: `store_blueprint()` so that we can store parameters (for example `store_query` which is the store to query)

Same thing has been done for the API module which has been transformed into a class so that the header is built once.

# QA

- `./run`
- Should have snapcraft as usual
- In the folder `webapp/configs`, add the file `lime.py`:
```python
WEBAPP_CONFIG = {
    'STORE_QUERY': 'LimeNET',
    'LAYOUT': '_layout-brandstore.html',
    'STORE_NAME': 'LimeNET'
}
```
- ~In `.env` file change `WEBAPP`: `WEBAPP=lime`~
- ~`./run`~
- `./run --env WEBAPP=lime`
- http://0.0.0.0:8004
- Search for lime, you should have a list of snaps
- Search for toto, no snap found