### PR TITLE
Add revision history endpoint

### DIFF
--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -1,0 +1,9 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block meta_title %}
+Release history for {{ snap_title }}
+{% endblock %}
+
+{% block content %}
+{{ revision_history }}
+{% endblock %}

--- a/tests/tests_revision.py
+++ b/tests/tests_revision.py
@@ -1,0 +1,95 @@
+import responses
+
+from tests.endpoint_testing import BaseTestCases
+
+
+class RevisionHistoryPageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = '/account/snaps/{}/release'.format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url)
+
+
+class GetRevisionGetInfoPage(
+        BaseTestCases.EndpointLoggedInErrorHandling):
+    def setUp(self):
+        snap_name = "test-snap"
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = api_url.format(
+            snap_name
+        )
+        endpoint_url = '/account/snaps/{}/release'.format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url,
+            method_endpoint='GET',
+            api_url=api_url,
+            method_api='GET'
+        )
+
+
+class GetRevisionHistory(
+        BaseTestCases.EndpointLoggedInErrorHandling):
+
+    def setUp(self):
+        snap_name = "test-snap"
+
+        self.snap_id = 'complexId'
+        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        self.info_url = info_url.format(
+            snap_name
+        )
+
+        payload = {
+            'snap_id': 'id',
+            'title': 'Test Snap'
+        }
+
+        responses.add(
+            responses.GET, self.info_url,
+            json=payload, status=200)
+
+        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/id/history'
+        endpoint_url = '/account/snaps/{}/release'.format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url,
+            api_url=api_url,
+            method_endpoint='GET',
+            method_api='GET'
+        )
+
+    @responses.activate
+    def test_get_revision(self):
+        responses.add(
+            responses.GET, self.api_url,
+            json=[], status=200)
+
+        response = self.client.get(
+            self.endpoint_url,
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.info_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+        called = responses.calls[1]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used('publisher/release-history.html')
+        self.assert_context('snap_name', self.snap_name)
+        self.assert_context('revision_history', [])

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -55,6 +55,11 @@ REGISTER_NAME_URL = ''.join([
     'register-name/'
 ])
 
+REVISION_HISTORY_URL = ''.join([
+    DASHBOARD_API,
+    'snaps/{snap_id}/history'
+])
+
 
 def process_response(response):
     try:
@@ -280,3 +285,15 @@ def snap_screenshots(snap_id, session, data=None, files=None):
         raise MacaroonRefreshRequired
 
     return process_response(screenshot_response)
+
+
+def snap_revision_history(session, snap_id):
+    response = cache.get(
+        REVISION_HISTORY_URL.format(snap_id=snap_id),
+        headers=get_authorization_header(session)
+    )
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired
+
+    return process_response(response)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -392,3 +392,32 @@ def post_listing_snap(snap_name):
 
     return flask.redirect(
         flask.url_for('.get_listing_snap', snap_name=snap_name))
+
+
+@publisher_snaps.route('/<snap_name>/release')
+@login_required
+def get_release_history(snap_name):
+    snap_id = ''
+    try:
+        snap_id = api.get_snap_id(snap_name, flask.session)
+    except ApiResponseErrorList as api_response_error_list:
+        return _handle_error_list(api_response_error_list.errors)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    try:
+        revision_history = api.snap_revision_history(flask.session, snap_id)
+    except ApiResponseErrorList as api_response_error_list:
+        return _handle_error_list(api_response_error_list.errors)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    context = {
+        'snap_name': snap_name,
+        'revision_history': revision_history
+    }
+
+    return flask.render_template(
+        'publisher/release-history.html',
+        **context
+    )


### PR DESCRIPTION
# Summary

Add release endpoint, which diplays the release history

# QA

- `./run`
- http://127.0.0.1:8004/account/snaps/toto/release