### PR TITLE
Standarise ubuntu versions in store listing and metrics pages

### DIFF
--- a/static/js/publisher/metrics/tooltips.js
+++ b/static/js/publisher/metrics/tooltips.js
@@ -6,12 +6,16 @@ function commaNumber(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
+function standariseOSName(os) {
+  return os.replace('/',' ');
+}
+
 function generateSeriesMarkup(point, color, highlight) {
   let series = [];
   color = color || 'transparent';
   let extraClass = highlight === point.name ? ' is-hovered' : '';
   series.push(`<span class="snapcraft-graph-tooltip__series${extraClass}" title="${point.name}">`);
-  series.push(`<span class="snapcraft-graph-tooltip__series-name">${point.name}</span>`);
+  series.push(`<span class="snapcraft-graph-tooltip__series-name">${standariseOSName(point.name)}</span>`);
   series.push(`<span class="snapcraft-graph-tooltip__series-color" style="background:${color};"></span>`);
   series.push(`<span class="snapcraft-graph-tooltip__series-value">${commaNumber(point.value)}</span>`);
   series.push('</span>');


### PR DESCRIPTION
Right now we displayed Ubuntu OS versions differently on:

- Public listing page: Where we refer them like 'Ubuntu 18.04'
- Metrics page: Where we refer them as 'Ubuntu/18.04'

This pull request suggests to refer them as on the public listing page using a space instead of /.