### PR TITLE
Typo fix (s/Amazons/Amazon)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
         <img src="https://assets.ubuntu.com/v1/2133a97d-heroku-logo+copy.svg" alt="Heroku" />
       </span>
       <span class="p-logo-list__item u-align--center">
-        <img src="https://assets.ubuntu.com/v1/7371f63d-Amazon.com-Logo+Copy.svg" alt="Amazons" />
+        <img src="https://assets.ubuntu.com/v1/7371f63d-Amazon.com-Logo+Copy.svg" alt="Amazon" />
       </span>
       <span class="p-logo-list__item u-align--center">
         <img src="https://assets.ubuntu.com/v1/e44026ff-Spotify_Logo_RGB_Green+Copy.svg" alt="Spotify" />


### PR DESCRIPTION
Small typo fix in Amazon logo alt attribute.