### PR TITLE
Update details to v2 of API

### DIFF
--- a/tests/tests_public_logic.py
+++ b/tests/tests_public_logic.py
@@ -15,16 +15,34 @@ class StoreLogicTest(unittest.TestCase):
     def test_one_track_channel_map(self):
         channel_maps_list = [
             {
-                'architecture': 'arch',
-                'map': [{'info': 'release'}],
-                'track': 'track'
+                'channel': {
+                    'name': 'channel',
+                    'architecture': 'arch',
+                    'track': 'track',
+                    'risk': 'risk'
+                },
+                'created-at': 'date',
+                'confinement': 'confinement',
+                'download': {
+                    'size': 'size'
+                },
+                'version': 'version'
             }
         ]
 
         result = logic.convert_channel_maps(channel_maps_list)
         expected_result = {
             'arch': {
-                'track': [{'info': 'release'}]
+                'track': [
+                    {
+                        'channel': 'channel',
+                        'created-at': 'date',
+                        'confinement': 'confinement',
+                        'size': 'size',
+                        'risk': 'risk',
+                        'version': 'version'
+                    }
+                ]
             }
         }
 
@@ -33,22 +51,57 @@ class StoreLogicTest(unittest.TestCase):
     def test_multiple_track_same_arch_channel_map(self):
         channel_maps_list = [
             {
-                'architecture': 'arch',
-                'map': [{'info': 'release'}],
-                'track': 'track'
+                'channel': {
+                    'name': 'channel',
+                    'architecture': 'arch',
+                    'track': 'track',
+                    'risk': 'risk'
+                },
+                'created-at': 'date',
+                'confinement': 'confinement',
+                'download': {
+                    'size': 'size'
+                },
+                'version': 'version'
             },
             {
-                'architecture': 'arch',
-                'map': [{'info': 'release'}],
-                'track': 'track1'
+                'channel': {
+                    'name': 'channel',
+                    'architecture': 'arch',
+                    'track': 'track1',
+                    'risk': 'risk'
+                },
+                'created-at': 'date',
+                'confinement': 'confinement',
+                'download': {
+                    'size': 'size'
+                },
+                'version': 'version'
             }
         ]
-
         result = logic.convert_channel_maps(channel_maps_list)
         expected_result = {
             'arch': {
-                'track': [{'info': 'release'}],
-                'track1': [{'info': 'release'}]
+                'track': [
+                    {
+                        'channel': 'channel',
+                        'created-at': 'date',
+                        'confinement': 'confinement',
+                        'size': 'size',
+                        'risk': 'risk',
+                        'version': 'version'
+                    }
+                ],
+                'track1': [
+                    {
+                        'channel': 'channel',
+                        'created-at': 'date',
+                        'confinement': 'confinement',
+                        'size': 'size',
+                        'risk': 'risk',
+                        'version': 'version'
+                    }
+                ]
             }
         }
 
@@ -57,24 +110,60 @@ class StoreLogicTest(unittest.TestCase):
     def test_multiple_track_different_arch_channel_map(self):
         channel_maps_list = [
             {
-                'architecture': 'arch',
-                'map': [{'info': 'release'}],
-                'track': 'track'
+                'channel': {
+                    'name': 'channel',
+                    'architecture': 'arch',
+                    'track': 'track',
+                    'risk': 'risk'
+                },
+                'created-at': 'date',
+                'confinement': 'confinement',
+                'download': {
+                    'size': 'size'
+                },
+                'version': 'version'
             },
             {
-                'architecture': 'arch1',
-                'map': [{'info': 'release'}],
-                'track': 'track'
+                'channel': {
+                    'name': 'channel',
+                    'architecture': 'arch1',
+                    'track': 'track',
+                    'risk': 'risk'
+                },
+                'created-at': 'date',
+                'confinement': 'confinement',
+                'download': {
+                    'size': 'size'
+                },
+                'version': 'version'
             }
         ]
 
         result = logic.convert_channel_maps(channel_maps_list)
         expected_result = {
             'arch': {
-                'track': [{'info': 'release'}],
+                'track': [
+                    {
+                        'channel': 'channel',
+                        'created-at': 'date',
+                        'confinement': 'confinement',
+                        'size': 'size',
+                        'risk': 'risk',
+                        'version': 'version'
+                    }
+                ]
             },
             'arch1': {
-                'track': [{'info': 'release'}],
+                'track': [
+                    {
+                        'channel': 'channel',
+                        'created-at': 'date',
+                        'confinement': 'confinement',
+                        'size': 'size',
+                        'risk': 'risk',
+                        'version': 'version'
+                    }
+                ]
             }
         }
 

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -11,16 +11,16 @@ SNAPCRAFT_IO_API = os.getenv(
     'https://api.snapcraft.io/api/v1/',
 )
 
