### PR TITLE
Add simple release table to revisions page

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,5 @@
     "test": {
       "presets": ["env"]
     }
-  },
-  "plugins": ["external-helpers"]
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -12,5 +12,6 @@
     "test": {
       "presets": ["env"]
     }
-  }
+  },
+  "plugins": ["external-helpers"]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "autoprefixer": "^6.3.1",
     "babel-core": "^6.26.0",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "billboard.js": "^1.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,8 @@ export default [
         jsnext: true
       }),
       babel({
-        exclude: 'node_modules/**'
+        exclude: 'node_modules/**',
+        plugins: ['external-helpers']
       })
     ],
     output: {
@@ -28,7 +29,8 @@ export default [
         jsnext: true
       }),
       babel({
-        exclude: 'node_modules/**'
+        exclude: 'node_modules/**',
+        plugins: ['external-helpers']
       })
     ],
     output: {
@@ -45,7 +47,8 @@ export default [
         jsnext: true
       }),
       babel({
-        exclude: 'node_modules/**'
+        exclude: 'node_modules/**',
+        plugins: ['external-helpers']
       })
     ],
     output: {
@@ -63,7 +66,8 @@ export default [
         jsnext: true
       }),
       babel({
-        exclude: 'node_modules/**'
+        exclude: 'node_modules/**',
+        plugins: ['external-helpers']
       }),
       // https://github.com/rollup/rollup-plugin-commonjs/issues/200
       commonjs({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,7 +82,13 @@ export default [
           'node_modules/vanilla-framework-react/**'
         ],
         namedExports: {
-          'node_modules/react/index.js': ['Children', 'Component', 'PropTypes', 'createElement'],
+          'node_modules/react/index.js': [
+            'Children',
+            'Component',
+            'Fragment',
+            'PropTypes',
+            'createElement'
+          ],
           'node_modules/react-dom/index.js': ['render']
         }
       }),

--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
 
 import RevisionsList from './release/revisionsList';
@@ -7,12 +7,10 @@ import RevisionsTable from './release/revisionsTable';
 
 const initReleases = (id, data) => {
   ReactDOM.render(
-    <div>
-      <h4>Releases available for install</h4>
+    <Fragment>
       <RevisionsTable revisions={data} />
-      <h4>Revisions available</h4>
       <RevisionsList revisions={data} />
-    </div>,
+    </Fragment>,
     document.querySelector(id)
   );
 };

