### PR TITLE
Hide revoked snaps

### DIFF
--- a/tests/publisher/tests_account_snaps.py
+++ b/tests/publisher/tests_account_snaps.py
@@ -64,6 +64,7 @@ class AccountSnapsPage(
             'snaps': {
                 '16': {
                     'test': {
+                        'status': 'Approved',
                         'snap-name': 'test',
                         'latest_revisions': []
                     }
@@ -98,6 +99,7 @@ class AccountSnapsPage(
             'snaps': {
                 '16': {
                     'test': {
+                        'status': 'Approved',
                         'snap-name': 'test',
                         'latest_revisions': [
                             {
@@ -137,6 +139,7 @@ class AccountSnapsPage(
             'snaps': {
                 '16': {
                     'test': {
+                        'status': 'Approved',
                         'snap-name': 'test',
                         'latest_revisions': [
                             {
@@ -146,6 +149,7 @@ class AccountSnapsPage(
                         ]
                     },
                     'test2': {
+                        'status': 'Approved',
                         'snap-name': 'test2',
                         'latest_revisions': []
                     }
@@ -170,6 +174,7 @@ class AccountSnapsPage(
 
         registered_snaps = {
             'test2': {
+                'status': 'Approved',
                 'snap-name': 'test2',
                 'latest_revisions': []
             }
@@ -177,6 +182,88 @@ class AccountSnapsPage(
 
         uploaded_snaps = {
             'test': {
+                'status': 'Approved',
+                'snap-name': 'test',
+                'latest_revisions': [
+                    {
+                        'test': 'test',
+                        'since': '2018-01-01T00:00:00Z'
+                    }
+                ]
+            }
+        }
+
+        assert response.status_code == 200
+        self.assert_template_used('publisher/account-snaps.html')
+        self.assert_context('current_user', 'Toto')
+        self.assert_context('snaps', uploaded_snaps)
+        self.assert_context('registered_snaps', registered_snaps)
+
+    @responses.activate
+    def test_revoked_snaps(self):
+        payload = {
+            'snaps': {
+                '16': {
+                    'test': {
+                        'status': 'Approved',
+                        'snap-name': 'test',
+                        'latest_revisions': [
+                            {
+                                'test': 'test',
+                                'since': '2018-01-01T00:00:00Z'
+                            }
+                        ]
+                    },
+                    'test2': {
+                        'status': 'Approved',
+                        'snap-name': 'test2',
+                        'latest_revisions': []
+                    },
+                    'test3': {
+                        'status': 'Revoked',
+                        'snap-name': 'test',
+                        'latest_revisions': [
+                            {
+                                'test': 'test',
+                                'since': '2018-01-01T00:00:00Z'
+                            }
+                        ]
+                    },
+                    'test4': {
+                        'status': 'Revoked',
+                        'snap-name': 'test2',
+                        'latest_revisions': []
+                    }
+                }
+            }
+        }
+        responses.add(
+            responses.GET, self.api_url,
+            json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url)
+        self.assertEqual(200, response.status_code)
+        # Add pyQuery basic context checks
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(
+            self.api_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
+
+        registered_snaps = {
+            'test2': {
+                'status': 'Approved',
+                'snap-name': 'test2',
+                'latest_revisions': []
+            }
+        }
+
+        uploaded_snaps = {
+            'test': {
+                'status': 'Approved',
                 'snap-name': 'test',
                 'latest_revisions': [
                     {

--- a/tests/publisher/tests_publisher_logic.py
+++ b/tests/publisher/tests_publisher_logic.py
@@ -21,6 +21,7 @@ class PublisherLogicTest(unittest.TestCase):
             'snaps': {
                 '16': {
                     'snap1': {
+                        'status': 'Approved',
                         'latest_revisions': [
                             {
                                 'since': '2018-01-01T00:00:00Z'
@@ -35,6 +36,7 @@ class PublisherLogicTest(unittest.TestCase):
 
         expected_user_snaps = {
             'snap1': {
+                'status': 'Approved',
                 'latest_revisions': [
                     {
                         'since': '2018-01-01T00:00:00Z'
@@ -51,6 +53,7 @@ class PublisherLogicTest(unittest.TestCase):
             'snaps': {
                 '16': {
                     'snap1': {
+                        'status': 'Approved',
                         'latest_revisions': None
                     }
                 }
@@ -61,6 +64,7 @@ class PublisherLogicTest(unittest.TestCase):
 
         expected_registered_snaps = {
             'snap1': {
+                'status': 'Approved',
                 'latest_revisions': None
             }
         }
@@ -73,6 +77,7 @@ class PublisherLogicTest(unittest.TestCase):
             'snaps': {
                 '16': {
                     'snap1': {
+                        'status': 'Approved',
                         'latest_revisions': [
                             {
                                 'since': '2018-01-01T00:00:00Z'
@@ -80,6 +85,7 @@ class PublisherLogicTest(unittest.TestCase):
                         ]
                     },
                     'snap2': {
+                        'status': 'Approved',
                         'latest_revisions': None
                     }
                 }
@@ -90,6 +96,7 @@ class PublisherLogicTest(unittest.TestCase):
 
         expected_user_snaps = {
             'snap1': {
+                'status': 'Approved',
                 'latest_revisions': [
                     {
                         'since': '2018-01-01T00:00:00Z'
@@ -99,6 +106,7 @@ class PublisherLogicTest(unittest.TestCase):
         }
         expected_registered_snaps = {
             'snap2': {
+                'status': 'Approved',
                 'latest_revisions': None
             }
         }

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -16,10 +16,11 @@ def get_snaps_account_info(account_info):
     if '16' in account_info['snaps']:
         snaps = account_info['snaps']['16']
         for snap in snaps.keys():
-            if not snaps[snap]['latest_revisions']:
-                registered_snaps[snap] = snaps[snap]
-            else:
-                user_snaps[snap] = snaps[snap]
+            if snaps[snap]['status'] != 'Revoked':
+                if not snaps[snap]['latest_revisions']:
+                    registered_snaps[snap] = snaps[snap]
+                else:
+                    user_snaps[snap] = snaps[snap]
 
     now = datetime.datetime.utcnow()
 


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/890
- A simple check around whether any of the snaps are revoked

# QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0/account/snaps
- Any revoked snaps should not be shown