### PR TITLE
Fix the <span> to be a <div> to increase standards compliance

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -304,9 +304,9 @@
                 <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
               {% endif %}
             </span>
-            <span class="p-media-object__details">
+            <div class="p-media-object__details">
               <h4>{{ snap.title }}</h4>
-            </span>
+            </div>
           </a>
         {% endfor %}
       </div>


### PR DESCRIPTION
Minor fix to front page to avoid putting block level elements inside an inline element