### PR TITLE
Declare category_results before use

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -405,6 +405,7 @@ def store_blueprint(store_query=None):
     def store_category(category):
         status_code = 200
         error_info = {}
+        category_results = []
 
         try:
             category_results = api.get_searched_snaps(


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/971

- Assign `category_results = []` in case `api.get_searched_snaps` fails

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store
- There should be no errors in the terminal
- Remove lines 408 and 409 from `/webapp/store/views.py`
- Visit http://0.0.0.0:8004/store
- There should be some an error in the terminal (this is how it used to be)
- Add lines 408 and 408 to `/webapp/store/views.py`
- Change the contents of the `try {` block to be `print('test')`
- Visit http://0.0.0.0:8004/store
- No errors on fail! Success!