### PR TITLE
h1 blog titles

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -41,7 +41,7 @@
 <section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
   <div class="row">
     <div class="col-10">
-      <h2>{{ article.title.rendered|safe }}</h2>
+      <h1 class="p-heading--two">{{ article.title.rendered|safe }}</h1>
       <p>by {{ article.author.name }} on {{ article.date }}</p>
     </div>
   </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/953

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/blog
- Click on a blog post
- Check the title is a `<h1 class="p-heading--two">`