### PR TITLE
Install instructions

### DIFF
--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -25,6 +25,18 @@
   {% include 'partials/search-bar.html' %}
 
   <section class="p-strip is-shallow">
+    {% if webapp_config['STORE_INSTALL_INSTRUCTIONS'] %}
+      <div class="row">
+        <h3>Installing apps</h3>
+        <p>To configure a snap enabled system to use {{ webapp_config['STORE_QUERY'] }}:</p>
+        <pre><code>sudo echo "UBUNTU_STORE_ID={{ webapp_config['STORE_QUERY'] }}" >> /etc/environment
+sudo service snapd restart</code></pre>
+      </div>
+      <div class="row">
+        <hr />
+      </div>
+    {% endif %}
+
     <div class="row">
       <div class="col-12 p-featured-snaps">
         {% for snap in snaps %}

--- a/webapp/configs/lime.py
+++ b/webapp/configs/lime.py
@@ -5,6 +5,7 @@ WEBAPP_CONFIG = {
         'LOGO': None,
         'COLOUR': None
     },
+    'STORE_INSTALL_INSTRUCTIONS': False,
     'FOOTER_TEXT': None,
     'STORE_QUERY': 'LimeNET'
 }


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/869

- Added config option `STORE_INSTALL_INSTRUCTIONS`
- Added section to `brand-store/store.html` template to show install instructions

# QA

- Pull the branch
- Change `.env` `WEBAPP=lime`
- Change `lime.py` `STORE_INSTALL_INSTRUCTIONS=True`
- `./run`
- Visit http://0.0.0.0:8004/
- See the instructions