### PR TITLE
Update register snap name title

### DIFF
--- a/static/sass/_button-overrides.scss
+++ b/static/sass/_button-overrides.scss
@@ -8,6 +8,11 @@
     background-image: url('#{$assets-path}61d83c7e-icon-github.svg');
   }
 
+  //propose to vanilla when two buttons are next to each other
+  [class^="p-button"] + [class^="p-button"]:not(span) {
+        margin-right: $sph-inter;
+  }
+
   // new button style for dark strip
   // TODO: propose as new pattern (or amendment?) to vanilla
   .p-strip--accent {

--- a/static/sass/_button-overrides.scss
+++ b/static/sass/_button-overrides.scss
@@ -10,7 +10,7 @@
 
   //propose to vanilla when two buttons are next to each other
   [class^="p-button"] + [class^="p-button"]:not(span) {
-        margin-right: $sph-inter;
+    margin-right: $sph-inter;
   }
 
   // new button style for dark strip

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -4,7 +4,7 @@
   $carousel-buttons-breakpoint: $breakpoint-medium;
 
   .p-carousel {
-    margin-bottom: $spv-inter--scaleable;    
+    margin-bottom: $spv-inter--scaleable;
     position: relative;
 
     .p-carousel__mask {

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -4,8 +4,8 @@
   $carousel-buttons-breakpoint: $breakpoint-medium;
 
   .p-carousel {
+    margin-bottom: $spv-inter--scaleable;    
     position: relative;
-    margin-bottom: $spv-inter--scaleable;
 
     .p-carousel__mask {
       overflow-x: scroll;

--- a/static/sass/_patterns_logo-links.scss
+++ b/static/sass/_patterns_logo-links.scss
@@ -24,7 +24,7 @@
 
     .p-logo-link {
       // by default (on mobile) use col-3 width (4 items in a row)
-      min-width: 150px;      
+      min-width: 150px;
       width: 21.875%; // mobile-col-1
 
       // on larger screens use col-2 width (6 items in a row)

--- a/static/sass/_patterns_logo-links.scss
+++ b/static/sass/_patterns_logo-links.scss
@@ -24,8 +24,8 @@
 
     .p-logo-link {
       // by default (on mobile) use col-3 width (4 items in a row)
+      min-width: 150px;      
       width: 21.875%; // mobile-col-1
-      min-width: 150px;
 
       // on larger screens use col-2 width (6 items in a row)
       @media screen and (min-width: $breakpoint-small) {

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -53,30 +53,6 @@
     }
   }
 
-  .p-form-validation__field {
-    position: relative;
-
-    // workaround for Vanilla added spacing
-    * + & {
-      margin-top: .75rem;
-      margin-bottom: $sp-medium;
-    }
-
-    .p-form-validation__counter {
-      color: $color-negative;
-      line-height: 42px;
-      margin: 0;
-      position: absolute;
-      right: 6px;
-      top: 0;
-    }
-  }
-
-  // hide validation icon when counter is visible
-  .has-counter .p-form-validation__input {
-    background-image: none;
-  }
-
   // Stick the Revert, Apply buttons to the top
   .snapcraft-p-sticky {
     background: $color-x-light;

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -59,6 +59,7 @@
     // workaround for Vanilla added spacing
     * + & {
       margin-top: .75rem;
+      margin-bottom: $sp-medium;
     }
 
     .p-form-validation__counter {

--- a/static/sass/_snapcraft_p-form-validation.scss
+++ b/static/sass/_snapcraft_p-form-validation.scss
@@ -2,24 +2,24 @@
   .p-form-validation__field {
     position: relative;
 
-			// workaround for Vanilla added spacing
-			* + & {
-				margin-top: .75rem;
-				margin-bottom: $sp-medium;
-			}
-
-			.p-form-validation__counter {
-			  color: $color-negative;
-		    line-height: 42px;
-				margin: 0;
-				position: absolute;
-				right: 6px;
-				top: 0;
-			}
+		// workaround for Vanilla added spacing
+		* + & {
+			margin-top: .75rem;
+			margin-bottom: $sp-medium;
 		}
 
-		// hide validation icon when counter is visible
-		.has-counter .p-form-validation__input {
-			background-image: none;
+		.p-form-validation__counter {
+			color: $color-negative;
+			line-height: 42px;
+			margin: 0;
+			position: absolute;
+			right: 6px;
+			top: 0;
 		}
+	}
+
+	// hide validation icon when counter is visible
+	.has-counter .p-form-validation__input {
+		background-image: none;
+	}
 }

--- a/static/sass/_snapcraft_p-form-validation.scss
+++ b/static/sass/_snapcraft_p-form-validation.scss
@@ -2,24 +2,24 @@
   .p-form-validation__field {
     position: relative;
 
-		// workaround for Vanilla added spacing
-		* + & {
-			margin-top: .75rem;
-			margin-bottom: $sp-medium;
-		}
+    // workaround for Vanilla added spacing
+    * + & {
+      margin-bottom: $sp-medium;
+      margin-top: .75rem;
+    }
 
-		.p-form-validation__counter {
-			color: $color-negative;
-			line-height: 42px;
-			margin: 0;
-			position: absolute;
-			right: 6px;
-			top: 0;
-		}
-	}
+    .p-form-validation__counter {
+      color: $color-negative;
+      line-height: 42px;
+      margin: 0;
+      position: absolute;
+      right: 6px;
+      top: 0;
+    }
+  }
 
-	// hide validation icon when counter is visible
-	.has-counter .p-form-validation__input {
-		background-image: none;
+  // hide validation icon when counter is visible
+  .has-counter .p-form-validation__input {
+    background-image: none;
 	}
 }

--- a/static/sass/_snapcraft_p-form-validation.scss
+++ b/static/sass/_snapcraft_p-form-validation.scss
@@ -1,0 +1,25 @@
+@mixin snapcraft-p-form-validation {
+  .p-form-validation__field {
+    position: relative;
+
+			// workaround for Vanilla added spacing
+			* + & {
+				margin-top: .75rem;
+				margin-bottom: $sp-medium;
+			}
+
+			.p-form-validation__counter {
+			  color: $color-negative;
+		    line-height: 42px;
+				margin: 0;
+				position: absolute;
+				right: 6px;
+				top: 0;
+			}
+		}
+
+		// hide validation icon when counter is visible
+		.has-counter .p-form-validation__input {
+			background-image: none;
+		}
+}

--- a/static/sass/_snapcraft_snap-list.scss
+++ b/static/sass/_snapcraft_snap-list.scss
@@ -10,6 +10,10 @@
     &__name {
       margin-right: $sp-medium;
     }
+
+    &__register {
+      margin-top: .45rem;
+    }
   }
 
   .p-snapcraft-first-snap {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -141,6 +141,9 @@ img {
 @import 'snapcraft_p-form-help-text';
 @include snapcraft-p-form-help-text;
 
+@import 'snapcraft_p-form-validation';
+@include snapcraft-p-form-validation;
+
 @import 'snapcraft_p-beta-notification';
 @include snapcraft-p-beta-notification;
 

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -27,7 +27,7 @@ My published snaps — Linux software in the Snap Store
     <div class="col-12">
       <h1 class="p-heading--three u-float--left">My published snaps</h1>
       {% if snaps %}
-        <a href="/account/register-name" class="p-button--neutral u-float--right">Register a snap name</a>
+        <a href="/account/register-name" class="p-button--neutral u-float--right">Register a name</a>
       {% endif %}
     </div>
   </div>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -27,7 +27,7 @@ My published snaps — Linux software in the Snap Store
     <div class="col-12">
       <h1 class="p-heading--three u-float--left">My published snaps</h1>
       {% if snaps %}
-        <a href="/account/register-name" class="p-button--neutral u-float--right">Register a name</a>
+        <a href="/account/register-snap" class="p-button--neutral u-float--right">Register snap</a>
       {% endif %}
     </div>
   </div>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -27,7 +27,7 @@ My published snaps — Linux software in the Snap Store
     <div class="col-12">
       <h1 class="p-heading--three u-float--left">My published snaps</h1>
       {% if snaps %}
-        <a href="/account/register-snap" class="p-button--neutral u-float--right">Register snap</a>
+        <a href="/account/register-snap" class="p-button--neutral u-float--right p-snap-list__register">Register snap</a>
       {% endif %}
     </div>
   </div>

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -27,7 +27,7 @@ My published snaps — Linux software in the Snap Store
     <div class="col-12">
       <h1 class="p-heading--three u-float--left">My published snaps</h1>
       {% if snaps %}
-        <a href="/account/register-name" class="p-button--neutral u-float--right">Register name</a>
+        <a href="/account/register-name" class="p-button--neutral u-float--right">Register a snap name</a>
       {% endif %}
     </div>
   </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -31,18 +31,18 @@
             </p>
           </div>
           <div class="col-5">
-            <div class="u-align--right">
-              <a class="p-button--neutral js-market-revert u-no-margin--bottom" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
-              <button type="submit" class="p-button--positive p-button-spinner js-market-submit u-no-margin--bottom" name="submit_apply" value="Save">
-                {#
-                  to force dark icon variant we need a fake --dark class name:
-                  https://github.com/vanilla-framework/vanilla-framework/issues/1817
-                #}
-                <span class="p-button__spinner vanilla-workaround--dark">
-                  <i class="p-icon--spinner u-animation--spin"></i>
-                </span>
-                <span class="p-button__text">Save</span>
+            <div class="u-align--right u-clearfix">
+              <button type="submit" class="p-button--positive p-button-spinner js-market-submit u-no-margin--bottom u-float-right" name="submit_apply" value="Save">
+                  {#
+                    to force dark icon variant we need a fake --dark class name:
+                    https://github.com/vanilla-framework/vanilla-framework/issues/1817
+                  #}
+                  <span class="p-button__spinner vanilla-workaround--dark">
+                    <i class="p-icon--spinner u-animation--spin"></i>
+                  </span>
+                  <span class="p-button__text">Save</span>
               </button>
+              <a class="p-button--neutral js-market-revert u-no-margin--bottom u-float-right" href="/account/snaps/{{ snap_name }}/listing">Revert</a>
             </div>
           </div>
         </div>

--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -16,7 +16,7 @@ Register new Snap name
   {% else %}
     <div class="row">
         <div class="col-8 push-2">
-          <h1 class="p-heading--three">Register a snap name</h1>
+          <h1 class="p-heading--three">Register a snap</h1>
         </div>
     </div>
   {% endif %}

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -98,12 +98,9 @@ Register new Snap name
     </div>
 
     <div class="row u-no-margin--top">
-      <div class="col-8 push-2">
-        <div class="u-align--right">
-
-          <a class="p-button--neutral" href="/account/snaps">Cancel</a>
-          <input type="submit" class="p-button--positive u-no-margin--top" value="Register"/>
-        </div>
+      <div class="col-8 push-2 u-clearfix u-align--right">
+          <input type="submit" class="p-button--positive u-no-margin--top u-float-right" value="Register"/>        
+          <a class="p-button--neutral u-float-right" href="/account/snaps">Cancel</a>
       </div>
     </div>
   </form>

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -16,7 +16,7 @@ Register new Snap name
   {% else %}
     <div class="row">
         <div class="col-8 push-2">
-          <h1 class="p-heading--three">Register a snap</h1>
+          <h1 class="p-heading--three">Register snap</h1>
         </div>
     </div>
   {% endif %}
@@ -67,7 +67,7 @@ Register new Snap name
       </div>
   {% endif %}
 
-  <form method="POST" action="/account/register-name" class="u-no-margin--top">
+  <form method="POST" action="/account/register-snap" class="u-no-margin--top">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
    <div class="row">

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -51,7 +51,7 @@ class GetReserveNamePage(BaseTestCases.BaseAppTesting):
 
 class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
-        endpoint_url = '/account/register-snap'
+        endpoint_url = '/account/register-name'
 
         super().setUp(
             snap_name=None,
@@ -61,10 +61,10 @@ class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
 
 class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
-        endpoint_url = '/account/register-snap'
+        endpoint_url = '/account/register-name'
         api_url = (
             'https://dashboard.snapcraft.io/dev/api/'
-            'register-snap/')
+            'register-name/')
 
         data = {
             'snap-name': 'test-snap'

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -51,7 +51,7 @@ class GetReserveNamePage(BaseTestCases.BaseAppTesting):
 
 class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
-        endpoint_url = '/account/register-name'
+        endpoint_url = '/account/register-snap'
 
         super().setUp(
             snap_name=None,
@@ -61,7 +61,7 @@ class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
 
 class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
-        endpoint_url = '/account/register-name'
+        endpoint_url = '/account/register-snap'
         api_url = (
             'https://dashboard.snapcraft.io/dev/api/'
             'register-name/')

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -4,7 +4,7 @@ from tests.publisher.endpoint_testing import BaseTestCases
 
 class GetRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
-        endpoint_url = '/account/register-name'
+        endpoint_url = '/account/register-snap'
         super().setUp(
             snap_name=None,
             endpoint_url=endpoint_url)
@@ -12,7 +12,7 @@ class GetRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
 
 class GetRegisterNamePage(BaseTestCases.BaseAppTesting):
     def setUp(self):
-        endpoint_url = '/account/register-name'
+        endpoint_url = '/account/register-snap'
         super().setUp(
             snap_name=None,
             api_url=None,
@@ -24,13 +24,13 @@ class GetRegisterNamePage(BaseTestCases.BaseAppTesting):
         response = self.client.get(self.endpoint_url)
 
         assert response.status_code == 200
-        self.assert_template_used('publisher/register-name.html')
+        self.assert_template_used('publisher/register-snap.html')
 
 
 class GetReserveNamePage(BaseTestCases.BaseAppTesting):
     def setUp(self):
         endpoint_url = (
-            '/account/register-name'
+            '/account/register-snap'
             '?snap_name=test-snap&is_private=False&conflict=True')
         super().setUp(
             snap_name=None,
@@ -43,7 +43,7 @@ class GetReserveNamePage(BaseTestCases.BaseAppTesting):
         response = self.client.get(self.endpoint_url)
 
         assert response.status_code == 200
-        self.assert_template_used('publisher/register-name.html')
+        self.assert_template_used('publisher/register-snap.html')
         self.assert_context('snap_name', 'test-snap')
         self.assert_context('is_private', False)
         self.assert_context('conflict', True)
@@ -51,7 +51,7 @@ class GetReserveNamePage(BaseTestCases.BaseAppTesting):
 
 class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
-        endpoint_url = '/account/register-name'
+        endpoint_url = '/account/register-snap'
 
         super().setUp(
             snap_name=None,
@@ -61,10 +61,10 @@ class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
 
 class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
-        endpoint_url = '/account/register-name'
+        endpoint_url = '/account/register-snap'
         api_url = (
             'https://dashboard.snapcraft.io/dev/api/'
-            'register-name/')
+            'register-snap/')
 
         data = {
             'snap-name': 'test-snap'
@@ -217,7 +217,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             data=self.data,
         )
 
-        self.assert_template_used('publisher/register-name.html')
+        self.assert_template_used('publisher/register-snap.html')
         self.assert_context('errors', payload['error_list'])
 
     @responses.activate
@@ -246,7 +246,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             'is_private=False',
             response.location)
         self.assertIn(
-            'http://localhost/account/register-name',
+            'http://localhost/account/register-snap',
             response.location)
 
     @responses.activate

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -146,7 +146,7 @@ def post_account_name():
             flask.url_for('.get_account_name'))
 
 
-@account.route('/register-name')
+@account.route('/register-snap')
 @login_required
 def get_register_name():
     snap_name = flask.request.args.get('snap_name', default='', type=str)
@@ -173,11 +173,11 @@ def get_register_name():
         'already_owned': already_owned,
     }
     return flask.render_template(
-        'publisher/register-name.html',
+        'publisher/register-snap.html',
         **context)
 
 
-@account.route('/register-name', methods=['POST'])
+@account.route('/register-snap', methods=['POST'])
 @login_required
 def post_register_name():
     snap_name = flask.request.form.get('snap-name')
@@ -225,7 +225,7 @@ def post_register_name():
         }
 
         return flask.render_template(
-            'publisher/register-name.html',
+            'publisher/register-snap.html',
             **context)
     except ApiError as api_error:
         return _handle_errors(api_error)


### PR DESCRIPTION
Fixes #835 and #883 

# Done

- Add extra margin below 'private' on 'Register a snap' form
- Updates copy for CTA and page title for 'Register a snap'

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps
- View updated copy on 'Register a name' to 'Register a snap'
- Click on 'Register a snap'
- View updated copy on page title from 'Register a snap name' to 'Register a snap'