### PR TITLE
Updated whitelisting to make it more specific

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -54,7 +54,7 @@
     <script src="{{ static_url('js/modules/raven.min.js') }}"></script>
     <script>
       Raven.config('{{ SENTRY_PUBLIC_DSN }}', {
-        whitelistUrls: ['staging.snapcraft.io', 'snapcraft.io'],
+        whitelistUrls: ['staging.snapcraft.io/static/js', 'snapcraft.io/static/js/'],
         release: '{{ COMMIT_ID }}',
         environment: '{{ ENVIRONMENT }}'
       }).install();


### PR DESCRIPTION
This PR makes snapcraft.io js whitelisting more specific - by setting the path we should remove unrelated errors on the page, but it does mean that any inline code we have written will not be caught.