### PR TITLE
Added external link icon to forum item on header

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -35,7 +35,7 @@
         <li class="p-navigation__link" role="menuitem">
           <a href="https://build.snapcraft.io">Build</a></li>
         <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
-        <li class="p-navigation__link" role="menuitem"><a href="https://forum.snapcraft.io/categories">Forum</a></li>
+        <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
       </ul>
 
       <ul class="p-navigation__links--right" role="menu">


### PR DESCRIPTION
Added an external link icon to the forum item in the snapcraft.io main navigation.

## QA
1. Go to [snapcraft.io](https://snapcraft.io) or [snapcraft.io/store](https://snapcraft.io/store)
2. Notice the external link icon from vanilla in the forum link

## Notes
There are pending updates to build and docs that will propagate this change across the different domains:
[s.io#921](https://github.com/canonical-websites/snapcraft.io/issues/921)
[docs#419](https://github.com/canonical-docs/snappy-docs/issues/419)