### PR TITLE
Further fixes for innerHTML and more logging

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -20,6 +20,10 @@ class ChannelMap {
     this.channelOverlayEl = document.querySelector('.p-channel-map-overlay');
     this.channelMapData = channelMapData;
 
+    if (!this.channelOverlayEl) {
+      throw new Error('The channel map HTML is not present');
+    }
+
     this.events = new SnapEvents(this.channelMapEl.parentNode);
 
     this.initOtherVersions();

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -210,7 +210,12 @@
   <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>
     Raven.context(function () {
-      snapcraft.public.screenshots('#js-snap-screenshots');
+      try {
+        snapcraft.public.screenshots('#js-snap-screenshots');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
       {% if countries %}
         try {
           snapcraft.public.map('#js-snap-map', {{ countries | tojson }});
@@ -222,7 +227,9 @@
 
       {% if not webapp_config['STORE_QUERY'] and channel_map %}
         try {
-          snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
+          document.addEventListener('DOMContentLoaded', function() {
+            snapcraft.public.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ channel_map | tojson }}, "{{ default_track }}");
+          });
         } catch(e) {
           console.log(e);
           Raven.captureException(e);


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/959

- If the channel map overlay isn't present at the start of execution, abandon with a message to sentry
- Start the channel map js on `DOMContentLoaded`
- Extra `try {} catch` around screenshots

# QA

Again hard to QA because we can't replicate the issue