### PR TITLE
Remove unnecessary padding from screenshot wrapper

### DIFF
--- a/static/sass/_snapcraft_market_screenshots.scss
+++ b/static/sass/_snapcraft_market_screenshots.scss
@@ -22,6 +22,7 @@
   }
 
   .p-screenshot {
+    padding: 0;
     position: relative;
 
     &.is-selected {


### PR DESCRIPTION
Fixes #764 

### QA

- go to snap market page (with screenshots)
- hover over screenshot - checkbox should be evenly aligned in the corner
- click to select - there should be no unnecessary top padding inside the border

<img width="1005" alt="screen shot 2018-06-22 at 14 17 02" src="https://user-images.githubusercontent.com/83575/41776229-33ddc470-7627-11e8-90c3-33f79b31c9f3.png">
