### PR TITLE
Run script Yarn permissions

### DIFF
--- a/run
+++ b/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.0"
+dev_image="canonicalwebteam/dev:v1.6.1"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi


### PR DESCRIPTION
This is to fix a yarn permissions error on some usage of the run script.
It updates how CircleCI can mount .ssh folders.

## QA

./run should work as usual.

The tests in this PR should pass!