### PR TITLE
Don't show install buttons for brand stores

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -65,14 +65,27 @@
           </div>
         </div>
       </div>
-      <div class="col-5 p-snap-install-buttons">
-        <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
-        <button class="p-button--neutral js-open-channel-map" aria-controls="channel-map-tab-versions">All versions</button>
-      </div>
+      {% if not webapp_config['STORE_QUERY'] %}
+        <div class="col-5 p-snap-install-buttons">
+          <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
+          <button class="p-button--neutral js-open-channel-map" aria-controls="channel-map-tab-versions">All versions</button>
+        </div>
+      {% else %}
+        <div class="col-5 p-snap-install-buttons">
+          <div class="p-code-snippet">
+            <input class="p-code-snippet__input" id="snap-install-stable" value="sudo snap install {{ package_name }}" readonly="readonly">
+            <button class="p-code-snippet__action js-clipboard-copy" data-clipboard-target="#snap-install-stable">
+              Copy to clipboard
+            </button>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 
-  {% include "store/snap-details/_channel_map.html" %}
+  {% if not webapp_config['STORE_QUERY'] %}
+    {% include "store/snap-details/_channel_map.html" %}
+  {% endif %}
 
   {% if screenshots %}
     <div class="p-strip is-shallow">
@@ -194,7 +207,7 @@
         }
       {% endif %}
 
-      {% if channel_map %}
+      {% if not webapp_config['STORE_QUERY'] and channel_map %}
         try {
           snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }});
         } catch(e) {


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/870

- Added if and else for brand-store to toggle display of the install button
- If brand store - show the CLI install instructions

# QA

- Pull the branch
- Change `.env` `WEBAPP=lime`
- `./run`
- Visit http://0.0.0.0:8004/limesuite
- Ensure there's not install button and you can copy and paste the CLI instructions