### PR TITLE
Add some styles for brand-store header

### DIFF
--- a/static/sass/_snapcraft_p-navigation.scss
+++ b/static/sass/_snapcraft_p-navigation.scss
@@ -1,6 +1,6 @@
 @mixin snapcraft-p-navigation {
-  $navigation-border-color: lighten($color-navigation-background, 20%);
-  $navigation-hover-color: darken($color-navigation-background, 8%); // from #252525 to #111
+  $navigation-border-color: rgba(255, 255, 255, .2);
+  $navigation-hover-color: rgba(0, 0, 0, .08);
 
   .p-navigation {
     z-index: 100; // appear over channel map

--- a/templates/_header-brandstore.html
+++ b/templates/_header-brandstore.html
@@ -1,9 +1,16 @@
-<header id="navigation" class="p-navigation">
+<header id="navigation" class="p-navigation"
+  {% if webapp_config['STORE_BRAND'] and webapp_config['STORE_BRAND']['COLOUR'] %}
+    style="background: {{ webapp_config['STORE_BRAND']['COLOUR'] }}"
+  {% endif %}>
   <div class="row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-              {{ webapp_config['STORE_NAME'] }}
+          {% if webapp_config['STORE_BRAND'] and webapp_config['STORE_BRAND']['LOGO'] %}
+            <img class="p-navigation__image" src="{{ webapp_config['STORE_BRAND']['LOGO'] }}" alt="{{ webapp_config['STORE_NAME'] }}" />
+          {% else %}
+            {{ webapp_config['STORE_NAME'] }}
+          {% endif %}
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/webapp/configs/lime.py
+++ b/webapp/configs/lime.py
@@ -1,4 +1,9 @@
 WEBAPP_CONFIG = {
     'LAYOUT': '_layout-brandstore.html',
-    'STORE_NAME': 'Limestore'
+    'STORE_NAME': 'Limestore',
+    'STORE_BRAND': {
+        'LOGO': None,
+        'COLOUR': None
+    },
+    'STORE_QUERY': 'LimeNET'
 }


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/841

- Added some config for styles
- Implement the style in the navigation
- Updated navigation hover to be transparency based

# QA

- Pull the branch
- Change `.env` `WEBAPP=snapcraft` to `WEBAPP=lime`
- Update `webapp/configs/lime.py` add a URL to `STORE_BRAND LOGO` and a colour to `STORE_BRAND COLOUR`
- `./run`
- Visit http://0.0.0.0:8004
- The header should have the image you set as the logo and the header background colour you set