### PR TITLE
Fixed LimeNET command instructions on homepage

### DIFF
--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -29,7 +29,7 @@
       <div class="row">
         <h3>Installing apps</h3>
         <p>To configure a snap enabled system to use {{ webapp_config['STORE_QUERY'] }}:</p>
-        <pre><code>sudo echo "UBUNTU_STORE_ID={{ webapp_config['STORE_QUERY'] }}" >> /etc/environment
+        <pre><code>echo "UBUNTU_STORE_ID={{ webapp_config['STORE_QUERY'] }}" | sudo tee -a /etc/environment
 sudo service snapd restart</code></pre>
       </div>
       <div class="row">


### PR DESCRIPTION
Updates script commands on LimeNET homepage

## QA
- Pull the branch 
- Edit `.env` file to run the LimeNET brand store
- Run `./run`
- Visit https://0.0.0.0:8004
- Compare to the [copy doc](https://docs.google.com/document/d/1EFWYq_RK1IpmuI__3ipmBoFNWNxIbFghdDgKt9DdQcI/edit#)