### PR TITLE
Tweaks testimonials

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -226,8 +226,8 @@
         <div class="p-testimonial__logo">
           <img src="https://assets.ubuntu.com/v1/53b1b835-logo-heroku.svg" alt="Heroku logo" />
         </div>
-        <h4 class="p-testimonial__title">"The auto-updating feature is huge"</h4>
-        <p class="p-testimonial__content">We had been facing issues with packaging problems for years...snaps seemed it would make my life a lot easier. The auto-updating feature is huge and one that we haven’t seen elsewhere. Due to the nature of our platform, we release updates more than daily which admittedly can be annoying for our users to constantly update.</p>
+        <h4 class="p-testimonial__title">“The auto-updating feature is huge”</h4>
+        <p class="p-testimonial__content">Due to the nature of our platform, we release updates more than daily which admittedly can be annoying for our users to constantly update.</p>
         <p class="p-testimonial__content">Therefore, having them done seamlessly in the background makes life for our users so much easier. It’s great to see snaps as the first serious attempt to try and unify the community.</p>
         <cite class="p-testimonial__citation">
           Jeff Dickey<br /> CLI engineer, <a href="https://www.heroku.com/" class="p-link--external">Heroku</a>
@@ -239,7 +239,7 @@
         <div class="p-testimonial__logo">
           <img src="https://assets.ubuntu.com/v1/e4c220b3-logo-microsoft.svg" alt="Microsoft logo" />
         </div>
-        <h4 class="p-testimonial__title">"Starting with snaps is easy"</h4>
+        <h4 class="p-testimonial__title">“Starting with snaps is easy”</h4>
         <p class="p-testimonial__content">We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts artefacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication. The modular containments is what appealed about snaps and can see it will be a lot more flexible. Starting with snaps is easy and the resources that are provided are clean and structured which aids adoption.</p>
         <cite class="p-testimonial__citation">
           Lee Coward and Rakesh Singh<br/> <a href="https://www.microsoft.com/net/" class="p-link--external">.NET (Microsoft)</a>
@@ -251,7 +251,7 @@
         <div class="p-testimonial__logo">
           <img src="https://assets.ubuntu.com/v1/a82ec61c-logo-jetbrains.svg" alt="JetBrains logo" />
         </div>
-        <h4 class="p-testimonial__title">"A major software discovery tool"</h4>
+        <h4 class="p-testimonial__title">“A major software discovery tool”</h4>
         <p class="p-testimonial__content">The Snap store provides additional exposure to our tools for many of our existing and potential users. The decision to use it came quite naturally. We believe the store will be a major software discovery tool on Linux, so the more people find out about our tools naturally and install them more easily, the better for everyone.</p>
         <cite class="p-testimonial__citation">
           Aleksey Rostovskiy<br /> Engineer, <a href="https://www.jetbrains.com/" class="p-link--external">JetBrains</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -240,7 +240,8 @@
           <img src="https://assets.ubuntu.com/v1/e4c220b3-logo-microsoft.svg" alt="Microsoft logo" />
         </div>
         <h4 class="p-testimonial__title">“Starting with snaps is easy”</h4>
-        <p class="p-testimonial__content">We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts artefacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication. The modular containments is what appealed about snaps and can see it will be a lot more flexible. Starting with snaps is easy and the resources that are provided are clean and structured which aids adoption.</p>
+        <p class="p-testimonial__content">We definitely find Snapcraft easier as it is yaml based and provides details of what artifacts are needed. Debian packaging has things that need to be followed which can be distribution specific, which creates complication.
+        <p class="p-testimonial__content">The modular containment is what appealed about snaps and [we] can see it will be a lot more flexible. Starting with snaps is easy and the resources that are provided are clean and structured which aids adoption.</p>
         <cite class="p-testimonial__citation">
           Lee Coward and Rakesh Singh<br/> <a href="https://www.microsoft.com/net/" class="p-link--external">.NET (Microsoft)</a>
         </cite>


### PR DESCRIPTION
Across all testimonials:
- Fixes the ugly Ascii quotes in the headings.

In the first testimonial:
- Drops these sentences: “We had been facing issues with packaging problems for years...snaps seemed it would make my life a lot easier. The auto-updating feature is huge and one that we haven’t seen elsewhere.” The first sentence could easily be misinterpreted as describing two problems with snaps. The second sentence is mostly redundant with the heading. And dropping both sentences brings the length of this testimonial in line with the other two.

In the second testimonial:
- Fixes the accidental “artifacts artefacts”.
- Fixes two grammar errors.
- Splits the paragraph in two.