--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -2,10 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import RevisionsList from './release/revisionsList';
+import RevisionsTable from './release/revisionsTable';
+
 
 const initReleases = (id, data) => {
   ReactDOM.render(
-    <RevisionsList revisions={data} />,
+    <div>
+      <h4>Releases available for install</h4>
+      <RevisionsTable revisions={data} />
+      <h4>Revisions available</h4>
+      <RevisionsList revisions={data} />
+    </div>,
     document.querySelector(id)
   );
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
@@ -9,7 +9,7 @@ export default class RevisionsList extends Component {
 
       return (
         <tr key={revision.revision}>
-          <td>#{ revision.revision }</td>
+          <td>{ revision.revision }</td>
           <td>{ revision.version }</td>
           <td>{ revision.arch }</td>
           <td>{ revision.channels.join(", ") }</td>
@@ -28,21 +28,24 @@ export default class RevisionsList extends Component {
 
   render() {
     return (
-      <table>
-        <thead>
-          <tr>
-            <th width="10%" scope="col">Revision</th>
-            <th width="28%" scope="col">Version</th>
-            <th width="12%" scope="col">Architecture</th>
-            <th width="35%" scope="col">Channels</th>
-            <th width="15%" scope="col" className="u-align--right">Submission date</th>
-          </tr>
-        </thead>
+      <Fragment>
+        <h4>Revisions available</h4>
+        <table>
+          <thead>
+            <tr>
+              <th width="10%" scope="col">Revision</th>
+              <th width="28%" scope="col">Version</th>
+              <th width="12%" scope="col">Architecture</th>
+              <th width="35%" scope="col">Channels</th>
+              <th width="15%" scope="col" className="u-align--right">Submission date</th>
+            </tr>
+          </thead>
 
-        <tbody>
-          { this.renderRows(this.props.revisions) }
-        </tbody>
-      </table>
+          <tbody>
+            { this.renderRows(this.props.revisions) }
+          </tbody>
+        </table>
+      </Fragment>
     );
   }
 }

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -1,7 +1,15 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 export default class RevisionsTable extends Component {
+  constructor() {
+    super();
+
+    // default to latest track
+    this.state = {
+      currentTrack: 'latest'
+    };
+  }
 
   // getting list of tracks names from track/channel names list
   getTracksFromChannels(releasedChannels) {
@@ -62,64 +70,93 @@ export default class RevisionsTable extends Component {
   }
 
   renderRows(releaseData) {
-    const { channels, tracks, archs } = releaseData;
+    const { channels, archs } = releaseData;
 
-    let rows = [];
+    const track = this.state.currentTrack;
 
-    tracks.forEach(track => {
-      rows = rows.concat(['stable', 'candidate', 'beta', 'edge'].map((channel) => {
-        if (track !== 'latest') {
-          channel = `${track}/${channel}`;
-        }
+    return ['stable', 'candidate', 'beta', 'edge'].map((channel) => {
+      if (track !== 'latest') {
+        channel = `${track}/${channel}`;
+      }
 
-        const release = channels[channel] || {};
+      const release = channels[channel] || {};
 
-        // make sure to display 'latest' in front of default channels
-        if (track === 'latest') {
-          channel = `${track}/${channel}`;
-        }
+      // make sure to display 'latest' in front of default channels
+      if (track === 'latest') {
+        channel = `${track}/${channel}`;
+      }
 
-        return (
-          <tr key={channel}>
-            <td>{ channel }</td>
-            {
-              archs.map(arch => {
-                return (
-                  <td
-                    key={`${channel}/${arch}`}
-                    title={ release[arch] ? release[arch].version : null }
-                  >
-                    { release[arch] ? release[arch].version : '-' }
-                  </td>
-                );
-              })
-            }
-          </tr>
-        );
-      }));
+      return (
+        <tr key={channel}>
+          <td>{ channel }</td>
+          {
+            archs.map(arch => {
+              return (
+                <td
+                  key={`${channel}/${arch}`}
+                  title={ release[arch] ? release[arch].version : null }
+                >
+                  { release[arch] ? release[arch].version : '-' }
+                </td>
+              );
+            })
+          }
+        </tr>
+      );
     });
+  }
 
-    return rows;
+  renderTrackDropdown(tracks) {
+    return (
+      <form className="p-form p-form--inline u-float--right">
+        <div className="p-form__group">
+          <label htmlFor="track-dropdown" className="p-form__label">
+            Show revisions released in
+          </label>
+          <div className="p-form__control u-clearfix">
+            <select
+              id="track-dropdown"
+              onChange={this.onTrackChange.bind(this)}
+            >
+              {
+                tracks.map(track => <option key={`${track}`} value={track}>{ track }</option>)
+              }
+            </select>
+          </div>
+        </div>
+      </form>
+    );
+  }
+
+  onTrackChange(event) {
+    this.setState({ currentTrack: event.target.value });
   }
 
   render() {
     const releaseData = this.getReleaseDataFromList(this.props.revisions);
 
-    return (
-      <table className="p-release-table">
-        <thead>
-          <tr>
-            <th width="40%" scope="col"></th>
-            {
-              releaseData.archs.map(arch => <th width="10%" key={`${arch}`}>{ arch }</th>)
-            }
-          </tr>
-        </thead>
 
-        <tbody>
-          { this.renderRows(releaseData) }
-        </tbody>
-      </table>
+    return (
+      <Fragment>
+        <div className="u-clearfix">
+          <h4 className="u-float--left">Releases available for install</h4>
+          { releaseData.tracks.length > 1 && this.renderTrackDropdown(releaseData.tracks) }
+        </div>
+        <table className="p-release-table">
+          <thead>
+            <tr>
+              <th width="22%" scope="col"></th>
+              {
+                releaseData.archs.map(arch => <th width="13%" key={`${arch}`}>{ arch }</th>)
+              }
+            </tr>
+          </thead>
+
+          <tbody>
+            { this.renderRows(releaseData) }
+          </tbody>
+        </table>
+      </Fragment>
     );
   }
 }

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -1,0 +1,114 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class RevisionsTable extends Component {
+
+  // getting list of tracks names from track/channel names list
+  getTracksFromChannels(releasedChannels) {
+    const channels = Object.keys(releasedChannels);
+    const tracks = ['latest'];
+
+    channels.forEach(channel => {
+      const split = channel.split('/');
+
+      // if there is a track name in the channel name
+      // and we haven't saved it yet, s
+      if (split.length > 1 && tracks.indexOf(split[0]) === -1) {
+        tracks.push(split[0]);
+      }
+    });
+
+    return tracks;
+  }
+
+  // getting 'channel map' kind of data out of revisions list
+  // TODO: possibly it would be good to do it in backend (or even get from API)
+  getReleaseDataFromList(revisions) {
+    const releasedChannels = {};
+    const releasedArchs = {};
+
+    revisions.forEach(revision => {
+
+      revision.channels.forEach(channel => {
+        if (!releasedChannels[channel]) {
+          releasedChannels[channel] = {};
+        }
+
+        // some revisions may have multiple architectures listed
+        const archs = revision.arch.split(', ');
+
+        archs.forEach(arch => {
+          if (releasedChannels[channel][arch]) {
+            if (revision.revision > releasedChannels[channel][arch]) {
+              releasedChannels[channel][arch] = revision.revision;
+            }
+          } else {
+            releasedChannels[channel][arch] = revision.revision;
+          }
+          releasedArchs[arch] = true;
+        });
+      });
+    });
+
+    // channels - key-value map of a channel and all revisions released in it
+    //            for different architectures
+    // archs - list of archs that have released revisions
+    // tracks - list of tracks that have released revisions
+    return {
+      channels: releasedChannels,
+      archs: Object.keys(releasedArchs).sort(),
+      tracks: this.getTracksFromChannels(releasedChannels)
+    };
+  }
+
+  renderRows(releaseData) {
+    const { channels, tracks, archs } = releaseData;
+
+    let rows = [];
+
+    tracks.forEach(track => {
+      rows = rows.concat(['stable', 'candidate', 'beta', 'edge'].map((channel) => {
+        if (track !== 'latest') {
+          channel = `${track}/${channel}`;
+        }
+        const release = channels[channel] || {};
+
+        return (
+          <tr key={channel}>
+            <td>{ channel }</td>
+            {
+              archs.map(arch => <td key={`${channel}/${arch}`}>{ release[arch]}</td>)
+            }
+          </tr>
+        );
+      }));
+    });
+
+    return rows;
+  }
+
+  render() {
+    const releaseData = this.getReleaseDataFromList(this.props.revisions);
+
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th width="40%" scope="col"></th>
+            {
+              releaseData.archs.map(arch => <th width="10%" key={`${arch}`}>{ arch }</th>)
+            }
+          </tr>
+        </thead>
+
+        <tbody>
+          { this.renderRows(releaseData) }
+        </tbody>
+      </table>
+    );
+  }
+}
+
+RevisionsTable.propTypes = {
+  revisions: PropTypes.object.isRequired
+};

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -40,10 +40,10 @@ export default class RevisionsTable extends Component {
         archs.forEach(arch => {
           if (releasedChannels[channel][arch]) {
             if (revision.revision > releasedChannels[channel][arch]) {
-              releasedChannels[channel][arch] = revision.revision;
+              releasedChannels[channel][arch] = revision;
             }
           } else {
-            releasedChannels[channel][arch] = revision.revision;
+            releasedChannels[channel][arch] = revision;
           }
           releasedArchs[arch] = true;
         });
@@ -71,13 +71,28 @@ export default class RevisionsTable extends Component {
         if (track !== 'latest') {
           channel = `${track}/${channel}`;
         }
+
         const release = channels[channel] || {};
+
+        // make sure to display 'latest' in front of default channels
+        if (track === 'latest') {
+          channel = `${track}/${channel}`;
+        }
 
         return (
           <tr key={channel}>
             <td>{ channel }</td>
             {
-              archs.map(arch => <td key={`${channel}/${arch}`}>{ release[arch]}</td>)
+              archs.map(arch => {
+                return (
+                  <td
+                    key={`${channel}/${arch}`}
+                    title={ release[arch] ? release[arch].version : null }
+                  >
+                    { release[arch] ? release[arch].version : '-' }
+                  </td>
+                );
+              })
             }
           </tr>
         );
@@ -91,7 +106,7 @@ export default class RevisionsTable extends Component {
     const releaseData = this.getReleaseDataFromList(this.props.revisions);
 
     return (
-      <table>
+      <table className="p-release-table">
         <thead>
           <tr>
             <th width="40%" scope="col"></th>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -1,0 +1,12 @@
+@mixin snapcraft-release {
+  .p-release-table {
+    th {
+      text-transform: none;
+    }
+
+    td {
+      overflow: hidden;
+      white-space: nowrap;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -177,3 +177,6 @@ img {
 
 @import 'patterns_media-object--snap';
 @include snapcraft-p-media-object--snap;
+
+@import 'snapcraft_release';
+@include snapcraft-release;

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -12,7 +12,6 @@ Revision history for {{ snap_title }}
 
   <section class="p-strip is-shallow">
     <div class="row">
-      <h4>Revision history</h4>
 
       <div id="release-history"></div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,6 +443,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-external-helpers@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"


### PR DESCRIPTION
Fixes #894 

Adds simple static releases table to publishers snap revisions page

### QA

- ./run or demo
- go to publisher snap revisions page
- above revisions list there should be a table of released revisions
- table should only contain architectures that were released

<img width="1054" alt="screen shot 2018-07-23 at 11 40 34" src="https://user-images.githubusercontent.com/83575/43072236-4610706c-8e6d-11e8-85ea-467b6f5013bd.png">
