### PR TITLE
Workaround for vanilla media object bug in search results

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -51,7 +51,8 @@
               {% endif %}
 
               <div class="p-media-object__details">
-                <h3 class="p-media-object__title">
+                {# FIXME u-no-margin is a workaround for https://github.com/vanilla-framework/vanilla-framework/issues/1879 #}
+                <h3 class="p-media-object__title u-no-margin">
                   <a href="/{{ snap.package_name }}">{{ snap.title }}</a>
                 </h3>
                 <ul class="p-media-object__meta-list u-no-margin">


### PR DESCRIPTION
Fixes #752

Removes margin from heading in search result to workaround vanilla spacing issue in media object.

### QA

- go to search results
- there should be no big spacing between snap name and publisher

<img width="892" alt="screen shot 2018-06-22 at 12 49 35" src="https://user-images.githubusercontent.com/83575/41773289-d9558ae8-761b-11e8-9921-f314763fa2b9.png">
