### PR TITLE
Fixes selected navigation styles (on mobile)

### DIFF
--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -4,34 +4,11 @@
 
   .p-navigation {
     z-index: 100; // appear over channel map
+
     // custom styles for dark header with hover
-    @media (min-width: $breakpoint-navigation-threshold + 1) {
-      .p-navigation__link {
-        & > a:hover,
-        .p-contextual-menu__toggle:hover,
-        .is-selected {
-          background: $navigation-hover-color;
-        }
-      }
-
-      .p-navigation__links,
-      .p-navigation__links:last-of-type { // fighting vanilla specificity
-        border-right: 1px solid $navigation-border-color;
-
-        .p-navigation__link {
-          border-left: 1px solid $navigation-border-color;
-        }
-
-        // fix for hover styles
-        .p-navigation__link:hover {
-          background: transparent;
-        }
-      }
-    }
-
-    @media (max-width: $breakpoint-navigation-threshold) {
-      .p-navigation__link .is-selected {
-        background: $color-light;
+    .p-navigation__link {
+      .is-selected {
+        background: $navigation-hover-color;
       }
     }
 

--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -5,6 +5,11 @@
   .p-navigation {
     z-index: 100; // appear over channel map
 
+    // FIXME: workaround for https://github.com/vanilla-framework/vanilla-framework/issues/1892
+    .p-navigation__banner {
+      flex-basis: auto;
+    }
+
     // custom styles for dark header with hover
     .p-navigation__link {
       .is-selected {

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -41,7 +41,7 @@
                 aria-controls="account-menu" aria-expanded="false">
                 {{ user_name }} <i class="p-icon--chevron"></i>
               </a>
-              <ul class="p-dropdown__menu u-hide" id="account-menu" aria-hidden="true">
+              <ul class="p-dropdown__menu" id="account-menu" aria-hidden="true">
                   <li class="p-navigation__link" role="menuitem">
                     <a href="/account/snaps">My published snaps</a>
                   </li>


### PR DESCRIPTION
We had some custom navigation styling that broke (for mobile) after Vanilla 1.7 update. This PR removes unnecessary styling to fix the issue.

### QA

- go to store page
- make sure Store is selected in navigation
- make screen small (so navigation turns into dropdown menu)
- make sure Store is still correctly selected

<img width="645" alt="screen shot 2018-06-21 at 13 52 40" src="https://user-images.githubusercontent.com/83575/41717644-ab312364-755a-11e8-9349-b15e4df4efc0.png">
