### PR TITLE
Surface non-stable snaps in search

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -126,8 +126,15 @@ function setArchitecture(arch, packageName, channelMapData) {
 function selectTab(tabEl, tabsWrapperEl) {
   const selected = tabEl.getAttribute('aria-selected');
   if (!selected) {
-    tabsWrapperEl.querySelector('.p-channel-map__tab.is-open').classList.remove('is-open');
-    tabsWrapperEl.querySelector('.p-tabs__link[aria-selected]').removeAttribute('aria-selected');
+    const selectedTabEle = tabsWrapperEl.querySelector('.p-channel-map__tab.is-open');
+    if (selectedTabEle) {
+      selectedTabEle.classList.remove('is-open');
+    }
+
+    const selectedTabLinkEle = tabsWrapperEl.querySelector('.p-tabs__link[aria-selected]');
+    if (selectedTabLinkEle) {
+      selectedTabLinkEle.removeAttribute('aria-selected');
+    }
 
     document.getElementById(tabEl.getAttribute('aria-controls')).classList.add('is-open');
     tabEl.setAttribute('aria-selected', "true");

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -67,7 +67,9 @@
       </div>
       {% if not webapp_config['STORE_QUERY'] %}
         <div class="col-5 p-snap-install-buttons">
-          <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
+          {% if has_stable %}
+            <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
+          {% endif %}
           <button class="p-button--neutral js-open-channel-map" aria-controls="channel-map-tab-versions">All versions</button>
         </div>
       {% else %}

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -3,9 +3,11 @@
     <div class="col-12">
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="#install" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-install" aria-selected="true">{{ snap_title }} {{ version }}</a>
-          </li>
+          {% if has_stable %}
+            <li class="p-tabs__item" role="presentation">
+              <a href="#install" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-install" aria-selected="true">{{ snap_title }} {{ version }}</a>
+            </li>
+          {% endif %}
           <li class="p-tabs__item" role="presentation">
             <a href="#versions" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-versions">All versions</a>
           </li>
@@ -14,32 +16,34 @@
       </nav>
     </div>
   </div>
-  <div class="row p-channel-map__tab is-open" id="channel-map-tab-install">
-    <div class="col-5">
-      <label>Ubuntu 16.04 or later?</label>
-      <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
-      <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
-    </div>
-    <div class="col-5">
-      <label>Install with snapd</label>
-      <div class="p-code-snippet p-cli-install">
-        <input
-          class="p-code-snippet__input"
-          id="snap-install"
-          value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
-          readonly="readonly"
-        />
-        <button
-          class="p-code-snippet__action js-clipboard-copy"
-          data-clipboard-target="#snap-install">
-          Copy to clipboard
-        </button>
+  {% if has_stable %}
+    <div class="row p-channel-map__tab is-open" id="channel-map-tab-install">
+      <div class="col-5">
+        <label>Ubuntu 16.04 or later?</label>
+        <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
+        <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
       </div>
-      <p class="p-form-help-text">
-        Don't have snapd? <a href="https://docs.snapcraft.io/core/install">Get set up for snaps</a>.
-      </p>
+      <div class="col-5">
+        <label>Install with snapd</label>
+        <div class="p-code-snippet p-cli-install">
+          <input
+            class="p-code-snippet__input"
+            id="snap-install"
+            value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
+            readonly="readonly"
+          />
+          <button
+            class="p-code-snippet__action js-clipboard-copy"
+            data-clipboard-target="#snap-install">
+            Copy to clipboard
+          </button>
+        </div>
+        <p class="p-form-help-text">
+          Don't have snapd? <a href="https://docs.snapcraft.io/core/install">Get set up for snaps</a>.
+        </p>
+      </div>
     </div>
-  </div>
+  {% endif %}
   <div class="row p-channel-map__tab" id="channel-map-tab-versions">
     <div class="col-3">
       <form>

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -31,7 +31,7 @@ SNAP_METRICS_URL = ''.join([
 SNAP_SEARCH_URL = ''.join([
     SNAPCRAFT_IO_API,
     'snaps/search',
-    '?q={snap_name}&page={page}&size={size}',
+    '?q={snap_name}&page={page}&size={size}&scope=wide',
     '&confinement=strict,classic',
     '&fields=package_name,title,summary,icon_url,publisher,',
     'developer_validation'

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -231,3 +231,20 @@ def get_last_udpated_version(channel_maps):
             break
 
     return newest_channel
+
+
+def has_stable(channel_maps_list):
+    """Use the channel map to find out if the snap has a stable release
+
+    :param channel_maps_list: Channel map list
+
+    :returns: True or False
+    """
+    if channel_maps_list:
+        for arch in channel_maps_list:
+            for track in channel_maps_list[arch]:
+                for release in channel_maps_list[arch][track]:
+                    if release['risk'] == 'stable':
+                        return True
+
+    return False

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -348,6 +348,7 @@ def store_blueprint(store_query=None):
             'summary': details['snap']['summary'],
             'description_paragraphs': formatted_paragraphs,
             'channel_map': channel_maps_list,
+            'has_stable': logic.has_stable(channel_maps_list),
             'developer_validation': details['snap']['publisher']['validation'],
 
             # Transformed API data


### PR DESCRIPTION
# Done

- Enables the `wide` `scope` on the search endpoint
- Hides the install button and associated overlay if there is not a stable version

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store
- Search for `hello-roadmr`
- You should get many more results than https://snapcraft.io/search?category=&q=hello-roadmr
- Click on `hello-roadmr-comm4`
- You should not have the install button in the header and clicking 'all versions' should only have 1 tab