### PR TITLE
Simplify install intent GA

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -12,8 +12,6 @@ class ChannelMap {
     this.packageName = packageName;
     this.currentTab = 'overview';
 
-    this.openDesktopAttempt = 1;
-
     if (!defaultTrack) {
       this.defaultTrack = 'latest';
     } else {
@@ -177,12 +175,13 @@ class ChannelMap {
     this.channelOverlayEl.style.display = 'block';
     this.channelMapEl.classList.remove('is-closed');
 
-    if (typeof ga !== 'undefined') {
+    // As discussed with David Calle, we should just track 'install' button clicks
+    if (this.openScreenName === 'channel-map-install' && typeof ga !== 'undefined') {
       ga('gtm1.send', {
         hitType: 'event',
         eventCategory: 'Snap details',
         eventAction: 'Open install dialog',
-        eventLabel: `Open ${this.openScreenName} dialog screen for ${this.packageName} snap`
+        eventLabel: `Open install dialog screen for ${this.packageName} snap`
       });
     }
   }
@@ -231,28 +230,6 @@ class ChannelMap {
     iframe.style.left = '-9999px';
     iframe.src = `snap://${name}`;
     document.body.appendChild(iframe);
-
-    if (typeof ga !== 'undefined') {
-      // The first attempt should be counted towards the 'intent'
-      let label = 'Snap install intent';
-      let value = `${name}`;
-
-      // Subsequent attempts should still be tracked, but not as 'intent'
-      if (this.openDesktopAttempt > 1) {
-        label = 'Snap install click';
-        value += ` - click ${this.openDesktopAttempt}`;
-      }
-
-      ga('gtm1.send', {
-        hitType: 'event',
-        eventCategory: 'Snap details',
-        eventAction: 'Click view in desktop store button',
-        eventLabel: label,
-        eventValue: value
-      });
-    }
-
-    this.openDesktopAttempt += 1;
   }
 
   selectScreen(screenEl) {

--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -87,6 +87,15 @@ class ChannelMap {
             this.openButton = null;
           } else {
             this.openChannelMap(target);
+            // As discussed with David Calle, we should just track 'install' button clicks
+            if (this.openScreenName === 'channel-map-install' && typeof ga !== 'undefined') {
+              ga('gtm1.send', {
+                hitType: 'event',
+                eventCategory: 'Snap details',
+                eventAction: 'Open install dialog',
+                eventLabel: `Open install dialog screen for ${this.packageName} snap`
+              });
+            }
           }
         },
 
@@ -174,16 +183,6 @@ class ChannelMap {
 
     this.channelOverlayEl.style.display = 'block';
     this.channelMapEl.classList.remove('is-closed');
-
-    // As discussed with David Calle, we should just track 'install' button clicks
-    if (this.openScreenName === 'channel-map-install' && typeof ga !== 'undefined') {
-      ga('gtm1.send', {
-        hitType: 'event',
-        eventCategory: 'Snap details',
-        eventAction: 'Open install dialog',
-        eventLabel: `Open install dialog screen for ${this.packageName} snap`
-      });
-    }
   }
 
   closeChannelMap() {

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -230,55 +230,8 @@
         }
       {% endif %}
 
-      var ctrlDown = false;
-
-      function keyDown(e) {
-        if (e && e.key) {
-          var key = e.key.toLowerCase();
-          if (key === 'control' || key === 'meta') {
-            ctrlDown = true;
-          }
-          if ((key === 'c' || key === 'x') && ctrlDown) {
-            if (typeof ga !== 'undefined') {
-              ga('gtm1.send', {
-                hitType: 'event',
-                eventCategory: 'Snap details',
-                eventAction: 'Copy CLI install instructions',
-                eventLabel: 'Copy {{ package_name }} input'
-              });
-            }
-          }
-        }
-      }
-
-      function keyUp(e) {
-        if (e && e.key) {
-          var key = e.key.toLowerCase();
-          if (key === 'control' || key === 'meta') {
-            ctrlDown = false;
-          }
-        }
-      }
-
-      var snapInstall = document.querySelector('#snap-install');
-      if (snapInstall) {
-        snapInstall.addEventListener('keyup', keyUp);
-        snapInstall.addEventListener('keydown', keyDown);
-      }
-
       if (typeof ClipboardJS !== 'undefined') {
-        var copy = new ClipboardJS('.js-clipboard-copy');
-
-        copy.on('success', function() {
-          if (typeof ga !== 'undefined') {
-            ga('gtm1.send', {
-              hitType: 'event',
-              eventCategory: 'Snap details',
-              eventAction: 'Copy CLI install instructions',
-              eventLabel: 'Copy {{ package_name }} button'
-            });
-          }
-        });
+        new ClipboardJS('.js-clipboard-copy');
       }
     });
   </script>


### PR DESCRIPTION
This PR removes the complicated intent tracking to only fire an event when the green install button is clicked.

@caldav the important part:
```
{
    hitType: 'event',
    eventCategory: 'Snap details',
    eventAction: 'Open install dialog',
    eventLabel: `Open install dialog screen for ${this.packageName} snap`
}
```