### PR TITLE
Fix key-value table borders

### DIFF
--- a/static/sass/_patterns_table-key-value.scss
+++ b/static/sass/_patterns_table-key-value.scss
@@ -1,22 +1,16 @@
 @mixin vf-p-table-key-value {
   .p-table-key-value {
-    th,
-    td {
-      padding: $sp-x-small $sp-small;
-    }
 
     th {
       color: $color-mid-dark;
       font-weight: 300;
+      padding-right: $sph-intra; // workaround for https://github.com/vanilla-framework/vanilla-framework/issues/1883
       text-align: right;
     }
 
-    tr {
-      border-bottom-style: dotted;
+    tbody tr:not(:first-child) {
+      border-top-style: dotted;
     }
 
-    tr:last-child {
-      border-bottom: 0;
-    }
   }
 }


### PR DESCRIPTION
Updates table styles, so there are no oversized borders.

Fixes #755 

### QA
- go to any snap detail page
- snap data table should have light dotted borders

<img width="1069" alt="screen shot 2018-06-21 at 10 59 26" src="https://user-images.githubusercontent.com/83575/41708979-59eb5492-7542-11e8-8866-b9360acacfbb.png">
