### PR TITLE
Updated copy for contact information on publisher listing page

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -297,7 +297,7 @@
                 </p>
               {% endif %}
               <p class="p-form-help-text">
-                Please include a valid http://, https:// or mailto: link
+                Please include a valid e-mail address, http://, https:// or mailto: link
               </p>
             </div>
           </div>


### PR DESCRIPTION
Fixes [#437](https://github.com/CanonicalLtd/snapcraft-design/issues/437)

## QA
1. Sign in into snapcraft.io
2. Open account listing from a snap you own
3. Scroll down to the contact information input field
4. Notice updated copy below the contact information to match the following screenshot:

![image](https://user-images.githubusercontent.com/8167677/42283728-418527ec-7fa2-11e8-9b21-340f3c6e8381.png)
