### PR TITLE
Add entrypoint.sh for package.json and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN test -n "${WEBAPP}"
 ENV WEBAPP "${WEBAPP}"
 
 # Setup commands to run server
-ENTRYPOINT ["talisker.gunicorn", "webapp.app:create_app()", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["0.0.0.0:80"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+set -e
+
+talisker.gunicorn.gevent webapp.app:create_app\(\) --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind $1

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/d3-geo/build/d3-geo.min.js static/js/modules && cp node_modules/topojson-client/dist/topojson-client.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/moment/min/moment.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-transpile": "rollup -c",
-    "serve": "talisker.gunicorn.gevent webapp.app:create_app\\(\\) --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "./entrypoint.sh 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",


### PR DESCRIPTION
Update package.json and Dockerfile to use the same entrypoint for serving

## QA

Try to run locally and also build docker. They should work correctly and display gevent as the worker class.

`./run`

And also

- `docker build --build-arg COMMIT_ID=test --build-arg WEBAPP=snapcraft --tag test-sio .`
- `docker run --rm -p 80:80 -it -e SECRET_KEY=adsf test-sio`


Fixes #839 