### PR TITLE
Add build.snapcraft.io homepage to snapcraft.io/build

### DIFF
--- a/static/sass/_snapcraft_custom-typography.scss
+++ b/static/sass/_snapcraft_custom-typography.scss
@@ -43,12 +43,6 @@
     @extend %paragraph-copy;
   }
 
-  // update to p-list is-ticked style
-  // using em instead of rem to position the tick to make it look good with bigger fonts
-  .is-ticked {
-    background-position: 0 .3em;
-  }
-
   // This can be removed when
   // https://github.com/vanilla-framework/vanilla-framework/issues/1627
   // is resolved.

--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -1,0 +1,15 @@
+@mixin snapcraft-p-build {
+  .p-build__github-button {
+    font-size: 1.25rem;
+    margin-top: $spv-inter--regular-scaleable;
+
+    img {
+      display: inline-block;
+      height: 1.5em;
+      margin-left: .5rem;
+      vertical-align: middle;
+    }
+  }
+}
+
+

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -180,3 +180,6 @@ img {
 
 @import 'snapcraft_release';
 @include snapcraft-release;
+
+@import 'snapcraft_p-build';
+@include snapcraft-p-build;

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -32,7 +32,14 @@
         </a>
       </li>
       <li class="p-navigation__link" role="menuitem">
-        <a href="https://build.snapcraft.io">Build</a></li>
+        <a
+          {% if page_slug == 'build' %}
+            class="is-selected"
+          {% endif %}
+            href="/build">
+          Build
+        </a>
+      </li>
       <li class="p-navigation__link" role="menuitem"><a href="https://docs.snapcraft.io">Docs</a></li>
       <li class="p-navigation__link" role="menuitem"><a class="p-link--external" href="https://forum.snapcraft.io/categories">Forum</a></li>
     </ul>

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -1,0 +1,179 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block content %}
+  <section id="main-content" class="p-strip is-bordered">
+    <div class="row">
+      <p class="p-heading--two">
+        Auto-build and publish software for any Linux system or device
+      </p>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <img src="https://assets.ubuntu.com/v1/ed6d1c5b-build.snapcraft.hero.svg" width="100%" />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-4">
+        <p class="p-heading--four u-align-text--center">Push to GitHub</p>
+      </div>
+      <div class="col-4">
+        <p class="p-heading--four u-align-text--center">Built automatically</p>
+      </div>
+      <div class="col-4">
+        <p class="p-heading--four u-align-text--center">Released for your users</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6 push-3 u-align--center">
+        <a href="https://build.snapcraft.io/auth/authenticate" class="p-button--positive p-build__github-button">
+          Set up in minutes <img src="https://assets.ubuntu.com/v1/cb4b9125-github-white.svg" />
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="row">
+      <h3>Publish your software for</h3>
+    </div>
+    <div class="row">
+      <div class="col-12 p-logo-list">
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/4e18e57c-logo-ubuntu--in-card.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/2ce868d9-mint.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/eccf1818-raspberrypi.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/44789cf1-arch.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/f24733d2-fedora.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/0dd4809d-openwrit.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/f131a86c-yocto.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/38659979-openembed.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/c4c720c6-suse.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/02d49758-manjaro.png" alt="">
+        </div>
+        <div class="p-logo-list__item">
+          <img src="https://assets.ubuntu.com/v1/4ea80b29-solus.png" alt="">
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row">
+      <h3>Why use Snapcraft?</h3>
+    </div>
+    <div class="row">
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Scale to millions of installs</li>
+        <li class="p-list__item is-ticked">Available on all clouds and linux OSes</li>
+        <li class="p-list__item is-ticked">No need for build infrastructure</li>
+        <li class="p-list__item is-ticked">Automatic updates for everyone</li>
+        <li class="p-list__item is-ticked">Roll back versions effortlessly</li>
+        <li class="p-list__item is-ticked">FREE for open source projects</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="row">
+      <h3>How Snapcraft fits your workflow</h3>
+    </div>
+    <div class="row">
+      <div class="u-align--center">
+        <img src="https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable." data-reactid="75">
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6 push-3 u-align--center">
+        <a href="https://build.snapcraft.io/auth/authenticate" class="p-button--positive p-build__github-button">
+          Get started now <img src="https://assets.ubuntu.com/v1/cb4b9125-github-white.svg" />
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-8">
+        <h3>Fast to install, easy to create, safe to run</h3>
+        <p>With Snapcraft, it’s easy to get your software published in the snap store. This store lets people safely install apps from any vendor on mission-critical devices and PCs. Snaps are secure, sandboxed, containerised applications, packaged with their dependencies for predictable behaviour.</p>
+        <p><a href="/">More about snaps &rsaquo;</a></p>
+      </div>
+      <div class="col-4">
+        <img src="https://assets.ubuntu.com/v1/2c5e93c5-fast-easy-safe-illustration.svg" />
+      </div>
+    </div>
+  </section>
+  <section class="p-strip">
+    <div class="row">
+      <h3>What people are saying about snaps</h3>
+    </div>
+    <div class="row">
+      <div class="col-4">
+        <blockquote class="p-testimonial">
+          <div class="p-testimonial__logo">
+            <img src="https://assets.ubuntu.com/v1/99a0b969-Nextcloud_Logo.svg" />
+          </div>
+          <p class="p-testimonial__content">
+            Snaps provide an excellent way to distribute updates in a way that is both secure and does not risk breaking end user devices.
+          </p>
+          <cite class="p-testimonial__citation">
+            Frank Karlitschek
+            <br />
+            <a href="https://nextcloud.com/" class="p-link--external">NextCloud</a>
+          </cite>
+        </blockquote>
+      </div>
+      <div class="col-4">
+        <blockquote class="p-testimonial">
+          <div class="p-testimonial__logo">
+            <img src="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg" />
+          </div>
+          <p class="p-testimonial__content">
+            Snaps allow developers to build and deploy applications in a format that’s easily portable and upgradeable across a number of IoT devices so that a cognitive relationship between the cloud and the edges of the network can be established.
+          </p>
+          <cite class="p-testimonial__citation">
+            Mac Devine
+            <br />
+            <a href="https://www.ibm.com" class="p-link--external">IBM</a>
+          </cite>
+        </blockquote>
+      </div>
+      <div class="col-4">
+        <blockquote class="p-testimonial">
+          <div class="p-testimonial__logo">
+            <img src="https://assets.ubuntu.com/v1/1ad274f9-rocket-chat.svg" />
+          </div>
+          <p class="p-testimonial__content">
+            Getting Rocket.Chat snapped was as easy as defining a simple yaml file and adding into our CI. This is definitely one of the easiest distribution methods we have ever used.
+          </p>
+          <cite class="p-testimonial__citation">
+            Aaron Ogle
+            <br />
+            <a href="https://rocket.chat/" class="p-link--external">Rocket.Chat</a>
+          </cite>
+        </blockquote>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -132,7 +132,7 @@
       <div class="col-4">
         <blockquote class="p-testimonial">
           <div class="p-testimonial__logo">
