### PR TITLE
Corrects help text for snap listing contact field

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -297,7 +297,7 @@
                 </p>
               {% endif %}
               <p class="p-form-help-text">
-                Please include a valid http://, https:// or mailto: link
+                An http: or https: link, or an e-mail address
               </p>
             </div>
           </div>


### PR DESCRIPTION
Removes the implication that you need to include “mailto:” when entering an e-mail address. Fixes [snapcraft-design#437](https://github.com/CanonicalLtd/snapcraft-design/issues/437).

(Captions should normally be sentences ending in periods. I haven’t added a period here to be consistent with the other captions on the same page, but they should all be added at some point.)