### PR TITLE
Disables “Revert” button when non-functional

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -170,7 +170,7 @@ function initForm(config, initialState, errors) {
       if (isFormValid()) {
         enableSubmit();
       } else {
-        disablesubmit();
+        disableSubmit();
       }
     } else {
       disableRevert();

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -86,6 +86,14 @@ function initForm(config, initialState, errors) {
   const submitButton = marketForm.querySelector('.js-market-submit');
   const revertButton = marketForm.querySelector('.js-market-revert');
 
+  function disableRevert() {
+    revertButton.disabled = 'disabled';
+  }
+
+  function enableRevert() {
+    revertButton.disabled = false;
+  }
+
   function disableSubmit() {
     submitButton.disabled = 'disabled';
   }
@@ -94,7 +102,8 @@ function initForm(config, initialState, errors) {
     submitButton.disabled = false;
   }
 
-  // disable submit by default, it will be enabled on valid change
+  // commit buttons are disabled by default, as there’s nothing to revert/save
+  disableRevert();
   disableSubmit();
 
   let state = JSON.parse(JSON.stringify(initialState));
@@ -156,10 +165,15 @@ function initForm(config, initialState, errors) {
   function checkForm() {
     const diff = diffState(initialState, state);
 
-    if (diff && isFormValid()) {
-      enableSubmit();
+    if (diff) {
+      enableRevert();
+      if (isFormValid()) {
+        enableSubmit();
+      } else {
+        disablesubmit();
+      }
     } else {
-      disableSubmit();
+      disableRevert();
     }
   }
 


### PR DESCRIPTION
Disables the List page’s “Revert” button whenever there are no changes to revert. Fixes #517.