### PR TITLE
Updated channel map

### DIFF
--- a/static/js/libs/events.js
+++ b/static/js/libs/events.js
@@ -1,0 +1,64 @@
+const Events = {
+  constructor: function() {
+    this.events = {};
+    this.availableHandles = [];
+
+    return this;
+  },
+
+  _addListener: function(type, bindWindow) {
+    const bindTarget = bindWindow ? window : document.body;
+    bindTarget.addEventListener(type, this._handleEvent.bind(this, type));
+  },
+
+  _handleEvent: function(type, event) {
+    const eventTarget = event.target;
+
+    this.events[type].forEach(ev => {
+      // A bit hacky but this allows using the same api to bind to window for key, resize and scroll events
+      const target = ev.selector === 'window' ? window : eventTarget.closest(ev.selector);
+
+      if (target) {
+        ev.func(target, event);
+      }
+    });
+  },
+
+  /**
+   * Add an event listener
+   *
+   * @param {String} type The event type (click, change, keyup etc.)
+   * @param {String} selector CSS Selector to trigger the event
+   * @param {Function} func The function to trigger
+   */
+  addEvent: function(type, selector, func) {
+    if (!this.events[type]) {
+      this.events[type] = [];
+    }
+
+    this.events[type].push({
+      selector: selector,
+      func: func
+    });
+
+    if (!this.availableHandles.includes(type)) {
+      this._addListener(type, selector === 'window');
+      this.availableHandles.push(type);
+    }
+  },
+
+  /**
+   * Add events by type
+   *
+   * @param {Array.<{eventType: {selector: Function}}>} types
+   */
+  addEvents: function(types) {
+    Object.keys(types).forEach(type => {
+      Object.keys(types[type]).forEach(selector => {
+        this.addEvent(type, selector, types[type][selector]);
+      });
+    });
+  }
+};
+
+export default Events.constructor();

