### PR TITLE
Remove link to dashboard.snapcraft.io

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -21,7 +21,6 @@
               {% if is_on_stable %}
                 {% if private %}
                   This listing is not public because the snap is set to private.
-                  <a href="https://dashboard.snapcraft.io/snaps/{{ snap_name }}">Settings</a>
                 {% else %}
                   Changes you make here will appear immediately on the <a href="/{{ snap_name }}">public listing</a>.
                 {% endif %}


### PR DESCRIPTION
A private snap's Listing page currently links a user to dashboard to manage the snap's privacy settings, but we can manage those settings on the Listing page itself.

### Screenshot
![image](https://user-images.githubusercontent.com/23459065/43151931-fcf30fc2-8f64-11e8-80fa-eaf2093d0609.png)