-SNAP_DETAILS_URL = ''.join([
-    SNAPCRAFT_IO_API,
-    'snaps/details/{snap_name}',
-    '?channel={snap_channel}',
-    '&fields=snap_id,package_name,title,summary,description,license,contact,',
-    'website,publisher,prices,media,',
-    # Released (stable) revision fields will eventually be replaced by
-    # `channel_maps_list` contextual information.
-    'revision,version,binary_filesize,last_updated,',
-    'developer_validation,channel_maps_list'
+SNAPCRAFT_IO_API_V2 = os.getenv(
+    'SNAPCRAFT_IO_API_V2',
+    'https://api.snapcraft.io/v2/'
+)
+
+SNAP_INFO_URL = ''.join([
+    SNAPCRAFT_IO_API_V2,
+    'snaps/info/{snap_name}',
+    '?fields=title,summary,description,license,contact,website,publisher,',
+    'prices,media,download,version,created-at,confinement',
 ])
 
 SNAP_METRICS_URL = ''.join([
@@ -60,10 +60,12 @@ CATEGORIES_URL = ''.join([
 
 class StoreApi:
     headers = {'X-Ubuntu-Series': '16'}
+    headers_v2 = {'Snap-Device-Series': '16'}
 
     def __init__(self, store=None):
         if store:
             self.headers.update({'X-Ubuntu-Store': store})
+            self.headers_v2.update({'X-Ubuntu-Store': store})
 
     def process_response(self, response):
         try:
@@ -123,14 +125,11 @@ class StoreApi:
 
         return self.process_response(searched_response)
 
-    def get_snap_details(self, snap_name, snap_channel):
-        details_headers = self.headers.copy()
-        details_headers.update({'X-Ubuntu-Architecture': 'any'})
+    def get_snap_details(self, snap_name):
         details_response = cache.get(
-            SNAP_DETAILS_URL.format(
-                snap_name=snap_name,
-                snap_channel=snap_channel),
-            headers=self.headers
+            SNAP_INFO_URL.format(
+                snap_name=snap_name),
+            headers=self.headers_v2
         )
 
         return self.process_response(details_response)

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -1,4 +1,5 @@
 import bleach
+import dateutil
 import re
 from urllib.parse import parse_qs, urlparse
 
@@ -141,7 +142,7 @@ def split_description_into_paragraphs(unformatted_description):
     return formatted_paragraphs
 
 
-def convert_channel_maps(channel_maps_list):
+def convert_channel_maps(channel_map):
     """Converts channel maps list to format easier to manipulate
 
     Example:
@@ -167,33 +168,26 @@ def convert_channel_maps(channel_maps_list):
 
     :returns: The channel maps reshaped
     """
-    channel_maps = {}
-    for channel_map in channel_maps_list:
-        arch = channel_map.get('architecture')
-        track = channel_map.get('track')
-        if arch not in channel_maps:
-            channel_maps[arch] = {}
-        channel_maps[arch][track] = []
+    channel_map_restruct = {}
+    for channel in channel_map:
+        arch = channel.get('channel').get('architecture')
+        track = channel.get('channel').get('track')
+        if arch not in channel_map_restruct:
+            channel_map_restruct[arch] = {}
+        if track not in channel_map_restruct[arch]:
+            channel_map_restruct[arch][track] = []
 
-        for channel in channel_map['map']:
-            if channel.get('info'):
-                channel_maps[arch][track].append(channel)
+        info = {
+            'created-at': channel.get('created-at'),
+            'version': channel.get('version'),
+            'channel': channel.get('channel').get('name'),
+            'risk': channel.get('channel').get('risk'),
+            'confinement': channel.get('confinement'),
+            'size': channel.get('download').get('size')
+        }
+        channel_map_restruct[arch][track].append(info)
 
-    return channel_maps
-
-
-def get_default_channel(snap_name):
-    """Get's the default channel of 'stable' unless the snap_name is node.
-
-    This is a temporary* hack to get around nodejs not using 'latest'
-    as their default.
-
-    * depending on snapd and store work (not in the 18.10 cycle)
-    """
-    if snap_name == 'node':
-        return '10/stable'
-
-    return 'stable'
+    return channel_map_restruct
 
 
 def get_categories(categories_json):
@@ -216,3 +210,27 @@ def get_categories(categories_json):
         })
 
     return categories
+
+
+def get_last_udpated_version(channel_map):
+    """Get the oldest channel that was created
+
+    :param channel_map: List of a specific track
+
+    :returns: The oldest created channel
+    """
+    newest_channel = None
+    for latest in channel_map:
+        if not newest_channel:
+            newest_channel = latest
+            parsed_creation_date = dateutil.parser.parse(
+                newest_channel['created-at'])
+        else:
+            parsed_actual_creation_date = dateutil.parser.parse(
+                latest['created-at'])
+            if parsed_creation_date > parsed_actual_creation_date:
+                newest_channel = latest
+                parsed_creation_date = dateutil.parser.parse(
+                    newest_channel['created-at'])
+
+    return newest_channel


### PR DESCRIPTION
# Summary

Fixes #737 
- Update details endpoint with version 2 of API
- Now that we don't have anymore the `last_updated` field I have to guess which one is the latest one: in the track latest I grab the oldest created snap, which seems that usually is the stable one

# QA

- `./run`
- http://127.0.0.1:8004/firefox
- http://127.0.0.1:8004/node
- http://127.0.0.1:8004/spotify
- http://127.0.0.1:8004/toto
- Make sure the informations in the fields are ok
- Make sure the version displayed on the array next to the description is the last one (the oldest of its channel)
