### PR TITLE
Remove default channel reference

### DIFF
--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -26,7 +26,7 @@
         <input
           class="p-code-snippet__input"
           id="snap-install"
-          value="sudo snap install {{ package_name }} {% if default_channel != 'stable' %}--channel {{default_channel}}{% endif %}"
+          value="sudo snap install {{ package_name }}"
           readonly="readonly"
         />
         <button


### PR DESCRIPTION
Fixes #891 

# Done

- Removed `--channel` reference on snapd install instructions

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/vlc
- Click on `Install`
- Copy install with snapd command line instructions
- Run copied code in terminal
- No error shown by `snapd`