### PR TITLE
Make details endpoint case insensitive

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -306,6 +306,11 @@ def store_blueprint(store=None):
             **context
         ), status_code
 
+    @store.route('/<regex("[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*"):snap_name>')
+    def snap_details_case_sensitive(snap_name):
+        return flask.redirect(
+            flask.url_for('.snap_details', snap_name=snap_name.lower()))
+
     @store.route('/store/categories/<category>')
     def store_category(category):
         status_code = 200


### PR DESCRIPTION
# Summary

Fixes #614
- Make Details endpoint case insensitive
- When accessing details endpoint with a Uppercase in the snap name, you should be redirect to the details endpoint with lower case snap name

# QA

- `./run`
- http://127.0.0.1:8004/firEfox
- http://127.0.0.1:8004/Firefox
- http://127.0.0.1:8004/FirefoX
- Should redirect to: - http://127.0.0.1:8004/firefox