### PR TITLE
Fix redirection to homage

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -47,12 +47,12 @@ def store_blueprint(store_query=None):
     @store.route('/snaps')
     def snaps_view():
         return flask.redirect(
-            flask.url_for('.store_view'))
+            flask.url_for('.homepage'))
 
     @store.route('/discover')
     def discover():
         return flask.redirect(
-            flask.url_for('.store_view'))
+            flask.url_for('.homepage'))
 
     def store_view():
         error_info = {}
@@ -129,7 +129,7 @@ def store_blueprint(store_query=None):
 
         if not snap_searched and not snap_category:
             return flask.redirect(
-                flask.url_for('.store_view'))
+                flask.url_for('.homepage'))
 
         size = flask.request.args.get('limit', default=25, type=int)
         offset = flask.request.args.get('offset', default=0, type=int)


### PR DESCRIPTION
# Summary

- Since the custom url route for brandstore's homepage some redirects were broken. Now instead of using the function `url_for` with as argument the name of the function, I use it with the name of the endpoint. Which here are the same for the 2 custom routes.

# QA

- `./run`
```
store.discover                     GET      /discover
store.homepage                     GET      /
store.search_snap                  GET      /search
store.snaps_view                   GET      /snaps
```
- search should work with empty search
- Other endpoint should redirect properly
- Make the same tests on brand store
