### PR TITLE
Remove bogus role="menubar" from <nav>

### DIFF
--- a/templates/_header-brandstore.html
+++ b/templates/_header-brandstore.html
@@ -16,7 +16,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" role="menubar">
+    <nav class="p-navigation__nav">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -9,7 +9,7 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-    <nav class="p-navigation__nav" role="menubar">
+    <nav class="p-navigation__nav">
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>


### PR DESCRIPTION
<nav> isn't allowed to have a role of `menubar` so let's remove it. There's a default role for <nav>