### PR TITLE
Show --classic on snap details

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -273,14 +273,14 @@ class ChannelMap {
 
   slideToInstructions(clickEl) {
     // Add content to the right slide area
-    this.writeInstallInstructions(clickEl.dataset.channel);
+    this.writeInstallInstructions(clickEl.dataset.channel, clickEl.dataset.confinement);
 
     const slides = clickEl.closest('.p-channel-map__slides');
     slides.classList.add('show-right');
     slides.classList.remove('show-left');
   }
 
-  writeInstallInstructions(channel) {
+  writeInstallInstructions(channel, confinement) {
     let paramString = '';
 
     // By default no params are required
@@ -288,10 +288,14 @@ class ChannelMap {
     // For all other tracks and risks, use the full --channel={channel} syntax
     if (channel.indexOf('latest/') === 0) {
       if (channel !== 'latest/stable') {
-        paramString = `--${channel.split('/')[1]}`;
+        paramString = ` --${channel.split('/')[1]}`;
       }
     } else {
-      paramString = `--channel=${channel}`;
+      paramString = ` --channel=${channel}`;
+    }
+
+    if (confinement === 'classic') {
+      paramString += ` --classic`;
     }
 
     const template = this.INSTALL_TEMPLATE
@@ -393,7 +397,8 @@ class ChannelMap {
           trackName,
           trackInfo['risk'],
           trackInfo['version'],
-          moment.utc(trackInfo['created-at']).fromNow()
+          moment.utc(trackInfo['created-at']).fromNow(),
+          trackInfo['confinement']
         ]);
       });
     });

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -26,7 +26,8 @@
             id="snap-install"
             value="sudo snap install {{ package_name }}
 {% if default_track != 'latest' %} --channel={{ default_track }}/{{ lowest_risk_available }}
-{% elif lowest_risk_available != 'stable' %}--{{ lowest_risk_available }}{% endif %}"
+{% elif lowest_risk_available != 'stable' %}--{{ lowest_risk_available }}{% endif %}
+{% if confinement == 'classic' %} --classic{% endif %}"
             readonly="readonly"
           />
           <button
@@ -128,7 +129,7 @@
       <input
         class="p-code-snippet__input"
         id="snap-install-alt"
-        value="sudo snap install {{ package_name }} ${paramString}"
+        value="sudo snap install {{ package_name }}${paramString}"
         readonly="readonly"
       />
       <button
@@ -143,7 +144,7 @@
   </div>
 </script>
 <script type="text/template" id="channel-map-row-template" data-js="channel-map-row">
-  <tr class="${rowClass}" data-js="slide-install-instructions" data-channel="${row[0]}/${row[1]}">
+  <tr class="${rowClass}" data-js="slide-install-instructions" data-channel="${row[0]}/${row[1]}" data-confinement="${row[4]}">
     <td>${row[0]}/${row[1]}</td>
     <td>${row[2]}</td>
     <td class="u-hide--medium u-hide--small">${row[3]}</td>

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -220,3 +220,25 @@ class StoreLogicTest(unittest.TestCase):
                 ]
             }
         })
+
+
+    def test_get_confinement(self):
+        channel_map = {
+            'arch': {
+                'track': [
+                    {
+                        'risk': 'edge',
+                        'confinement': 'classic'
+                    },
+                    {
+                        'risk': 'stable',
+                        'confinement': 'strict'
+                    }
+                ]
+            }
+        }
+        classic_result = logic.get_confinement(channel_map, 'track', 'edge')
+        self.assertEqual(classic_result, 'classic')
+
+        strict_result = logic.get_confinement(channel_map, 'track', 'stable')
+        self.assertEqual(strict_result, 'strict')

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -250,18 +250,19 @@ def has_stable(channel_maps_list):
     return False
 
 
-def get_lowest_available_risk(channel_map, default_track):
+def get_lowest_available_risk(channel_map, track):
     """Get the lowest available risk for the default track
 
     :param channel_map: Channel map list
+    :param track: The track of the channel
 
     :returns: The lowest available risk
     """
     risk_order = ['stable', 'candidate', 'beta', 'edge']
     lowest_available_risk = None
     for arch in channel_map:
-        if arch in channel_map and default_track in channel_map[arch]:
-            releases = channel_map[arch][default_track]
+        if arch in channel_map and track in channel_map[arch]:
+            releases = channel_map[arch][track]
             for release in releases:
                 if not lowest_available_risk:
                     lowest_available_risk = release['risk']
@@ -272,3 +273,22 @@ def get_lowest_available_risk(channel_map, default_track):
                         lowest_available_risk = release['risk']
 
     return lowest_available_risk
+
+
+def get_confinement(channel_map, track, risk):
+    """Get the confinement for a channel
+
+    :param channel_map: Channel map list
+    :param track: The track of the channel
+    :param risk: The risk of the channel
+
+    :returns: The confinement
+    """
+    for arch in channel_map:
+        if arch in channel_map and track in channel_map[arch]:
+            releases = channel_map[arch][track]
+            for release in releases:
+                if release['risk'] == risk:
+                    return release['confinement']
+
+    return None

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -341,6 +341,11 @@ def store_blueprint(store_query=None):
             channel_maps_list,
             default_track)
 
+        confinement = logic.get_confinement(
+            channel_maps_list,
+            default_track,
+            lowest_risk_available)
+
         context = {
             # Data direct from details API
             'snap_title': details['snap']['title'],
@@ -360,6 +365,7 @@ def store_blueprint(store_query=None):
             'developer_validation': details['snap']['publisher']['validation'],
             'default_track': default_track,
             'lowest_risk_available': lowest_risk_available,
+            'confinement': confinement,
 
             # Transformed API data
             'filesize': humanize.naturalsize(binary_filesize),


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/928

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/powershell
- Click the install button, the CLI command should include `--classic`
- Click around the 'Other versions' they should all also contain `--classic` along with their track params
- Visit http://0.0.0.0:8004/slack
- Repeat the above and see similar results
- Visit http://0.0.0.0:8004/surl
- Notice there isn't a `--classic` param
- Squeal with excitement