### PR TITLE
Added conflict_on_update flag for listing PUTs

### DIFF
--- a/tests/publisher/snaps/tests_post_listing.py
+++ b/tests/publisher/snaps/tests_post_listing.py
@@ -24,7 +24,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         endpoint_url = '/account/snaps/{}/listing'.format(snap_name)
         api_url = (
             'https://dashboard.snapcraft.io/dev/api/'
-            'snaps/{}/metadata').format(
+            'snaps/{}/metadata?conflict_on_update=true').format(
                 self.snap_id)
 
         changes = {

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -41,6 +41,7 @@ AGREEMENT_URL = ''.join([
 METADATA_QUERY_URL = ''.join([
     DASHBOARD_API,
     'snaps/{snap_id}/metadata',
+    '?conflict_on_update=true'
 ])
 
 SCREENSHOTS_QUERY_URL = ''.join([


### PR DESCRIPTION
As per

https://bugs.launchpad.net/snapstore/+bug/1782368
https://bugs.launchpad.net/snapstore/+bug/1782368/comments/3
https://code.launchpad.net/~matiasb/software-center-agent/metadata-api-conflict-on-update/+merge/351809
https://code.launchpad.net/~matiasb/software-center-agent/conflict-on-update-docs/+merge/351813

This sets the `conflict_on_update` query param when saving on the listings page and should resolve the issue of metadata being overwritten when pushing a new snap to the store.

# QA

Hard to QA before the API update is live