### PR TITLE
Improved homepage logos

### DIFF
--- a/static/sass/_patterns_logo-list.scss
+++ b/static/sass/_patterns_logo-list.scss
@@ -2,7 +2,7 @@
   .p-logo-list {
     @extend %image-grid;
     justify-content: space-around;
-    padding: $sp-medium 0;
+    padding: 0;
 
     &__item {
       align-items: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,19 +20,19 @@
   <div class="row">
     <div class="p-logo-list no-border">
       <span class="p-logo-list__item u-align--center">
-        <img src="https://assets.ubuntu.com/v1/2133a97d-heroku-logo+copy.svg" alt="Heroku" />
+        <img src="https://assets.ubuntu.com/v1/a3c41e00-logo-heroku--snapcraft-homepage.svg" alt="Heroku" />
       </span>
       <span class="p-logo-list__item u-align--center">
-        <img src="https://assets.ubuntu.com/v1/7371f63d-Amazon.com-Logo+Copy.svg" alt="Amazon" />
+        <img src="https://assets.ubuntu.com/v1/2c9fa6c0-logo-amazon--snapcraft-homepage.svg" alt="Amazon" />
       </span>
       <span class="p-logo-list__item u-align--center">
-        <img src="https://assets.ubuntu.com/v1/e44026ff-Spotify_Logo_RGB_Green+Copy.svg" alt="Spotify" />
+        <img src="https://assets.ubuntu.com/v1/63d5fd3f-logo-spotify--snapcraft-homepage.svg" alt="Spotify" />
       </span>
       <span class="p-logo-list__item u-align--center">
-        <img src="https://assets.ubuntu.com/v1/79161103-Google_2015_logo+Copy.svg" alt="Google" />
+        <img src="https://assets.ubuntu.com/v1/2d54fa27-logo-google--snapcraft-homepage.svg" alt="Google" />
       </span>
       <span class="p-logo-list__item u-align--center">
-        <img src="https://assets.ubuntu.com/v1/b179abab-microsoft-logo+copy.svg" alt="Microsoft" />
+        <img src="https://assets.ubuntu.com/v1/7b03d4b8-logo-microsoft--snapcraft-homepage.svg" alt="Microsoft" />
       </span>
     </div>
   </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/831

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/
- Make sure the top publisher logos look correct