--- a/static/js/libs/events.js
+++ b/static/js/libs/events.js
@@ -1,37 +1,38 @@
-const Events = {
-  constructor: function() {
+class Events {
+
+  constructor(defaultBindTarget) {
+    this.defaultBindTarget = defaultBindTarget || document.body;
     this.events = {};
     this.availableHandles = [];
 
     return this;
-  },
+  }
 
-  _addListener: function(type, bindWindow) {
-    const bindTarget = bindWindow ? window : document.body;
+  _addListener(type, selector) {
+    const bindTarget = typeof(selector) === 'string' ? this.defaultBindTarget : selector;
     bindTarget.addEventListener(type, this._handleEvent.bind(this, type));
-  },
+  }
 
-  _handleEvent: function(type, event) {
+  _handleEvent(type, event) {
     const eventTarget = event.target;
 
     this.events[type].forEach(ev => {
-      // A bit hacky but this allows using the same api to bind to window for key, resize and scroll events
-      const target = ev.selector === 'window' ? window : eventTarget.closest(ev.selector);
+      const target = typeof(ev.selector) === 'string' ? eventTarget.closest(ev.selector) : ev.selector;
 
       if (target) {
-        ev.func(target, event);
+        ev.func(event, target);
       }
     });
-  },
+  }
 
   /**
    * Add an event listener
    *
    * @param {String} type The event type (click, change, keyup etc.)
-   * @param {String} selector CSS Selector to trigger the event
+   * @param {String|Element} selector CSS Selector or element to trigger the event
    * @param {Function} func The function to trigger
    */
-  addEvent: function(type, selector, func) {
+  addEvent(type, selector, func) {
     if (!this.events[type]) {
       this.events[type] = [];
     }
@@ -42,23 +43,23 @@ const Events = {
     });
 
     if (!this.availableHandles.includes(type)) {
-      this._addListener(type, selector === 'window');
+      this._addListener(type, selector);
       this.availableHandles.push(type);
     }
-  },
+  }
 
-  /**
-   * Add events by type
-   *
-   * @param {Array.<{eventType: {selector: Function}}>} types
-   */
-  addEvents: function(types) {
-    Object.keys(types).forEach(type => {
-      Object.keys(types[type]).forEach(selector => {
-        this.addEvent(type, selector, types[type][selector]);
+  addEvents(eventTypes) {
+    /**
+     * Add events by type
+     *
+     * @param {{eventType: {selector: Function}}} eventTypes
+     */
+    Object.keys(eventTypes).forEach(type => {
+      Object.keys(eventTypes[type]).forEach(selector => {
+        this.addEvent(type, selector, eventTypes[type][selector]);
       });
     });
   }
-};
+}
 
-export default Events.constructor();
+export default Events;

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -7,6 +7,7 @@ class ChannelMap {
   constructor(selectorString, packageName, channelMapData, defaultTrack) {
     this.RISK_ORDER = ['stable', 'candidate', 'beta', 'edge'];
     this.INSTALL_TEMPLATE = document.querySelector('[data-js="install-window"]').innerHTML;
+    this.CHANNEL_ROW_TEMPLATE = document.querySelector('[data-js="channel-map-row"]').innerHTML;
 
     this.packageName = packageName;
     this.currentTab = 'overview';
@@ -315,13 +316,14 @@ class ChannelMap {
         rowClass.push('no-border');
       }
 
-      let _row = `
-<tr class="${rowClass.join(' ')}" data-js="slide-install-instructions" data-channel="${row[0]}/${row[1]}">
-  <td>${row[0]}/${row[1]}</td>
-  <td>${row[2]}</td>
-  <td class="u-hide--medium u-hide--small">${row[3]}</td>
-  <td class="u-align--center"><a href="#" class="p-channel-map__version-table-install">Install &rsaquo;</a></td>
-</tr>`;
+      let _row = this.CHANNEL_ROW_TEMPLATE
+        .split('${rowClass}')
+        .join(rowClass.join(' '));
+
+      row.forEach((val, index) => {
+        _row = _row.split('${row[' + index + ']}').join(val);
+      });
+
       cache = row[0];
       return _row;
     });

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -137,6 +137,9 @@ class ChannelMap {
   }
 
   positionChannelMap() {
+    if (!this.openButton) {
+      return;
+    }
     const windowWidth = document.body.scrollWidth;
     const buttonRect = this.openButton.getBoundingClientRect();
     const channelMapPosition = [

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -1,294 +1,418 @@
-/* global ga */
+/* global ga, ClipboardJS, snapcraft */
 
-const LATEST = 'latest';
+import moment from '../../../../node_modules/moment/src/moment';
 
-function setTrack(arch, track, packageName, channelMap) {
-  ['stable', 'candidate', 'beta', 'edge'].forEach((risk, i, risks) => {
-    const channelEl = document.getElementById(`js-channel-map-${risk}`);
+class ChannelMap {
+  constructor(selectorString, packageName, channelMapData, defaultTrack) {
+    this.RISK_ORDER = ['stable', 'candidate', 'beta', 'edge'];
+    this.INSTALL_TEMPLATE = document.querySelector('[data-js="install-window"]').innerHTML;
 
-    // channel names in tracks other then latest are prefixed with track name
-    const channelName = track === LATEST ? risk : `${track}/${risk}`;
+    this.packageName = packageName;
+    this.currentTab = 'overview';
 
-    channelEl.querySelector('.js-channel-name').innerHTML = channelName;
-    let channelData = channelMap[channelName];
+    this.openDesktopAttempt = 1;
 
-    // update install instructions
-    let command = `sudo snap install ${packageName}`;
-
-    if (track === LATEST) {
-      if (risk !== 'stable') {
-        command += ` --${risk}`;
-      }
+    if (!defaultTrack) {
+      this.defaultTrack = 'latest';
     } else {
-      command += ` --channel=${track}/${risk}`;
+      this.defaultTrack = defaultTrack;
     }
 
-    channelEl.querySelector('input').value = command;
+    this.selectorString = selectorString;
+    this.channelMapEl = document.querySelector(this.selectorString);
+    this.channelOverlayEl = document.querySelector('.p-channel-map-overlay');
+    this.channelMapData = channelMapData;
 
-    const versionEl = channelEl.querySelector('.p-form-help-text');
-    channelEl.classList.remove('p-channel-map__row--closed');
+    // get architectures from data
+    const architectures = Object.keys(this.channelMapData);
 
-    // show version
-    if (channelData) {
-      versionEl.innerHTML = `Version: ${channelData.version}`;
-    } else {
-      let fallbackRisk;
-      for (let j = 0; j < i; j++) {
-        const channelName = track === LATEST ? risks[j] : `${track}/${risks[j]}`;
-        if (channelMap[channelName]) {
-          fallbackRisk = risks[j];
-        }
-      }
+    // initialize architecture select
+    const archSelect = document.getElementById("js-channel-map-architecture-select");
 
-      if (fallbackRisk) {
-        versionEl.innerHTML = `No release in ${risk} channel, using ${fallbackRisk} release.`;
+    archSelect.innerHTML = architectures.map(arch => `<option value="${arch}">${arch}</option>`).join('');
+
+    archSelect.addEventListener('change', ()=> {
+      this.prepareTable(this.channelMapData[archSelect.value]);
+    });
+
+    this.arch = this.channelMapData['amd64'] ? 'amd64' : architectures[0];
+
+    // To ensure the scope of the event handlers are bound to the class (not the element)
+    // and that 'removeEventListener' works
+    this.closeOnClick = function(event) {
+      this._closeOnClick(event);
+    }.bind(this);
+
+    this.closeOnEscape = function(event) {
+      this._closeOnEscape(event);
+    }.bind(this);
+
+    // capture events
+    document.addEventListener('click', this.handleClick.bind(this));
+
+    // Bind escape to close channel map
+    window.addEventListener('keyup', this.closeOnEscape.bind(this));
+  }
+
+  sortRows(rows){
+    // split tracks into strings and numbers
+    let numberTracks = [];
+    let stringTracks = [];
+    let latestTracks = [];
+    rows.forEach(row => {
+      // numbers are defined by any string starting any of the following patterns:
+      //   just a number – 1,2,3,4,
+      //   numbers on the left in a pattern – 2018.3 , 1.1, 1.1.23 ...
+      //   or numbers on the left with strings at the end – 1.1-hotfix
+      if (row[0] === this.defaultTrack) {
+        latestTracks.push(row);
+      } else if (isNaN(parseInt(row[0].substr(0, 1)))) {
+        stringTracks.push(row);
       } else {
-        versionEl.innerHTML = `No release in ${risk} channel.`;
-        channelEl.classList.add('p-channel-map__row--closed');
+        numberTracks.push(row);
       }
-    }
-  });
-}
+    });
 
+    // Ignore case
+    stringTracks.sort(function (a, b) {
+      return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
+    });
 
-function getArchTrackChannels(arch, track, channelMapData) {
-  const channels = channelMapData[arch][track];
-  const archTrackChannels = {};
+    stringTracks = latestTracks.concat(stringTracks);
 
-  channels.forEach(channel => {
-    archTrackChannels[channel.channel] = channel;
-  });
+    // Sort numbers (that are actually strings)
+    numberTracks.sort((a, b) => {
+      return b[0].localeCompare(a[0], undefined, { numeric: true, sensitivity: 'base' });
+    });
 
-  return archTrackChannels;
-}
+    // Join the arrays together again
 
-function setArchitecture(arch, packageName, channelMapData) {
-  if (!arch) {
-    return;
+    return stringTracks.concat(numberTracks);
   }
 
-  const tracks = Object.keys(channelMapData[arch]);
+  handleClick(event) {
+    const clickEl = event.target;
 
-  // split tracks into strings and numbers
-  let numberTracks = [];
-  let stringTracks = [];
-  tracks.forEach(track => {
-    // numbers are defined by any string starting any of the following patterns:
-    //   just a number – 1,2,3,4,
-    //   numbers on the left in a pattern – 2018.3 , 1.1, 1.1.23 ...
-    //   or numbers on the left with strings at the end – 1.1-hotfix
-    if (isNaN(parseInt(track.substr(0, 1)))) {
-      stringTracks.push(track);
-    } else {
-      numberTracks.push(track);
-    }
-  });
-
-  // Ignore case
-  stringTracks.sort(function (a, b) {
-    return a.toLowerCase().localeCompare(b.toLowerCase());
-  });
-
-  const latestIndex = stringTracks.indexOf(LATEST);
-  stringTracks.splice(latestIndex, 1);
-  stringTracks = [LATEST].concat(stringTracks);
-
-  // Sort numbers (that are actually strings)
-  numberTracks.sort((a, b) => {
-    return b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' });
-  });
-
-  // Join the arrays together again
-  const sortedTracks = stringTracks.concat(numberTracks);
-
-  const track = sortedTracks[0];
-
-  if (!track) {
-    return;
-  }
-
-  // update tracks select
-  const trackSelect = document.getElementById("js-channel-map-track-select");
-  trackSelect.innerHTML = sortedTracks.map(track => `<option value="${track}">${track}</option>`).join('');
-  trackSelect.value = track;
-
-  // hide tracks if there is only one
-  if (sortedTracks.length === 1) {
-    trackSelect.closest('.js-channel-map-track-field').style.display = 'none';
-  } else {
-    trackSelect.closest('.js-channel-map-track-field').style.display = '';
-  }
-
-  const channelMap = getArchTrackChannels(arch, track, channelMapData);
-  setTrack(arch, track, packageName, channelMap);
-}
-
-function selectTab(tabEl, tabsWrapperEl) {
-  const selected = tabEl.getAttribute('aria-selected');
-  if (!selected) {
-    const selectedTabEle = tabsWrapperEl.querySelector('.p-channel-map__tab.is-open');
-    if (selectedTabEle) {
-      selectedTabEle.classList.remove('is-open');
-    }
-
-    const selectedTabLinkEle = tabsWrapperEl.querySelector('.p-tabs__link[aria-selected]');
-    if (selectedTabLinkEle) {
-      selectedTabLinkEle.removeAttribute('aria-selected');
-    }
-
-    document.getElementById(tabEl.getAttribute('aria-controls')).classList.add('is-open');
-    tabEl.setAttribute('aria-selected', "true");
-  }
-}
-
-function initTabs(el) {
-  el.addEventListener('click', (event) => {
-    const target = event.target.closest('.p-tabs__link');
-
-    if (target) {
-      event.preventDefault();
-      selectTab(target, el);
-    }
-  });
-}
-
-function initOpenSnapButtons() {
-  let attempt = 1;
-
-  document.addEventListener('click', (event) => {
-    const openButton = event.target.closest('.js-open-snap-button');
-
-    if (openButton) {
-      const name = openButton.dataset.snap;
-      let iframe = document.querySelector('.js-snap-open-frame');
-
-      if (iframe) {
-        iframe.parentNode.removeChild(iframe);
-      }
-
-      iframe = document.createElement('iframe');
-      iframe.className = 'js-snap-open-frame';
-      iframe.style.position = 'absolute';
-      iframe.style.top = '-9999px';
-      iframe.style.left = '-9999px';
-      iframe.src = `snap://${name}`;
-      document.body.appendChild(iframe);
-
-      if (typeof ga !== 'undefined') {
-        // The first attempt should be counted towards the 'intent'
-        let label = 'Snap install intent';
-        let value = `${name}`;
-
-        // Subsequent attempts should still be tracked, but not as 'intent'
-        if (attempt > 1) {
-          label = 'Snap install click';
-          value += ` - click ${attempt}`;
+    if (clickEl.dataset.js) {
+      if (clickEl.dataset.js === 'open-channel-map') {
+        event.preventDefault();
+        // If the button has already been clicked, close the channel map
+        if (clickEl === this.openButton) {
+          this.closeChannelMap();
+          this.openButton = null;
+        } else {
+          this.openChannelMap(clickEl);
         }
 
-        ga('gtm1.send', {
-          hitType: 'event',
-          eventCategory: 'Snap details',
-          eventAction: 'Click view in desktop store button',
-          eventLabel: label,
-          eventValue: value
-        });
+        return;
       }
 
-      attempt += 1;
+      if (clickEl.dataset.js === 'close-channel-map') {
+        event.preventDefault();
+        this.closeChannelMap();
+        this.openButton = null;
+
+        return;
+      }
+
+      if (clickEl.dataset.js === 'slide-all-versions') {
+        event.preventDefault();
+        this.slideToVersions(clickEl);
+
+        return;
+      }
+
+      if (clickEl.dataset.js === 'switch-tab') {
+        event.preventDefault();
+        this.switchTab(clickEl);
+
+        return;
+      }
+
+      if (clickEl.dataset.js === 'open-desktop') {
+        event.preventDefault();
+        this.openDesktop(clickEl);
+
+        return;
+      }
+
+      if (clickEl.dataset.js === 'copy-to-clipboard') {
+        const copy = new ClipboardJS('.js-clipboard-copy');
+        copy.on('success', snapcraft.copySuccess);
+
+        return;
+      }
     }
-  });
+
+    let slideToInstructions = clickEl.closest('[data-js="slide-install-instructions"]');
+    if (slideToInstructions) {
+      event.preventDefault();
+      this.slideToInstructions(slideToInstructions);
+
+      return;
+    }
+  }
+
+  openChannelMap(openButton) {
+    // Hide everything first, so we can click between
+    this.closeChannelMap();
+
+    this.openButton = openButton;
+
+    this.openButton.classList.add('is-active');
+
+    const windowWidth = document.body.scrollWidth;
+    const buttonRect = this.openButton.getBoundingClientRect();
+    const channelMapPosition = [
+      windowWidth - buttonRect.right,
+      buttonRect.y + buttonRect.height + 16
+    ];
+
+    this.channelMapEl.style.right = `${channelMapPosition[0]}px`;
+    this.channelMapEl.style.top = `${channelMapPosition[1]}px`;
+
+    // open screen based on button click (or install screen by default)
+    this.openScreenName = this.openButton.getAttribute('aria-controls') || 'channel-map-install';
+
+    const openScreen = this.channelMapEl.querySelector(`#${this.openScreenName}`);
+
+    // select default screen before opening
+    this.selectScreen(openScreen);
+
+    // If we're going to the 'other' screen, prepare the tables
+    if (openButton.dataset.controls === 'channel-map-versions') {
+      this.prepareTable(this.channelMapData[this.arch]);
+    }
+
+    this.channelOverlayEl.style.display = 'block';
+    this.channelMapEl.classList.remove('is-closed');
+
+    if (typeof ga !== 'undefined') {
+      ga('gtm1.send', {
+        hitType: 'event',
+        eventCategory: 'Snap details',
+        eventAction: 'Open install dialog',
+        eventLabel: `Open ${this.openScreenName} dialog screen for ${this.packageName} snap`
+      });
+    }
+  }
+
+  closeChannelMap() {
+    this.channelMapEl.classList.add('is-closed');
+    const children = this.channelMapEl.children;
+    for (let i = 0; i < children.length; i++) {
+      const screenEl = children[i];
+      screenEl.classList.remove('is-open');
+      screenEl.removeAttribute('aria-selected');
+    }
+    this.channelOverlayEl.style.display = 'none';
+
+    if (this.openButton) {
+      this.openButton.classList.remove('is-active');
+    }
+  }
+
+  _closeOnEscape(event) {
+    if (event.key === "Escape" && !this.channelMapEl.classList.contains('is-closed')) {
+      this.closeChannelMap();
+    }
+  }
+
+  _closeOnClick(event) {
+    // when channel map is not closed and clicking outside of it, close it
+    if (!this.channelMapEl.classList.contains('is-closed') &&
+      !event.target.closest(this.selectorString)) {
+      this.closeChannelMap();
+    }
+  }
+
+  openDesktop(clickEl) {
+    const name = clickEl.dataset.snap.trim();
+    let iframe = document.querySelector('.js-snap-open-frame');
+
+    if (iframe) {
+      iframe.parentNode.removeChild(iframe);
+    }
+
+    iframe = document.createElement('iframe');
+    iframe.className = 'js-snap-open-frame';
+    iframe.style.position = 'absolute';
+    iframe.style.top = '-9999px';
+    iframe.style.left = '-9999px';
+    iframe.src = `snap://${name}`;
+    document.body.appendChild(iframe);
+
+    if (typeof ga !== 'undefined') {
+      // The first attempt should be counted towards the 'intent'
+      let label = 'Snap install intent';
+      let value = `${name}`;
+
+      // Subsequent attempts should still be tracked, but not as 'intent'
+      if (this.openDesktopAttempt > 1) {
+        label = 'Snap install click';
+        value += ` - click ${this.openDesktopAttempt}`;
+      }
+
+      ga('gtm1.send', {
+        hitType: 'event',
+        eventCategory: 'Snap details',
+        eventAction: 'Click view in desktop store button',
+        eventLabel: label,
+        eventValue: value
+      });
+    }
+
+    this.openDesktopAttempt += 1;
+  }
+
+  selectScreen(screenEl) {
+    const selected = screenEl.getAttribute('aria-selected');
+    const currentlySelected = screenEl.parentNode.querySelector('.is-open');
+
+    if (currentlySelected) {
+      currentlySelected.classList.remove('is-open');
+    }
+
+    if (!selected) {
+      screenEl.classList.add('is-open');
+      screenEl.setAttribute('aria-selected', "true");
+    }
+  }
+
+  slideToVersions(clickEl) {
+    const slides = clickEl.closest('.p-channel-map__slides');
+    slides.classList.add('show-left');
+    slides.classList.remove('show-right');
+  }
+
+  slideToInstructions(clickEl) {
+    // Add content to the right slide area
+    this.writeInstallInstructions(clickEl.dataset.channel);
+
+    const slides = clickEl.closest('.p-channel-map__slides');
+    slides.classList.add('show-right');
+    slides.classList.remove('show-left');
+  }
+
+  writeInstallInstructions(channel) {
+    let paramString = '';
+
+    if (channel.indexOf('latest') === 0) {
+      if (channel.indexOf('stable') !== 7) {
+        paramString = `--${channel.split('/')[1]}`;
+      }
+    } else {
+      paramString = `--channel=${channel}`;
+    }
+
+    const template = this.INSTALL_TEMPLATE
+      .split('${channel}')
+      .join(channel)
+      .split('${paramString}')
+      .join(paramString);
+    const holder = document.querySelector('[data-js="channel-map-install-details"]');
+
+    holder.innerHTML = template;
+  }
+
+  writeTable(el, data) {
+    let cache;
+    const tbody = data.map((row, i) => {
+      const isSameTrack = (cache && row[0] === cache);
+      let rowClass = [];
+
+      if (i === 0) {
+        rowClass.push('is-highlighted');
+      }
+
+      if (isSameTrack) {
+        rowClass.push('no-border');
+      }
+
+      let _row = `
+<tr class="${rowClass.join(' ')}" data-js="slide-install-instructions" data-channel="${row[0]}/${row[1]}">
+  <td>${row[0]}/${row[1]}</td>
+  <td>${row[2]}</td>
+  <td class="u-hide--medium u-hide--small">${row[3]}</td>
+  <td class="u-align--center"><a href="#" class="p-channel-map__version-table-install">Install &rsaquo;</a></td>
+</tr>`;
+      cache = row[0];
+      return _row;
+    });
+
+    el.innerHTML = tbody.join('');
+  }
+
+  prepareTable(archData) {
+    const tbodyEl = this.channelMapEl.querySelector('[data-js="channel-map-table"]');
+
+    const filtered = this.currentTab === 'overview';
+
+    let numberOfTracks = 0;
+    let trimmedNumberOfTracks = 0;
+
+    Object.keys(archData).forEach(arch => {
+      numberOfTracks += archData[arch].length;
+    });
+
+    let rows = [];
+
+    let trimmed = filtered ? {} : archData;
+
+    if (filtered) {
+      Object.keys(archData).forEach(track => {
+        archData[track].sort((a, b) => {
+          return this.RISK_ORDER.indexOf(a['risk']) - this.RISK_ORDER.indexOf(b['risk']);
+        });
+
+        if (track === this.defaultTrack) {
+          trimmed[track] = archData[track];
+          trimmedNumberOfTracks += trimmed[track].length;
+        } else {
+          trimmed[track] = [archData[track][0]];
+          trimmedNumberOfTracks += 1;
+        }
+      });
+
+      if (numberOfTracks === trimmedNumberOfTracks) {
+        this.hideTabs();
+      }
+    }
+
+
+    Object.keys(trimmed).forEach(track => {
+      trimmed[track].forEach(trackInfo => {
+        const trackName = track.split('/')[0];
+        rows.push([
+          trackName,
+          trackInfo['risk'],
+          trackInfo['version'],
+          moment.utc(trackInfo['created-at']).fromNow()
+        ]);
+      });
+    });
+
+    this.writeTable(tbodyEl, this.sortRows(rows));
+  }
+
+  hideTabs() {
+    const tabs = document.querySelector('[data-js="channel-map-tabs"]');
+
+    if (tabs) {
+      tabs.style.display = 'none';
+    }
+  }
+
+  switchTab(clickEl) {
+    const selected = clickEl.closest('.p-tabs').querySelector('[aria-selected="true"]');
+    this.currentTab = clickEl.dataset.tab;
+    selected.removeAttribute('aria-selected');
+    clickEl.setAttribute('aria-selected', 'true');
+
+    this.prepareTable(this.channelMapData[this.arch]);
+  }
 }
 
-export default function initChannelMap(el, packageName, channelMapData) {
-  initOpenSnapButtons();
-
-  const channelMapEl = document.querySelector(el);
-  const channelOverlayEl = document.querySelector('.p-channel-map-overlay');
-
-  initTabs(channelMapEl);
-
-  let closeTimeout;
-
-  // init open/hide buttons
-  const openChannelMap = (event) => {
-    const openButton = event.target.closest('.js-open-channel-map');
-
-    if (openButton) {
-      // open tab based on button click (or install tab by default)
-      const openTabName = openButton.getAttribute('aria-controls') || 'channel-map-tab-install';
-
-      // clear hiding animation if it's still running
-      clearTimeout(closeTimeout);
-
-      const openTab = channelMapEl.querySelector(`.p-tabs__link[aria-controls=${openTabName}]`);
-
-      // select default tab before opening
-      selectTab(openTab, channelMapEl);
-
-      // make sure overlay is displayed before CSS transitions are triggered
-      channelOverlayEl.style.display = 'block';
-      setTimeout(() => channelMapEl.classList.remove('is-closed'), 10);
-
-      window.addEventListener('keyup', hideOnEscape);
-      document.addEventListener('click', hideOnClick);
-
-      if (typeof ga !== 'undefined') {
-        ga('gtm1.send', {
-          hitType: 'event',
-          eventCategory: 'Snap details',
-          eventAction: 'Open install dialog',
-          eventLabel: `Open ${openTabName} dialog tab for ${packageName} snap`
-        });
-      }
-    }
-  };
-
-  const hideChannelMap = () => {
-    channelMapEl.classList.add('is-closed');
-    // hide overlay after CSS transition is finished
-    closeTimeout = setTimeout(() => channelOverlayEl.style.display = 'none', 500);
-
-    window.removeEventListener('keyup', hideOnEscape);
-    document.removeEventListener('click', hideOnClick);
-  };
-
-  const hideOnEscape = (event) => {
-    if (event.key === "Escape" && !channelMapEl.classList.contains('is-closed')) {
-      hideChannelMap();
-    }
-  };
-
-  const hideOnClick = (event) => {
-    // when channel map is not closed and clicking outside of it, close it
-    if (!channelMapEl.classList.contains('is-closed') &&
-        !event.target.closest(el)) {
-      hideChannelMap();
-    }
-  };
-
-  // show/hide when clicking on buttons
-  document.addEventListener('click', openChannelMap);
-  document.querySelector('.js-hide-channel-map').addEventListener('click', hideChannelMap);
-
-  // get architectures from data
-  const architectures = Object.keys(channelMapData);
-
-  // initialize arch and track selects
-  const archSelect = document.getElementById("js-channel-map-architecture-select");
-  const trackSelect = document.getElementById("js-channel-map-track-select");
-
-  archSelect.innerHTML = architectures.map(arch => `<option value="${arch}">${arch}</option>`).join('');
-
-  archSelect.addEventListener('change', ()=> {
-    setArchitecture(archSelect.value, packageName, channelMapData);
-  });
-
-  trackSelect.addEventListener('change', ()=> {
-    const channels = getArchTrackChannels(archSelect.value, trackSelect.value, channelMapData);
-    setTrack(archSelect.value, trackSelect.value, packageName, channels);
-  });
-
-  const arch = channelMapData['amd64'] ? 'amd64' : architectures[0];
-  archSelect.value = arch;
-  setArchitecture(arch, packageName, channelMapData);
+export default function channelMap(el, packageName, channelMapData, defaultTrack) {
+  return new ChannelMap(el, packageName, channelMapData, defaultTrack);
 }

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -331,45 +331,61 @@ class ChannelMap {
     el.innerHTML = tbody.join('');
   }
 
+  /**
+   * Prepare the channel map tables
+   *
+   * @param {Object} archData
+   * @param {Array.<{channel: string, confinement: string, 'created-at': string, risk: string, size: number, version: string}>} archData.track
+   */
   prepareTable(archData) {
     const tbodyEl = this.channelMapEl.querySelector('[data-js="channel-map-table"]');
 
+    // If we're on the overview tab we only want to see latest/[all risks]
+    // and [all tracks]/[highest risk], so filter out anything that isn't these
     const filtered = this.currentTab === 'overview';
 
     let numberOfTracks = 0;
     let trimmedNumberOfTracks = 0;
 
+    // Get a total number of tracks
     Object.keys(archData).forEach(arch => {
       numberOfTracks += archData[arch].length;
     });
 
     let rows = [];
 
-    let trimmed = filtered ? {} : archData;
+    // If we're not filtering, pass through all the data...
+    let trackList = filtered ? {} : archData;
 
+    // ...and don't do the expensive bit
     if (filtered) {
       Object.keys(archData).forEach(track => {
+        // Sort by risk
         archData[track].sort((a, b) => {
           return this.RISK_ORDER.indexOf(a['risk']) - this.RISK_ORDER.indexOf(b['risk']);
         });
 
+        // Only the default track has all risks
+        // Other tracks should show the highest risk
         if (track === this.defaultTrack) {
-          trimmed[track] = archData[track];
-          trimmedNumberOfTracks += trimmed[track].length;
+          trackList[track] = archData[track];
+          trimmedNumberOfTracks += trackList[track].length;
         } else {
-          trimmed[track] = [archData[track][0]];
+          trackList[track] = [archData[track][0]];
           trimmedNumberOfTracks += 1;
         }
       });
 
+      // If we're filtering, but that list ends up with the same number of tracks
+      // we don't need to show the tabs (we'll show the same data twice)
       if (numberOfTracks === trimmedNumberOfTracks) {
         this.hideTabs();
       }
     }
 
-
-    Object.keys(trimmed).forEach(track => {
-      trimmed[track].forEach(trackInfo => {
+    // Create an array of columns
+    Object.keys(trackList).forEach(track => {
+      trackList[track].forEach(trackInfo => {
         const trackName = track.split('/')[0];
         rows.push([
           trackName,

--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -1,5 +1,7 @@
 /* global d3, topojson */
 
+import globalEvents from '../../libs/events';
+
 export default function renderMap(el, snapData) {
   const mapEl = d3.select(el);
 
@@ -113,7 +115,7 @@ export default function renderMap(el, snapData) {
 
     let resizeTimeout;
 
-    window.addEventListener('resize', function() {
+    globalEvents.addEvent('resize', 'window', () => {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(function () {
         render(mapEl, snapData, world);

--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -1,6 +1,6 @@
 /* global d3, topojson */
 
-import globalEvents from '../../libs/events';
+import SnapEvents from '../../libs/events';
 
 export default function renderMap(el, snapData) {
   const mapEl = d3.select(el);
@@ -115,7 +115,9 @@ export default function renderMap(el, snapData) {
 
     let resizeTimeout;
 
-    globalEvents.addEvent('resize', 'window', () => {
+    const events = new SnapEvents();
+
+    events.addEvent('resize', window, () => {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(function () {
         render(mapEl, snapData, world);

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -90,8 +90,8 @@
 
     @media screen and (max-width: $breakpoint-medium) {
       border: {
-        top: 1px solid $color-mid-light;
         bottom: 1px solid $color-mid-light;
+        top: 1px solid $color-mid-light;
       }
       box-shadow: none;
       margin-top: -$spv-inter--shallow-scaleable;

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -112,6 +112,15 @@
       display: none;
     }
 
+    .p-channel-map-arch-select {
+      min-width: 0;
+    }
+
+    .p-channel-map__form {
+      justify-content: space-between;
+      width: 100%;
+    }
+
     &__row {
       @extend %vf-clearfix;
       margin: 0;

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -1,5 +1,4 @@
 @mixin snapcraft-details-heading {
-  $color-drawer-overlay: rgba(0, 0, 0, .2);
 
   .p-code-snippet__input {
     padding-right: 40px;
@@ -47,12 +46,30 @@
   .p-snap-install-buttons {
     text-align: right;
 
+    .p-snap-install-buttons__install,
+    .p-snap-install-buttons__versions {
+      position: relative;
+      z-index: 5;
+    }
+
     @media screen and (min-width: $breakpoint-medium) {
       margin-top: 8.5 * $sp-unit; // align with snap name baseline
     }
 
     button:last-child {
       margin-bottom: 0;
+    }
+
+    .p-snap-install-buttons__install {
+      &.is-active {
+        background-color: darken($color-positive, 10%);
+      }
+    }
+
+    .p-snap-install-buttons__versions {
+      &.is-active {
+        background-color: darken($color-light, 10%);
+      }
     }
   }
 
@@ -62,22 +79,32 @@
   }
 
   .p-channel-map {
+    background: $color-x-light;
     box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
-    left: 0;
-    padding-top: $sp-medium;
+    max-width: 600px;
+    overflow: hidden;
     position: absolute;
     right: 0;
     top: 0;
-    transform: translateY(48px); // just under the header (mobile)
-    transition: transform 500ms;
     z-index: 10;
+
+    @media screen and (max-width: $breakpoint-medium) {
+      margin-top: -$spv-inter--shallow-scaleable;
+      max-width: 100%;
+      overflow: visible;
+      position: static;
+    }
+
+    @media screen and (max-width: $breakpoint-small) {
+      margin-top: 0;
+    }
 
     label {
       margin-bottom: $spv-inter--condensed + $spv-nudge-compensation;
     }
 
     &.is-closed {
-      transform: translateY(-1111px); // should be high enough to hide it on mobile
+      display: none;
     }
 
     &__row {
@@ -130,14 +157,14 @@
 
   .p-channel-map__tab {
     display: none;
+    overflow: hidden;
 
     &.is-open {
-      display: block;
+      display: flex;
     }
   }
 
   .p-channel-map-overlay {
-    background: $color-drawer-overlay;
     bottom: 0;
     height: auto;
     left: 0;
@@ -154,6 +181,10 @@
     .is-closed + & {
       opacity: 0;
     }
+
+    @media screen and (max-width: $breakpoint-medium) {
+      pointer-events: none;
+    }
   }
 
   // positioning fixes for track tooltip
@@ -164,6 +195,77 @@
       &::before {
         left: 3rem; // reposition arrow correctly under the icon
       }
+    }
+  }
+
+  .p-channel-map__slides {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    position: relative;
+    transition: transform .333s;
+
+    &.show-right {
+      transform: translateX(-100%);
+    }
+
+    &.show-left {
+      transform: translate(0);
+    }
+
+    .p-channel-map__slide {
+      flex-shrink: 0;
+      width: 100%;
+    }
+  }
+
+  .p-channel-map__version-table {
+    max-height: 16rem;
+    overflow: auto;
+
+    @media screen and (max-width: $breakpoint-medium) {
+      max-height: 100%;
+    }
+
+    &-install {
+      display: none;
+    }
+
+    tbody tr {
+      cursor: pointer;
+
+      &:hover {
+        background-color: $color-light;
+
+        .p-channel-map__version-table-install {
+          display: block;
+        }
+      }
+
+      &.is-highlighted {
+        td:first-child {
+          font-weight: 400;
+        }
+      }
+
+      &.no-border {
+        border-top-color: transparent;
+      }
+    }
+
+    @media screen and (max-width: $breakpoint-medium) {
+      th:nth-child(4) {
+        width: 20%;
+      }
+
+      .p-channel-map__version-table-install {
+        display: block;
+      }
+    }
+
+    td {
+      overflow: hidden;
+      white-space: nowrap;
     }
   }
 }

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -89,6 +89,11 @@
     z-index: 10;
 
     @media screen and (max-width: $breakpoint-medium) {
+      border: {
+        top: 1px solid $color-mid-light;
+        bottom: 1px solid $color-mid-light;
+      }
+      box-shadow: none;
       margin-top: -$spv-inter--shallow-scaleable;
       max-width: 100%;
       overflow: visible;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -42,6 +42,7 @@ $color-navigation-background: #252525;
 @include vf-u-animations;
 @include vf-u-image-position;
 @include vf-u-equal-height;
+@include vf-u-hide;
 
 // FIXME: workaround for https://github.com/vanilla-framework/vanilla-framework/issues/1880
 img {

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -266,7 +266,9 @@
       }
 
       if (typeof ClipboardJS !== 'undefined') {
-        snapcraft.copySuccess = function() {
+        var copy = new ClipboardJS('.js-clipboard-copy');
+
+        copy.on('success', function() {
           if (typeof ga !== 'undefined') {
             ga('gtm1.send', {
               hitType: 'event',
@@ -275,10 +277,7 @@
               eventLabel: 'Copy {{ package_name }} button'
             });
           }
-        }
-        var copy = new ClipboardJS('.js-clipboard-copy');
-
-        copy.on('success', snapcraft.copySuccess);
+        });
       }
     });
   </script>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -81,7 +81,7 @@
             data-js="open-channel-map"
             data-controls="channel-map-versions"
             aria-controls="channel-map-versions">
-              <i class="p-icon--chevron"></i>&nbsp;&nbsp;Other versions
+              Other versions&nbsp;&nbsp;<i class="p-icon--chevron"></i>
           </button>
         </div>
       {% else %}

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -224,6 +224,7 @@
         try {
           snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
         } catch(e) {
+          console.log(e);
           Raven.captureException(e);
           document.querySelector('.js-open-channel-map').style.display = 'none';
         }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -68,9 +68,21 @@
       {% if not webapp_config['STORE_QUERY'] %}
         <div class="col-5 p-snap-install-buttons">
           {% if has_stable %}
-            <button class="p-button--positive js-open-channel-map" aria-controls="channel-map-tab-install">Install</button>
+            <button
+              class="p-button--positive p-snap-install-buttons__install"
+              data-js="open-channel-map"
+              data-controls="channel-map-install"
+              aria-controls="channel-map-install">
+                Install
+            </button>
           {% endif %}
-          <button class="p-button--neutral js-open-channel-map" aria-controls="channel-map-tab-versions">All versions</button>
+          <button
+            class="p-button--neutral p-snap-install-buttons__versions"
+            data-js="open-channel-map"
+            data-controls="channel-map-versions"
+            aria-controls="channel-map-versions">
+              <i class="p-icon--chevron"></i>&nbsp;&nbsp;Other versions
+          </button>
         </div>
       {% else %}
         <div class="col-5 p-snap-install-buttons">
@@ -128,8 +140,7 @@
       <div class="col-4">
         <table class="p-table-key-value">
           <tr><th>License</th><td>{{ license }}</td></tr>
-          <tr><th>Size</th><td>{{ filesize }}</td></tr>
-          <tr><th width="100">Version</th><td>{{ version }}</td></tr>
+          <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
         </table>
       </div>
     </div>
@@ -211,7 +222,7 @@
 
       {% if not webapp_config['STORE_QUERY'] and channel_map %}
         try {
-          snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }});
+          snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
         } catch(e) {
           Raven.captureException(e);
           document.querySelector('.js-open-channel-map').style.display = 'none';
@@ -255,9 +266,7 @@
       }
 
       if (typeof ClipboardJS !== 'undefined') {
-        var copy = new ClipboardJS('.js-clipboard-copy');
-
-        copy.on('success', function () {
+        snapcraft.copySuccess = function() {
           if (typeof ga !== 'undefined') {
             ga('gtm1.send', {
               hitType: 'event',
@@ -266,7 +275,10 @@
               eventLabel: 'Copy {{ package_name }} button'
             });
           }
-        });
+        }
+        var copy = new ClipboardJS('.js-clipboard-copy');
+
+        copy.on('success', snapcraft.copySuccess);
       }
     });
   </script>

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -1,35 +1,32 @@
-<div id='js-channel-map' class="p-strip--light p-channel-map is-closed">
-  <div class="row">
-    <div class="col-12">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          {% if has_stable %}
-            <li class="p-tabs__item" role="presentation">
-              <a href="#install" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-install" aria-selected="true">{{ snap_title }} {{ version }}</a>
-            </li>
-          {% endif %}
-          <li class="p-tabs__item" role="presentation">
-            <a href="#versions" class="p-tabs__link" role="tab" aria-controls="channel-map-tab-versions">All versions</a>
-          </li>
-        </ul>
-        <button class="p-channel-map__hide p-icon--close js-hide-channel-map" aria-label="Hide all versions">Hide</button>
-      </nav>
-    </div>
-  </div>
-  {% if has_stable %}
-    <div class="row p-channel-map__tab is-open" id="channel-map-tab-install">
-      <div class="col-5">
+<div id="js-channel-map" class="p-channel-map is-closed">
+  <div id="channel-map-install" class="p-channel-map__tab">
+    <div class="p-strip--light is-shallow">
+      <div class="row">
+        <p class="p-heading--four">Install {{ default_track }}/{{ lowest_risk_available }} of {{ snap_title }}</p>
         <label>Ubuntu 16.04 or later?</label>
-        <button data-snap="{{ package_name }}" class="js-open-snap-button p-view-store-button">View in Desktop store</button>
+        <button
+          data-snap="{{ package_name }}
+            {% if default_track != 'latest' or lowest_risk_available != 'stable' %}
+              ?channel={{ default_track }}/{{ lowest_risk_available }}
+            {% endif %}"
+          class="p-view-store-button"
+          data-js="open-desktop">
+            View in Desktop store
+        </button>
         <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
       </div>
-      <div class="col-5">
-        <label>Install with snapd</label>
+      <div class="row">
+        <hr />
+      </div>
+      <div class="row">
+        <p><b>Install using the command line</b></p>
         <div class="p-code-snippet p-cli-install">
           <input
             class="p-code-snippet__input"
             id="snap-install"
-            value="sudo snap install {{ package_name }}"
+            value="sudo snap install {{ package_name }}
+{% if default_track != 'latest' %} --channel={{ default_track }}/{{ lowest_risk_available }}
+{% elif lowest_risk_available != 'stable' %}--{{ lowest_risk_available }}{% endif %}"
             readonly="readonly"
           />
           <button
@@ -43,141 +40,108 @@
         </p>
       </div>
     </div>
-  {% endif %}
-  <div class="row p-channel-map__tab" id="channel-map-tab-versions">
-    <div class="col-3">
-      <form>
-        <div class="js-channel-map-arch-field">
-          <label for="js-channel-map-track-select">
-            Architecture
-          </label>
-          <select id="js-channel-map-architecture-select">
-          </select>
+  </div>
+  <div id="channel-map-versions" class="p-channel-map__tab">
+    <div class="p-channel-map__slides show-left">
+      <div class="p-strip is-shallow p-channel-map__slide u-no-padding--bottom" data-js="channel-map-options">
+        <div class="row">
+          <form class="p-form--inline">
+            <div class="p-form__group">
+              <label class="p-form__label">
+                All available options to install this snap
+              </label>
+            </div>
+            <div class="js-channel-map-arch-field p-form__group">
+              <label for="js-channel-map-track-select" class="p-form__label">
+                Architecture
+              </label>
+              <div class="p-form__control">
+                <select id="js-channel-map-architecture-select">
+                </select>
+              </div>
+            </div>
+          </form>
         </div>
-        <div class="p-channel-map__track-field js-channel-map-track-field">
-          <label for="js-channel-map-track-select">
-            Track
-            <span class="p-tooltip is-icon" aria-describedby="tooltip-track">
-              <i class="p-icon--information"></i>
-              <span class="p-tooltip__message" role="tooltip" id="tooltip-track">This application has alternate series or 'tracks'
-where you can install and get updates from.</span>
-            </span>
-          </label>
-          <select id="js-channel-map-track-select">
-          </select>
+        <div class="row" data-js="channel-map-tabs">
+          <nav class="p-tabs">
+            <ul class="p-tabs__list" role="tablist">
+              <li class="p-tabs__item" role="presentation">
+                <a
+                  hre="#"
+                  class="p-tabs__link"
+                  role="tab"
+                  data-tab="overview"
+                  data-js="switch-tab"
+                  aria-selected="true">
+                    Overview
+                </a>
+              </li>
+              <li class="p-tabs__item" role="presentation">
+                <a
+                  hre="#"
+                  class="p-tabs__link"
+                  role="tab"
+                  data-tab="all"
+                  data-js="switch-tab">
+                    All releases
+                </a>
+              </li>
+            </ul>
+          </nav>
         </div>
-      </form>
-    </div>
-
-    <div class="col-9">
-
-      <div class="p-channel-map__row p-channel-map__row--heading">
-        <div class="col-8">
-          <label>
-            Command line install
-            <span class="p-tooltip p-tooltip--btm-center" aria-describedby="tooltip-channel">
-              <i class="p-icon--information"></i>
-              <span class="p-tooltip__message" role="tooltip" id="tooltip-channel">Install this application from ‘channels’ of varying stability.
-For example, Edge is used for development and testing, whereas
-Stable is used for well tested and production ready versions.</span>
-            </span>
-          </label>
-        </div>
-      </div>
-
-      <div id="js-channel-map-stable" class="p-channel-map__row">
-        <div class="col-2">
-          <span class="p-channel-map__channel-name js-channel-name">stable</span>
-        </div>
-        <div class="col-6">
-          <div class="p-code-snippet">
-            <input
-              class="p-code-snippet__input"
-              id="snap-install-stable"
-              value="sudo snap install {{ package_name }}"
-              readonly="readonly"
-            />
-            <button
-              class="p-code-snippet__action js-clipboard-copy"
-              data-clipboard-target="#snap-install-stable">
-              Copy to clipboard
-            </button>
-          </div>
-          <p class="p-form-help-text">
-          </p>
-        </div>
-      </div>
-
-      <div id="js-channel-map-candidate" class="p-channel-map__row">
-        <div class="col-2">
-          <span class="p-channel-map__channel-name js-channel-name">candidate</span>
-        </div>
-        <div class="col-6">
-          <div class="p-code-snippet">
-            <input
-              class="p-code-snippet__input"
-              id="snap-install-candidate"
-              value="sudo snap install {{ package_name }} --candidate"
-              readonly="readonly"
-            />
-            <button
-              class="p-code-snippet__action js-clipboard-copy"
-              data-clipboard-target="#snap-install-candidate">
-              Copy to clipboard
-            </button>
-          </div>
-          <p class="p-form-help-text">
-          </p>
+        <div class="row p-channel-map__version-table">
+          <table>
+            <thead>
+              <tr>
+                <th>Channel</th>
+                <th>Version</th>
+                <th width="25%" class="u-hide--medium u-hide--small">Published date</th>
+                <th width="12%"></th>
+              </tr>
+            </thead>
+            <tbody data-js="channel-map-table">
+            </tbody>
+          </table>
         </div>
       </div>
-
-      <div id="js-channel-map-beta" class="p-channel-map__row">
-        <div class="col-2">
-          <span class="p-channel-map__channel-name js-channel-name">beta</span>
-        </div>
-        <div class="col-6">
-          <div class="p-code-snippet">
-            <input
-              class="p-code-snippet__input"
-              id="snap-install-beta"
-              value="sudo snap install {{ package_name }} --beta"
-              readonly="readonly"
-            />
-            <button
-              class="p-code-snippet__action js-clipboard-copy"
-              data-clipboard-target="#snap-install-beta">
-              Copy to clipboard
-            </button>
-          </div>
-          <p class="p-form-help-text">
-          </p>
-        </div>
+      <div class="p-strip--light is-shallow p-channel-map__slide" data-js="channel-map-install-details">
       </div>
-
-      <div id="js-channel-map-edge" class="p-channel-map__row">
-        <div class="col-2">
-          <span class="p-channel-map__channel-name js-channel-name">edge</span>
-        </div>
-        <div class="col-6">
-          <div class="p-code-snippet">
-            <input
-              class="p-code-snippet__input"
-              id="snap-install-edge"
-              value="sudo snap install {{ package_name }} --edge"
-              readonly="readonly"
-            />
-            <button
-              class="p-code-snippet__action js-clipboard-copy"
-              data-clipboard-target="#snap-install-edge">
-              Copy to clipboard
-            </button>
-          </div>
-          <p class="p-form-help-text">
-          </p>
-        </div>
-      </div>
-
     </div>
   </div>
 </div>
-<div class="p-channel-map-overlay" style="display: none"></div>
+<script type="text/template" data-js="install-window">
+  <div class="row">
+    <a href="#" data-js="slide-all-versions">&lsaquo; Other versions</a>
+  </div>
+  <div class="row">
+    <p class="p-heading--four">Install ${channel} of {{ snap_title }}</p>
+    <label>Ubuntu 16.04 or later?</label>
+    <button data-snap="{{ package_name }}?channel=${channel}" class="p-view-store-button" data-js="open-desktop">View in Desktop store</button>
+    <p class="p-form-help-text">Make sure <a href="https://docs.snapcraft.io/core/install">snap support</a> is enabled in your Desktop store.</p>
+  </div>
+  <div class="row">
+    <hr />
+  </div>
+  <div class="row">
+    <p><b>Install using the command line</b></p>
+    <div class="p-code-snippet p-cli-install">
+      <input
+        class="p-code-snippet__input"
+        id="snap-install-alt"
+        value="sudo snap install {{ package_name }} ${paramString}"
+        readonly="readonly"
+      />
+      <button
+        class="p-code-snippet__action js-clipboard-copy"
+        data-js="copy-to-clipboard"
+        data-clipboard-target="#snap-install-alt">
+        Copy to clipboard
+      </button>
+    </div>
+    <p class="p-form-help-text">
+      Don't have snapd? <a href="https://docs.snapcraft.io/core/install">Get set up for snaps</a>.
+    </p>
+  </div>
+</script>
+</div>
+<div class="p-channel-map-overlay" data-js="close-channel-map" style="display: none"></div>

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -143,4 +143,12 @@
   </div>
 </script>
 </div>
+<script type="text/template" data-js="channel-map-row">
+  <tr class="${rowClass}" data-js="slide-install-instructions" data-channel="${row[0]}/${row[1]}">
+    <td>${row[0]}/${row[1]}</td>
+    <td>${row[2]}</td>
+    <td class="u-hide--medium u-hide--small">${row[3]}</td>
+    <td class="u-align--center"><a href="#" class="p-channel-map__version-table-install">Install &rsaquo;</a></td>
+  </tr>
+</script>
 <div class="p-channel-map-overlay" data-js="close-channel-map" style="display: none"></div>

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -51,12 +51,12 @@
                 All available options to install this snap
               </label>
             </div>
-            <div class="js-channel-map-arch-field p-form__group">
-              <label for="js-channel-map-track-select" class="p-form__label">
+            <div class="channel-map-arch-field p-form__group">
+              <label for="channel-map-track-select" class="p-form__label">
                 Architecture
               </label>
               <div class="p-form__control">
-                <select id="js-channel-map-architecture-select">
+                <select id="channel-map-architecture-select" data-js="arch-select">
                 </select>
               </div>
             </div>
@@ -133,7 +133,6 @@
       />
       <button
         class="p-code-snippet__action js-clipboard-copy"
-        data-js="copy-to-clipboard"
         data-clipboard-target="#snap-install-alt">
         Copy to clipboard
       </button>

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -45,18 +45,18 @@
     <div class="p-channel-map__slides show-left">
       <div class="p-strip is-shallow p-channel-map__slide u-no-padding--bottom" data-js="channel-map-options">
         <div class="row">
-          <form class="p-form--inline">
+          <form class="p-form--inline p-channel-map__form">
             <div class="p-form__group">
               <label class="p-form__label">
-                All available options to install this snap
+                Options to install this snap
               </label>
             </div>
             <div class="channel-map-arch-field p-form__group">
               <label for="channel-map-track-select" class="p-form__label">
-                Architecture
+                Show architecture
               </label>
               <div class="p-form__control">
-                <select id="channel-map-architecture-select" data-js="arch-select">
+                <select id="channel-map-architecture-select" data-js="arch-select" class="p-channel-map-arch-select">
                 </select>
               </div>
             </div>
@@ -95,7 +95,7 @@
               <tr>
                 <th>Channel</th>
                 <th>Version</th>
-                <th width="25%" class="u-hide--medium u-hide--small">Published date</th>
+                <th width="25%" class="u-hide--medium u-hide--small">Published</th>
                 <th width="12%"></th>
               </tr>
             </thead>

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -168,3 +168,55 @@ class StoreLogicTest(unittest.TestCase):
         }
 
         self.assertEqual(result, expected_result)
+
+
+    def test_get_lowest_available_risk(self):
+        channel_map = {
+            'arch': {
+                'track': [
+                    {
+                        'risk': 'edge'
+                    }
+                ]
+            }
+        }
+        edge_result = logic.get_lowest_available_risk(channel_map, 'track')
+        self.assertEqual(edge_result, 'edge')
+
+        channel_map['arch']['track'].append({
+            'risk': 'beta'
+        })
+        beta_result = logic.get_lowest_available_risk(channel_map, 'track')
+        self.assertEqual(beta_result, 'beta')
+
+        channel_map['arch']['track'].append({
+            'risk': 'candidate'
+        })
+        cand_result = logic.get_lowest_available_risk(channel_map, 'track')
+        self.assertEqual(cand_result, 'candidate')
+
+        channel_map['arch']['track'].append({
+            'risk': 'stable'
+        })
+        stable_result = logic.get_lowest_available_risk(channel_map, 'track')
+        self.assertEqual(stable_result, 'stable')
+
+        # assert that channel_map has been updated successfully
+        self.assertEqual(channel_map, {
+            'arch': {
+                'track': [
+                    {
+                        'risk': 'edge'
+                    },
+                    {
+                        'risk': 'beta'
+                    },
+                    {
+                        'risk': 'candidate'
+                    },
+                    {
+                        'risk': 'stable'
+                    }
+                ]
+            }
+        })

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -248,3 +248,27 @@ def has_stable(channel_maps_list):
                         return True
 
     return False
+
+
+def get_lowest_available_risk(channel_map, default_track):
+    """Get the lowest available risk for the default track
+
+    :param channel_map: Channel map list
+
+    :returns: The lowest available risk
+    """
+    risk_order = ['stable', 'candidate', 'beta', 'edge']
+    lowest_available_risk = None
+    for arch in channel_map:
+        if channel_map[arch][default_track]:
+            releases = channel_map[arch][default_track]
+            for release in releases:
+                if not lowest_available_risk:
+                    lowest_available_risk = release['risk']
+                else:
+                    risk_index = risk_order.index(release['risk'])
+                    lowest_index = risk_order.index(lowest_available_risk)
+                    if risk_index < lowest_index:
+                        lowest_available_risk = release['risk']
+
+    return lowest_available_risk

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -212,12 +212,12 @@ def get_categories(categories_json):
     return categories
 
 
-def get_last_udpated_version(channel_maps):
+def get_last_updated_version(channel_maps):
     """Get the oldest channel that was created
 
     :param channel_map: Channel map list
 
-    :returns: The latest stable version, if no stable, the lastest risk updated
+    :returns: The latest stable version, if no stable, the latest risk updated
     """
     newest_channel = None
     for channel_map in channel_maps:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -333,6 +333,12 @@ def store_blueprint(store_query=None):
         icons = [
             m['url'] for m in details['snap']['media'] if m['type'] == "icon"]
 
+        default_track = '10' if details['name'] == 'node' else 'latest'
+
+        lowest_risk_available = logic.get_lowest_available_risk(
+            channel_maps_list,
+            default_track)
+
         context = {
             # Data direct from details API
             'snap_title': details['snap']['title'],
@@ -350,6 +356,8 @@ def store_blueprint(store_query=None):
             'channel_map': channel_maps_list,
             'has_stable': logic.has_stable(channel_maps_list),
             'developer_validation': details['snap']['publisher']['validation'],
+            'default_track': default_track,
+            'lowest_risk_available': lowest_risk_available,
 
             # Transformed API data
             'filesize': humanize.naturalsize(binary_filesize),

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -274,7 +274,7 @@ def store_blueprint(store_query=None):
         channel_maps_list = logic.convert_channel_maps(
             details.get('channel-map'))
 
-        latest_channel = logic.get_last_udpated_version(
+        latest_channel = logic.get_last_updated_version(
             details.get('channel-map'))
 
         last_updated = latest_channel['created-at']
@@ -333,6 +333,8 @@ def store_blueprint(store_query=None):
         icons = [
             m['url'] for m in details['snap']['media'] if m['type'] == "icon"]
 
+        # until default tracks are supported by the API we special case node
+        # to use 10, rather then latest
         default_track = '10' if details['name'] == 'node' else 'latest'
 
         lowest_risk_available = logic.get_lowest_available_risk(


### PR DESCRIPTION
# Done

 Fixes https://github.com/canonical-websites/snapcraft.io/issues/731

- Refactored `channelMap.js` to be a class
- Refactored `_channel_map.html`
- Added extra styles to `_snapcraft_details_heading.scss`
- Included `vf-u-hide`
- Removed `Size` and `Version` but added `Last updated` in the details table on the snap details page
- Better implemented `defaultTrack` throughought (hardcoded to 'node' for now, until implemented store-side)
- Made `copySuccess` a method on the global `snapcraft` so as to initialize within JS
- Added `get_lowest_available_risk` to find the lowest available risk for the default track

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store
- Click on some snaps, search for snaps and click on them
- For each snap click the 'Install' button, make sure the overlay works and everything within it does
- For each snap click the 'Other versions' button, make sure the overlay works and everything in does
- The default channel should always be at the top of the table
- The default channel should always have a bold name
- The 'Overview' tab (if present) should show all available risks within 'latest' and the lowest available risk for other tracks
- The 'All releases' tab (if present) should show all available tracks