### PR TITLE
added bsi login route

### DIFF
--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -18,6 +18,12 @@ LOGIN_URL = os.getenv(
     'LOGIN_URL',
     'https://login.ubuntu.com',
 )
+
+BSI_URL = os.getenv(
+    'BSI_URL',
+    'https://build.snapcraft.io'
+)
+
 open_id = OpenID(
     stateless=True,
     safe_roots=[],
@@ -75,3 +81,8 @@ def logout():
     if authentication.is_authenticated(flask.session):
         authentication.empty_session(flask.session)
     return flask.redirect('/')
+
+
+@login.route('/login/bsi')
+def login_bsi():
+    return flask.redirect(BSI_URL + '/auth/authenticate')


### PR DESCRIPTION
# Done

Added login redirect to:
1. Log in to snapcraft.io, then
2. Redirect to log in to BSI

This is to facilitate the ability to login to BSI and redirect to SI, then back again after SSO

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/login/bsi
- Login with SSO
- Find yourself at https://build.snapcraft.io/auth/authorise

# ORDER OF DEPLOYMENT

1. This PR
2. https://github.com/canonical-websites/build.snapcraft.io/pull/1129
3. https://github.com/canonical-websites/snapcraft.io/pull/974