### PR TITLE
Fix search form styles

### DIFF
--- a/static/sass/_search-form.scss
+++ b/static/sass/_search-form.scss
@@ -1,10 +1,14 @@
 @mixin search-form {
   .p-form--search {
-    align-items: unset; // to fix alignment bug
     width: 100%;
 
     .p-form__group {
       flex-grow: 1;
     }
+
+    .p-form__control {
+      width: 100%;
+    }
+
   }
 }

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block content %}
-
   <section id="main-content" class="p-strip--image is-deep snapcraft-banner-background">
     <div class="row">
       <div class="col-10">
@@ -30,9 +29,11 @@
         <form action="/search" class="p-form p-form--inline p-form--search">
           <div class="p-form__group">
             <label for="search-input" class="u-off-screen">Search</label>
-            <input id="search-input" type="search" name="q" value="{{ query }}" class="p-form__control"/>
+            <div class="p-form__control u-clearfix">
+              <input id="search-input" type="search" name="q" value="{{ query }}" />
+            </div>
           </div>
-            <button type="submit" alt="search" class="p-button--positive u-align--left">Search</button>
+          <button type="submit" alt="search" class="p-button--positive">Search</button>
         </form>
       </div>
     </div>

--- a/templates/store.html
+++ b/templates/store.html
@@ -33,9 +33,11 @@
         <form action="/search" class="p-form p-form--inline p-form--search">
           <div class="p-form__group">
             <label for="search-input" class="u-off-screen">Search</label>
-            <input id="search-input" type="search" name="q" value="{{ query }}" class="p-form__control"/>
+            <div class="p-form__control u-clearfix">
+              <input id="search-input" type="search" name="q" value="{{ query }}" />
+            </div>
           </div>
-            <button type="submit" alt="search" class="p-button--positive">Search</button>
+          <button type="submit" alt="search" class="p-button--positive">Search</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
Fixes #751 

Updates search form styles to fix issues with search button

### QA

- ./run
- go to /store
- search form should look good (no oversized button)
- search for some snap
- search form should look good on search results page as well

<img width="1027" alt="screen shot 2018-06-20 at 12 35 01" src="https://user-images.githubusercontent.com/83575/41653441-639930e8-7486-11e8-8649-0b98be955536.png">
