### PR TITLE
[HACKDAY] Add copydocs metadata

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/1q9ia7iDuWQlCaJ7nfKVeQ5G-FPyJbP-H{% endblock %}">
 
     <title>{% block meta_title %}Snapcraft - Snaps are universal Linux packages{% endblock %}</title>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,7 @@
 {% extends webapp_config['LAYOUT'] %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1_uwPkHmAgV6_uE9ISqIgXjZGJxXPBD90vdeO95h7ikE/edit{% endblock %}
+
 {% block content %}
 <div id="main-content" class="p-strip--image snapcraft-banner-background">
   <h1 class="u-off-screen">Snapcraft</h1>


### PR DESCRIPTION
Adds copy doc metadata to snapcraft.io home page.

### QA

- go to https://github.com/bartaz/ubuntu-copy-docs and install extension for Firefox or Chrome
- with extension installed visit snapcraft home page http://snapcraft.io-pr-936.run.demo.haus
- there should be a link at the bottom that goes to copy doc

<img width="1360" alt="screen shot 2018-07-26 at 10 08 09" src="https://user-images.githubusercontent.com/83575/43253046-ea2d27e4-90bb-11e8-80f1-eb3b9426fce2.png">
