### PR TITLE
Workaround for incorrect img alignment

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -43,6 +43,11 @@ $color-navigation-background: #252525;
 @include vf-u-image-position;
 @include vf-u-equal-height;
 
+// FIXME: workaround for https://github.com/vanilla-framework/vanilla-framework/issues/1880
+img {
+  align-self: initial;
+}
+
 @import 'base_image-grid';
 @include base-image-grid;
 


### PR DESCRIPTION
Fixes #757

Workaround for vanilla bug - making sure img can be vertically centered with flexbox.

### QA

- go to snap details page or listing page
- open screenshot in lightbox
- screenshot should be vertically centered