### PR TITLE
Remove copydocs metadata where it's not needed

### DIFF
--- a/templates/publisher/_publisher_layout.html
+++ b/templates/publisher/_publisher_layout.html
@@ -1,0 +1,3 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block meta_copydoc %}{% endblock %}

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
 Account details — Linux software in the Snap Store

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
 My published snaps — Linux software in the Snap Store

--- a/templates/publisher/developer_programme_agreement.html
+++ b/templates/publisher/developer_programme_agreement.html
@@ -1,4 +1,4 @@
-{% extends "_layout.html" %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
     Developer Program Agreement — Linux software in the Snap Store

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
   Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
 Publisher metrics for {{ snap_title }}

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block title %}
 Register new Snap name
@@ -99,7 +99,7 @@ Register new Snap name
 
     <div class="row u-no-margin--top">
       <div class="col-8 push-2 u-clearfix u-align--right">
-          <input type="submit" class="p-button--positive u-no-margin--top u-float-right" value="Register"/>        
+          <input type="submit" class="p-button--positive u-no-margin--top u-float-right" value="Register"/>
           <a class="p-button--neutral u-float-right" href="/account/snaps">Cancel</a>
       </div>
     </div>

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
 Revision history for {{ snap_title }}

--- a/templates/publisher/username.html
+++ b/templates/publisher/username.html
@@ -1,4 +1,4 @@
-{% extends webapp_config['LAYOUT'] %}
+{% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
 Choose username — Linux software in the Snap Store

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -1,5 +1,7 @@
 {% extends webapp_config['LAYOUT'] %}
 
+{% block meta_copydoc %}{% endblock %}
+
 {% block meta_title %}
   {% if query %}
     Snap search results for "{{ query }}"

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -1,5 +1,7 @@
 {% extends webapp_config['LAYOUT'] %}
 
+{% block meta_copydoc %}{% endblock %}
+
 {% block meta_title %}Install {{ snap_title }} for Linux, Linux apps in seconds | Snap Store{% endblock %}
 
 {% block meta_description %}Get the latest version of {{ snap_title }} for Linux - {{ summary }}{% endblock %}


### PR DESCRIPTION
Removes copydoc metadata from publisher pages, search and snap details (as they don't and will not have a copy doc).

## QA
- have Ubuntu Copy Docs extension installed
- ./run or demo
- go to publisher pages - there should be no copy doc link in the bottom
- go to search - there should be no copy doc link in the bottom
- go to snap details - there should be no copy doc link
- go to snapcraft.io home page - there should be a copy doc link