### PR TITLE
Fix spacing of install/channels overlay

### DIFF
--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -58,7 +58,7 @@
 
   .p-view-store-button,
   .p-cli-install {
-    margin-top: $sp-x-small;
+    margin-bottom: $input-margin-bottom;
   }
 
   .p-channel-map {
@@ -68,12 +68,12 @@
     position: absolute;
     right: 0;
     top: 0;
-    transform: translateY(57px); // just under the header (mobile)
+    transform: translateY(48px); // just under the header (mobile)
     transition: transform 500ms;
     z-index: 10;
 
-    @media screen and (min-width: $breakpoint-medium) {
-      transform: translateY(48px); // just under the header (desktop)
+    label {
+      margin-bottom: $spv-inter--condensed + $spv-nudge-compensation;
     }
 
     &.is-closed {
@@ -93,7 +93,7 @@
       }
 
       &--heading {
-        padding-bottom: $sp-small;
+        padding-bottom: 0;
         padding-top: 0;
 
         @media screen and (max-width: $breakpoint-medium) {
@@ -113,18 +113,8 @@
       padding-top: $sp-x-small;
     }
 
-    .p-tabs {
-      background: transparent; // remove default white background
-      border-bottom: 1px solid $color-mid-light;
-      position: relative; // for close button;
-
-      &::before {
-        display: none; // hide mobile arror thingy
-      }
-
-      .p-tabs__list {
-        padding: 0; // remove left padding
-      }
+    .p-tabs::before {
+      display: none; // hide mobile arror thingy
     }
 
     &__hide {
@@ -164,11 +154,6 @@
     .is-closed + & {
       opacity: 0;
     }
-  }
-
-  // because of Vanilla `* + *` top margin
-  .p-tooltip__message {
-    margin: 0;
   }
 
   // positioning fixes for track tooltip

--- a/templates/snap-details/_channel_map.html
+++ b/templates/snap-details/_channel_map.html
@@ -16,12 +16,12 @@
   </div>
   <div class="row p-channel-map__tab is-open" id="channel-map-tab-install">
     <div class="col-5">
-      <p>Ubuntu 16.04 or later?</p>
+      <label>Ubuntu 16.04 or later?</label>
       <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
       <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
     </div>
     <div class="col-5">
-      <p>Install with snapd</p>
+      <label>Install with snapd</label>
       <div class="p-code-snippet p-cli-install">
         <input
           class="p-code-snippet__input"
@@ -69,13 +69,15 @@ where you can install and get updates from.</span>
 
       <div class="p-channel-map__row p-channel-map__row--heading">
         <div class="col-8">
-          Command line install
-          <span class="p-tooltip p-tooltip--btm-center" aria-describedby="tooltip-channel">
-            <i class="p-icon--information"></i>
-            <span class="p-tooltip__message" role="tooltip" id="tooltip-channel">Install this application from ‘channels’ of varying stability.
+          <label>
+            Command line install
+            <span class="p-tooltip p-tooltip--btm-center" aria-describedby="tooltip-channel">
+              <i class="p-icon--information"></i>
+              <span class="p-tooltip__message" role="tooltip" id="tooltip-channel">Install this application from ‘channels’ of varying stability.
 For example, Edge is used for development and testing, whereas
 Stable is used for well tested and production ready versions.</span>
-          </span>
+            </span>
+          </label>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #756 

Updates spacing and removes unnecessary styles for channel map overlay.

### QA

- go to snap details page
- Click Install or All versions, check if channel map and install looks good

<img width="1043" alt="screen shot 2018-06-21 at 13 30 55" src="https://user-images.githubusercontent.com/83575/41716730-b26ad52e-7557-11e8-8235-60b3fb019575.png">
<img width="1042" alt="screen shot 2018-06-21 at 13 30 43" src="https://user-images.githubusercontent.com/83575/41716732-b288a81a-7557-11e8-9640-28361f1ad4e5.png">
