### PR TITLE
Brand store page

### DIFF
--- a/templates/_header-brandstore.html
+++ b/templates/_header-brandstore.html
@@ -20,17 +20,6 @@
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
-      <ul class="p-navigation__links" role="menu">
-        <li class="p-navigation__link" role="menuitem">
-          <a
-            {% if page_slug == 'store' %}
-              class="is-selected"
-            {% endif %}
-            href="/store">
-            Store
-          </a>
-        </li>
-      </ul>
     </nav>
   </div>
 </header>

--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -25,20 +25,24 @@
   {% include 'partials/search-bar.html' %}
 
   <section class="p-strip is-shallow">
-    {% for category in categories %}
-      {% if loop.index > 1 %}
-        <div class="row">
-          <hr />
-        </div>
-      {% endif %}
-
-      <div class="row">
-        <h3><a href="/search?category={{ category.slug }}">{{ category.name }}&nbsp;&rsaquo;</a></h3>
+    <div class="row">
+      <div class="col-12 p-featured-snaps">
+        {% for snap in snaps %}
+          <a class="p-featured-snaps__item p-media-object" href="/{{ snap.package_name }}">
+            <span class="p-media-object__image">
+              {% if snap.icon_url %}
+                <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
+              {% else %}
+                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
+              {% endif %}
+            </span>
+            <span class="p-media-object__details">
+              <h4>{{ snap.title }}</h4>
+            </span>
+          </a>
+        {% endfor %}
       </div>
-      <div data-category="{{ category.slug }}" class="row js-store-category">
-        {# _category-partial.html loaded via JS #}
-      </div>
-    {% endfor %}
+    </div>
   </section>
 {% endblock %}
 

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -1,0 +1,26 @@
+<section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
+  <div class="row">
+    <form action="/search" class="p-form p-form--inline p-form--search">
+      {% if categories %}
+        <div class="p-form__group p-form__group--no-grow">
+          <label for="category-input" class="u-off-screen">Category</label>
+          <div class="p-form__control u-clearfix">
+            <select id="category-input" name="category" class="u-no-margin--bottom">
+              <option value="">All snaps</option>
+              {% for category in categories %}
+                <option value="{{ category.slug }}">{{ category.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      {% endif %}
+      <div class="p-form__group">
+        <label for="search-input" class="u-off-screen">Search</label>
+        <div class="p-form__control u-clearfix">
+          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" />
+        </div>
+      </div>
+      <button type="submit" alt="search" class="p-button--positive">Search</button>
+    </form>
+  </div>
+</section>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -88,27 +88,16 @@ def store_blueprint(store_query=None):
         status_code = 200
 
         try:
-            categories_results = api.get_categories()
+            snaps_results = api.get_all_snaps(size=12)
         except ApiError as api_error:
-            categories_results = []
+            snaps_results = []
             status_code, error_info = _handle_errors(api_error)
 
-        categories = logic.get_categories(categories_results)
-
-        try:
-            featured_snaps_results = api.get_featured_snaps()
-        except ApiError as api_error:
-            featured_snaps_results = []
-            status_code, error_info = _handle_errors(api_error)
-
-        featured_snaps = logic.get_searched_snaps(
-            featured_snaps_results
-        )
+        snaps = logic.get_searched_snaps(snaps_results)
 
         return flask.render_template(
-            'store/store.html',
-            featured_snaps=featured_snaps,
-            categories=categories,
+            'brand-store/store.html',
+            snaps=snaps,
             error_info=error_info
         ), status_code
 


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/843

- Added different template for brand store homepage
- Use the `get_all_snaps` method (with a limit) to display on the homepage

# QA

- Pull the brand
- Change `.env` `WEBAPP=lime`
- `./run`
- Visit http://0.0.0.0:8004/
- Make sure the lime snaps show and are cickable
- Stop the app
- Change `.env` `WEBAPP=snapcraft`
- `./run`
- Visit http://0.0.0.0:8004/
- Make sure the snapcraft.io site works