### PR TITLE
Raise exception if `WEBAPP` is not defined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ defaults: &defaults
     - image: canonicalwebteam/dev
   environment:
     BLOG_ENABLED: True
+    WEBAPP: snapcraft
   working_directory: ~/project
 
 version: 2

--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ SECRET_KEY=local_development_fake_key
 ENVIRONMENT=devel
 DEVEL=True
 BLOG_ENABLED=true
+WEBAPP=snapcraft

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,6 +1,10 @@
 import os
 
 
+class ConfigurationError(Exception):
+    pass
+
+
 SECRET_KEY = os.getenv('SECRET_KEY')
 
 LOGIN_URL = os.getenv(
@@ -23,5 +27,8 @@ SENTRY_CONFIG = {
     'environment': ENVIRONMENT
 }
 
-WEBAPP = os.getenv('WEBAPP', 'snapcraft')
+WEBAPP = os.getenv('WEBAPP')
+if not WEBAPP:
+    raise ConfigurationError("`WEBAPP` is not configured")
+
 WEBAPP_EXTRA_HEADERS = {}


### PR DESCRIPTION
`WEBAPP` is a required configuration variable and should always be set.
We should avoid defaulting it to a value as it could result in a
misconfigured application. This change should not affect ./run script
and we already require this in the Dockerfile.

Any thoughts or disagreements on this?


## QA

No changes should be apparent in `./run`
Site should return error about WEBAPP if run with `./run --env WEBAPP=''`