-            <img src="https://assets.ubuntu.com/v1/99a0b969-Nextcloud_Logo.svg" />
+            <img src="https://assets.ubuntu.com/v1/4983bbf0-logo-next-cloud.svg" />
           </div>
           <p class="p-testimonial__content">
             Snaps provide an excellent way to distribute updates in a way that is both secure and does not risk breaking end user devices.
@@ -147,7 +147,7 @@
       <div class="col-4">
         <blockquote class="p-testimonial">
           <div class="p-testimonial__logo">
-            <img src="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg" />
+            <img src="https://assets.ubuntu.com/v1/a17a9cf6-logo-ibm.svg" />
           </div>
           <p class="p-testimonial__content">
             Snaps allow developers to build and deploy applications in a format that’s easily portable and upgradeable across a number of IoT devices so that a cognitive relationship between the cloud and the edges of the network can be established.
@@ -162,7 +162,7 @@
       <div class="col-4">
         <blockquote class="p-testimonial">
           <div class="p-testimonial__logo">
-            <img src="https://assets.ubuntu.com/v1/1ad274f9-rocket-chat.svg" />
+            <img src="https://assets.ubuntu.com/v1/1d59f449-logo-rocketchat.svg" />
           </div>
           <p class="p-testimonial__content">
             Getting Rocket.Chat snapped was as easy as defining a simple yaml file and adding into our CI. This is definitely one of the easiest distribution methods we have ever used.

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -74,4 +74,12 @@ def snapcraft_blueprint():
         return flask.redirect(
             'https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png')
 
+    @snapcraft.route('/build')
+    def build():
+        status_code = 200
+
+        return flask.render_template(
+            'snapcraft/build.html'
+        ), status_code
+
     return snapcraft

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -14,6 +14,9 @@ def generate_slug(path):
     if path == '/':
         return 'home'
 
+    if path.startswith('/build'):
+        return 'build'
+
     if path.startswith('/blog'):
         return 'blog'
 


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/919

- Added the content in a more familiar vanilla style

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/build
- Compare the page to https://build.snapcraft.io