### PR TITLE
Add undo release button

### DIFF
--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -271,9 +271,9 @@ export default class RevisionsTable extends Component {
     return (releasesCount > 0 &&
       <p>
         <span className="p-tooltip">
-          { releasesCount } revision{ releasesCount > 1 ? 's' : '' } to release
-          {' '}
           <i className="p-icon--question" />
+          {' '}
+          { releasesCount } revision{ releasesCount > 1 ? 's' : '' } to release
           <span className="p-tooltip__message" role="tooltip" id="default-tooltip">
             { Object.keys(releases).map(revId => {
               const release = releases[revId];
@@ -288,8 +288,8 @@ export default class RevisionsTable extends Component {
           </span>
         </span>
         {' '}
-        <button disabled title="Not implemented yet...">Apply</button>
-        <button onClick={ this.onRevertClick.bind(this) }>Cancel</button>
+        <button className="p-button--positive is-inline" disabled title="Not implemented yet...">Apply</button>
+        <button className="p-button--neutral" onClick={ this.onRevertClick.bind(this) }>Cancel</button>
       </p>
     );
   }

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -213,7 +213,7 @@ export default class RevisionsTable extends Component {
                     </span>
                   </span>
                   { (canBePromoted || nextRelease) &&
-                    <div style={{ position: 'absolute', right: '5px', top: '5px' }}>
+                    <div className="p-release-buttons">
                       { canBePromoted &&
                         <button className="p-icon-button" onClick={releaseClick.bind(this, thisRevision, track, risk)} title={`Promote ${thisRevision.version} (${thisRevision.revision})`}>&uarr;</button>
                       }
@@ -261,6 +261,8 @@ export default class RevisionsTable extends Component {
       <p>
         <span className="p-tooltip">
           { releasesCount } revision{ releasesCount > 1 ? 's' : '' } to release
+          {' '}
+          <i className="p-icon--question" />
           <span className="p-tooltip__message" role="tooltip" id="default-tooltip">
             { Object.keys(releases).map(revId => {
               const release = releases[revId];

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -170,10 +170,21 @@ export default class RevisionsTable extends Component {
               let canBePromoted = false;
               let thisRevision = this.getRevisionToDisplay(channels, nextChannelReleases, channel, arch);
               let targetRisk = RISKS[RISKS.indexOf(risk) - 1];
-              let promotedRevision = this.getRevisionToDisplay(channels, nextChannelReleases, `${track}/${targetRisk}`, arch);
 
+              let promotedRevision = null;
+              let currentRelease = null;
+              let hasPendingRelease = false;
 
-              if (risk !== 'stable' && thisRevision && (!promotedRevision || promotedRevision.revision !== thisRevision.revision)) {
+              if (targetRisk) {
+                promotedRevision = this.getRevisionToDisplay(channels, nextChannelReleases, `${track}/${targetRisk}`, arch);
+
+                currentRelease = channels[`${track}/${targetRisk}`] && channels[`${track}/${targetRisk}`][arch];
+                hasPendingRelease = currentRelease && promotedRevision && (currentRelease.revision !== promotedRevision.revision);
+              }
+
+              if (risk !== 'stable' && thisRevision && !hasPendingRelease &&
+                (!promotedRevision || promotedRevision.revision !== thisRevision.revision)
+              ) {
                 canBePromoted = true;
               }
 

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -142,14 +142,13 @@ export default class RevisionsTable extends Component {
   }
 
   renderRevisionCell(track, risk, arch, channels, nextChannelReleases) {
-
     const channel = `${track}/${risk}`;
-    //const release = channels[channel] || {};
 
     let canBePromoted = false;
     let thisRevision = this.getRevisionToDisplay(channels, nextChannelReleases, channel, arch);
     let thisPreviousRevision = channels[channel] && channels[channel][arch];
 
+    // check for revision and pending release in target channel (risk - 1)
     let targetRisk = RISKS[RISKS.indexOf(risk) - 1];
     let targetRevision = null;
     let targetPreviousRevision = null;
@@ -160,7 +159,9 @@ export default class RevisionsTable extends Component {
 
       targetRevision = this.getRevisionToDisplay(channels, nextChannelReleases, targetChannel, arch);
       targetPreviousRevision = channels[targetChannel] && channels[targetChannel][arch];
-      targetHasPendingRelease = targetPreviousRevision && targetRevision && (targetPreviousRevision.revision !== targetRevision.revision);
+      targetHasPendingRelease = (
+        targetRevision && (!targetPreviousRevision || (targetPreviousRevision.revision !== targetRevision.revision))
+      );
     }
 
     if (risk !== 'stable' && thisRevision && !targetHasPendingRelease &&
@@ -174,7 +175,9 @@ export default class RevisionsTable extends Component {
       canBePromoted = false;
     }
 
-    const hasPendingRelease = thisPreviousRevision && thisRevision && (thisPreviousRevision.revision !== thisRevision.revision);
+    const hasPendingRelease = (
+      thisRevision && (!thisPreviousRevision || (thisPreviousRevision.revision !== thisRevision.revision))
+    );
 
     return (
       <td

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -132,9 +132,9 @@ export default class RevisionsTable extends Component {
   }
 
   // TODO:
-  // - tooltip for release (list of revisions to release)
   // - tooltip for promote button
   // - tooltip for undo button
+  // - bug when releasing 2 revisions to same channel
   renderRows(releaseData) {
     const { channels, archs } = releaseData;
 
@@ -244,6 +244,34 @@ export default class RevisionsTable extends Component {
     );
   }
 
+  renderReleasesConfirm() {
+    const { releases } = this.state;
+    const releasesCount = Object.keys(releases).length;
+
+    return (releasesCount > 0 &&
+      <p>
+        <span className="p-tooltip">
+          { releasesCount } revision{ releasesCount > 1 ? 's' : '' } to release
+          <span className="p-tooltip__message" role="tooltip" id="default-tooltip">
+            { Object.keys(releases).map(revId => {
+              const release = releases[revId];
+
+              return <span key={revId}>
+                {release.revision.version} ({release.revision.arch})
+                {' '}
+                to {release.channels.join(', ')}
+                {'\n'}
+              </span>;
+            })}
+          </span>
+        </span>
+        {' '}
+        <button disabled title="Not implemented yet...">Apply</button>
+        <button onClick={ this.onRevertClick.bind(this) }>Cancel</button>
+      </p>
+    );
+  }
+
   onTrackChange(event) {
     this.setState({ currentTrack: event.target.value });
   }
@@ -284,9 +312,7 @@ export default class RevisionsTable extends Component {
           <h4 className="u-float--left">Releases available for install</h4>
           { releaseData.tracks.length > 1 && this.renderTrackDropdown(releaseData.tracks) }
         </div>
-        { Object.keys(this.state.releases).length > 0 &&
-          <p>{ Object.keys(this.state.releases).length } revision{ Object.keys(this.state.releases).length > 1 ? 's' : '' } to release <button disabled title="Not implemented yet...">Apply</button> <button onClick={ this.onRevertClick.bind(this) }>Cancel</button></p>
-        }
+        { this.renderReleasesConfirm() }
         <table className="p-release-table">
           <thead>
             <tr>

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -132,7 +132,6 @@ export default class RevisionsTable extends Component {
   }
 
   // TODO:
-  // - opacity to old release name
   // - tooltip for release (list of revisions to release)
   // - tooltip for promote button
   // - tooltip for undo button
@@ -197,7 +196,9 @@ export default class RevisionsTable extends Component {
                   key={`${channel}/${arch}`}
                   title={ release[arch] ? `${release[arch].version} (${release[arch].revision})` : null }
                 >
-                  { release[arch] ? release[arch].version : '-' }
+                  <span className={ nextRelease ? 'p-previous-revision' : '' }>
+                    { release[arch] ? release[arch].version : '-' }
+                  </span>
                   { nextRelease &&
                     <span> &rarr; { nextRelease.version }</span>
                   }

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -194,15 +194,24 @@ export default class RevisionsTable extends Component {
                 <td
                   style={ { position: 'relative' } }
                   key={`${channel}/${arch}`}
-                  title={ release[arch] ? `${release[arch].version} (${release[arch].revision})` : null }
                 >
-                  <span className={ nextRelease ? 'p-previous-revision' : '' }>
-                    { release[arch] ? release[arch].version : '-' }
-                  </span>
-                  { nextRelease &&
-                    <span> &rarr; { nextRelease.version }</span>
-                  }
+                  <span className="p-tooltip p-tooltip--btm-center">
+                    <span className="p-release-version">
+                      <span className={ nextRelease ? 'p-previous-revision' : '' }>
+                        { release[arch] ? release[arch].version : '-' }
+                      </span>
+                      { nextRelease &&
+                        <span> &rarr; { nextRelease.version }</span>
+                      }
+                    </span>
 
+                    <span className="p-tooltip__message">
+                      { release[arch] ? `${release[arch].version} (${release[arch].revision})` : 'None' }
+                      { nextRelease &&
+                        <span> &rarr; { `${nextRelease.version} (${nextRelease.revision})` }</span>
+                      }
+                    </span>
+                  </span>
                   { (canBePromoted || nextRelease) &&
                     <div style={{ position: 'absolute', right: '5px', top: '5px' }}>
                       { canBePromoted &&
@@ -257,7 +266,7 @@ export default class RevisionsTable extends Component {
               const release = releases[revId];
 
               return <span key={revId}>
-                {release.revision.version} ({release.revision.arch})
+                {release.revision.version} ({release.revision.revision}) {release.revision.arch}
                 {' '}
                 to {release.channels.join(', ')}
                 {'\n'}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -20,4 +20,7 @@
     }
   }
 
+  .p-previous-revision {
+    opacity: .5;
+  }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -3,11 +3,6 @@
     th {
       text-transform: none;
     }
-
-    td {
-      overflow: hidden;
-      white-space: nowrap;
-    }
   }
 
 
@@ -22,5 +17,13 @@
 
   .p-previous-revision {
     opacity: .5;
+  }
+
+  .p-release-version {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -9,4 +9,15 @@
       white-space: nowrap;
     }
   }
+
+
+  .p-icon-button {
+    padding-left: .5rem;
+    padding-right: .5rem;
+
+    &:not(:last-of-type):not(:only-of-type) {
+      margin-right: .25rem;
+    }
+  }
+
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -26,4 +26,10 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .p-release-buttons {
+    position: absolute;
+    right: 1rem; // match table padding
+    top: .5rem;
+  }
 }

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -37,7 +37,7 @@
                 aria-selected="true"
               {% endif %}
             >
-            Revisions
+            Releases
             </a>
           </li>
           <li class="p-tabs__item" role="presentation">

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -1,7 +1,7 @@
 {% extends "publisher/_publisher_layout.html" %}
 
 {% block meta_title %}
-Revision history for {{ snap_title }}
+Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
*Work in progress*

Fixes #967 

Done:
- adds undo 'X' button next to promoted release, so single release can be canceled
- adds tooltip with list of all revisions to be released next to confirm button

<img width="1029" alt="screen shot 2018-08-06 at 17 14 57" src="https://user-images.githubusercontent.com/83575/43725339-8b113928-999c-11e8-840b-7a0da4c6c17c.png">
