### PR TITLE
Removed 'stable only' store listing help text

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -18,7 +18,6 @@
         <div class="row">
           <div class="col-7">
             <p class="snapcraft-p-market-message u-no-margin--bottom">
-              {% if is_on_stable %}
                 {% if private %}
                   This listing is not public because the snap is set to private.
                 {% else %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -24,9 +24,6 @@
                 {% else %}
                   Changes you make here will appear immediately on the <a href="/{{ snap_name }}">public listing</a>.
                 {% endif %}
-              {% else %}
-                This listing will appear in the Snap Store when there is a <a href="https://docs.snapcraft.io/build-snaps/release">stable release</a>.
-              {% endif %}
             </p>
           </div>
           <div class="col-5">


### PR DESCRIPTION
A snap is available in the store no matter what channel it is in, so I removed that line from non-stable snap's Listing page.

1. Open the demo and head to [a non-stable snap](http://snapcraft.io-pr-945.run.demo.haus/account/snaps/grelementary/listing)
1. See that the message is displayed as the screenshot below

![image](https://user-images.githubusercontent.com/23459065/43316045-d6f92888-918f-11e8-8c9f-21cfb11ac056.png)
