### PR TITLE
Tools logos min-width

### DIFF
--- a/static/sass/_patterns_logo-links.scss
+++ b/static/sass/_patterns_logo-links.scss
@@ -17,14 +17,15 @@
   }
 
   .p-logo-links {
-    align-items: flex-start;
+    align-items: center;
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: space-around;
 
     .p-logo-link {
       // by default (on mobile) use col-3 width (4 items in a row)
       width: 21.875%; // mobile-col-1
+      min-width: 150px;
 
       // on larger screens use col-2 width (6 items in a row)
       @media screen and (min-width: $breakpoint-small) {

--- a/static/sass/_patterns_logo-list.scss
+++ b/static/sass/_patterns_logo-list.scss
@@ -1,6 +1,7 @@
 @mixin p-logo-list {
   .p-logo-list {
     @extend %image-grid;
+    justify-content: space-around;
     padding: $sp-medium 0;
 
     &__item {
@@ -8,6 +9,7 @@
       display: flex;
       margin-top: 0;
       min-height: 60px;
+      min-width: 150px;
 
       // by default (on mobile) use col-3 width (4 items in a row)
       width: 21.875%; // mobile-col-1


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/775

# QA

- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004
- Resize the browser narrow and wide
- Logos shouldn't go below 150px width and wrap nicely