### PR TITLE
Fix url_for call for measure redirection

### DIFF
--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -85,7 +85,7 @@ def get_account_snaps():
 def get_measure_snap(snap_name):
     return flask.redirect(
         flask.url_for(
-            '.publisher_snap_metrics', snap_name))
+            '.publisher_snap_metrics', snap_name=snap_name))
 
 
 @publisher_snaps.route('/<snap_name>/metrics')


### PR DESCRIPTION
# Summary

The redirection from measure to metrics uses `url_for` and was not used well.
The first argument should be the redirection to have, the other arguments should be the function arguments and should be named (`snap_name=snap_name`)

# QA

- `./run`
- http://127.0.0.1:8004/account/snaps/toto/measure
- Should redirect to http://127.0.0.1:8004account/snaps/toto/metrics withour error