### PR TITLE
Add footer string variable to brand store

### DIFF
--- a/templates/_footer-brandstore.html
+++ b/templates/_footer-brandstore.html
@@ -1,0 +1,16 @@
+<footer class="p-footer p-strip--light p-sticky-footer">
+  <div class="row">
+    <div class="col-8">
+      <nav class="p-footer__nav">
+        <ul class="p-footer__links">
+          <li class="p-footer__item">
+            <a class="p-footer__link" href="#">Back to top<i class="p-icon--top"></i></a>
+          </li>
+        </ul>
+      </nav>
+      {% if webapp_config['FOOTER_TEXT'] %}
+        <p>{{ webapp_config['FOOTER_TEXT']|safe }}</p>
+      {% endif %}
+    </div>
+  </div>
+</footer>

--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -46,7 +46,7 @@
 
     {% block content %}{% endblock %}
 
-    {% include "_footer.html" %}
+    {% include "_footer-brandstore.html" %}
 
     {% block scripts_modules %}{% endblock %}
     <script src="{{ static_url('js/modules/raven.min.js') }}"></script>

--- a/webapp/configs/lime.py
+++ b/webapp/configs/lime.py
@@ -5,5 +5,6 @@ WEBAPP_CONFIG = {
         'LOGO': None,
         'COLOUR': None
     },
+    'FOOTER_TEXT': None,
     'STORE_QUERY': 'LimeNET'
 }


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/842

# QA

- Pull the branch
- Change `.env` `WEBAPP=snapcraft` to `WEBAPP=lime`
- Update `webapp/configs/lime.py` add some text to `FOOTER_TEXT` such as '&copy; 2018'
- `./run`
- Visit http://0.0.0.0:8004
- The footer should display the 'Back to top' link and the text you've defined