### PR TITLE
Remove travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: required
-
-services:
-  - docker
-
-script:
-  - ./run test


### PR DESCRIPTION
# Summary

All the tests/lints are made with CircleCI, so I can remove `.travis.yaml`

# QA

Make sure the tests pass and travis is not running anymore