### PR TITLE
 Update the requests timeout for initial connection and total time 

### DIFF
--- a/webapp/api/requests.py
+++ b/webapp/api/requests.py
@@ -47,9 +47,7 @@ class BaseSession():
 
     Create an interface to manage exceptions and return API exceptions
     """
-    def __init__(self, *args, **kwargs):
-        timeout = 3
-
+    def __init__(self, timeout=(0.5, 3), *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.mount("http://", TimeoutHTTPAdapter(timeout=timeout))


### PR DESCRIPTION
This PR is built on top of #811 

---

When we are experiencing API failures we have load times longer than we would like. In testing this can be greatly improved by setting two timeouts as detailed in the [requests documentation](http://docs.python-requests.org/en/master/user/advanced/#timeouts)

This splits the timouts into:
 - Connection timeout
 - Read timeout

By setting a lower connection timeout, we can fail fast when the API server is completely unavailable and unresponsive. The read timeout then can be more flexible to allow a slow response to take place when needed.

## QA

To disable internet to test, you can turn your internet off or you can modify the `webapp/api/public.py` file. If you change the URL on line 11 to `'https://google.com:81',` all the API traffic will time out.

 - `./run` and try the site in general, it should all work well.
 - Disable the internet and the site should fail a lot faster.

You can set the connection timeout to be a lot lower (but that you can still connect) and see that the whole request (which takes longer than the connection limit) still works