### PR TITLE
Disabled revert button addition

### DIFF
--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -96,12 +96,10 @@ function initForm(config, initialState, errors) {
   }
 
   function disableRevert() {
-    console.log(revertURL);
     revertButton.setAttribute('href','javascript:void(0);');
     revertButton.classList.add('disabled');
   }
 
-  console.log(revertButton);
   function enableRevert() {
     revertButton.setAttribute('href',revertURL);
     revertButton.classList.remove('disabled');

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -85,6 +85,7 @@ function initForm(config, initialState, errors) {
   const marketForm = document.getElementById(config.form);
   const submitButton = marketForm.querySelector('.js-market-submit');
   const revertButton = marketForm.querySelector('.js-market-revert');
+  var revertURL = revertButton.getAttribute('href');
 
   function disableSubmit() {
     submitButton.disabled = 'disabled';
@@ -94,8 +95,21 @@ function initForm(config, initialState, errors) {
     submitButton.disabled = false;
   }
 
+  function disableRevert() {
+    console.log(revertURL);
+    revertButton.setAttribute('href','javascript:void(0);');
+    revertButton.classList.add('disabled');
+  }
+
+  console.log(revertButton);
+  function enableRevert() {
+    revertButton.setAttribute('href',revertURL);
+    revertButton.classList.remove('disabled');
+  }
+
   // disable submit by default, it will be enabled on valid change
   disableSubmit();
+  disableRevert();
 
   let state = JSON.parse(JSON.stringify(initialState));
 
@@ -156,10 +170,15 @@ function initForm(config, initialState, errors) {
   function checkForm() {
     const diff = diffState(initialState, state);
 
-    if (diff && isFormValid()) {
-      enableSubmit();
+    if (diff) {
+      enableRevert();
+      if (isFormValid()) {
+        enableSubmit(); 
+      } else {
+        disableSubmit();
+      }
     } else {
-      disableSubmit();
+      disableRevert();
     }
   }
 

--- a/static/js/publisher/market/market.js
+++ b/static/js/publisher/market/market.js
@@ -85,7 +85,8 @@ function initForm(config, initialState, errors) {
   const marketForm = document.getElementById(config.form);
   const submitButton = marketForm.querySelector('.js-market-submit');
   const revertButton = marketForm.querySelector('.js-market-revert');
-  var revertURL = revertButton.getAttribute('href');
+  const revertURL = revertButton.getAttribute('href');
+  const disabledRevertClass = 'is-disabled';
 
   function disableSubmit() {
     submitButton.disabled = 'disabled';
@@ -97,12 +98,12 @@ function initForm(config, initialState, errors) {
 
   function disableRevert() {
     revertButton.setAttribute('href','javascript:void(0);');
-    revertButton.classList.add('disabled');
+    revertButton.classList.add(disabledRevertClass);
   }
 
   function enableRevert() {
     revertButton.setAttribute('href',revertURL);
-    revertButton.classList.remove('disabled');
+    revertButton.classList.remove(disabledRevertClass);
   }
 
   // disable submit by default, it will be enabled on valid change

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -4,12 +4,13 @@
   .js-market-revert.disabled {
 
     cursor: not-allowed;
-    opacity: .5;    
+    opacity: .5;
 
     &:hover {
-      background-color:transparent;
+      background-color: transparent;
     }
   }
+
   .p-editable-icon {
     $white-overlay-color: rgba(255, 255, 255, .5);
     $black-overlay-color: rgba(0, 0, 0, .5);

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -1,5 +1,15 @@
 @mixin snapcraft-market {
 
+  // hack to make anchor link behave like a button
+  .js-market-revert.disabled {
+    cursor: not-allowed;
+    opacity: .5;
+    
+    &:hover {
+      background-color:transparent;
+    }
+  }
+  
   .p-editable-icon {
     $white-overlay-color: rgba(255, 255, 255, .5);
     $black-overlay-color: rgba(0, 0, 0, .5);

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -2,14 +2,14 @@
 
   // hack to make anchor link behave like a button
   .js-market-revert.disabled {
+
     cursor: not-allowed;
-    opacity: .5;
-    
+    opacity: .5;    
+
     &:hover {
       background-color:transparent;
     }
   }
-  
   .p-editable-icon {
     $white-overlay-color: rgba(255, 255, 255, .5);
     $black-overlay-color: rgba(0, 0, 0, .5);

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -1,7 +1,7 @@
 @mixin snapcraft-market {
 
   // hack to make anchor link behave like a button
-  .js-market-revert.disabled {
+  .js-market-revert.is-disabled {
 
     cursor: not-allowed;
     opacity: .5;


### PR DESCRIPTION
Fixes #849 

## Done
* Disables revert button when entering a snap listing page
* Enables revert button when any field has been modified on snap listing page

## QA
* Pull the branch
* `./run`
* Visit http://0.0.0.0:8004/account/snaps
* View listing page of a published snap
* Revert button should be disabled and become active once a change has been done to any field in the listing page
