### PR TITLE
Update spacing of snap details heading

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -26,6 +26,7 @@
     }
 
     &__name {
+      margin-bottom: 0;
       overflow: hidden;
       text-overflow: ellipsis;
     }
@@ -44,8 +45,15 @@
   }
 
   .p-snap-install-buttons {
-    margin-top: 68px; // align with snap name (60px icon + 8px margin)
     text-align: right;
+
+    @media screen and (min-width: $breakpoint-medium) {
+      margin-top: 8.5 * $sp-unit; // align with snap name baseline
+    }
+
+    button:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .p-view-store-button,


### PR DESCRIPTION
Fixes #753 

### QA

- go to any snap details page
- there should be no big spacing between snap name and publisher
- buttons should be aligned with snap name
- it should look nice on all screen sizes

<img width="1060" alt="screen shot 2018-06-20 at 15 53 28" src="https://user-images.githubusercontent.com/83575/41662769-1b6e5890-74a2-11e8-895d-7e0e9dfb6582.png">
