### PR TITLE
Adds some spacing to metrics page

### DIFF
--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -51,6 +51,8 @@ Publisher metrics for {{ snap_title }}
         </div>
         <div id="active_devices" class="snapcraft-metrics__graph snapcraft-metrics__active-devices"></div>
       </div>
+    </section>
+    <section class="p-strip is-shallow{% if nodata %} is-empty{% endif %}">
       <div class="row">
         <div class="u-clearfix">
           <h1 class="u-float--left p-heading--four">Territories</h1>


### PR DESCRIPTION
Fixes #798 

Adds strip section around each chart for better spacing.

###

- go to metrics page
- there should be reasonable space between the charts

<img width="1048" alt="screen shot 2018-06-22 at 13 36 45" src="https://user-images.githubusercontent.com/83575/41774757-58676a54-7621-11e8-8ace-3a9ab224f820.png">
