### PR TITLE
Use releases v2 API instead of revision history

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -6,10 +6,35 @@ import RevisionsTable from './release/revisionsTable';
 
 
 const initReleases = (id, data, options) => {
+
+  // init channel data in revisions list
+  const revisionsMap = {};
+  data.revisions.forEach(rev => {
+    rev.channels = [];
+    revisionsMap[rev.revision] = rev;
+  });
+
+  // go through releases from older to newest
+  data.releases.slice().reverse().forEach(release => {
+    if (release.revision) {
+      const rev = revisionsMap[release.revision];
+
+      if (rev) {
+        const channel = release.track === 'latest'
+          ? release.risk
+          : `${release.track}/${release.risk}`;
+
+        if (rev.channels.indexOf(`${release.track}/${release.risk}`) === -1) {
+          rev.channels.push(channel);
+        }
+      }
+    }
+  });
+
   ReactDOM.render(
     <Fragment>
-      <RevisionsTable revisions={data} options={options}/>
-      <RevisionsList revisions={data} />
+      <RevisionsTable revisions={data.revisions} options={options}/>
+      <RevisionsList revisions={data.revisions} />
     </Fragment>,
     document.querySelector(id)
   );

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -5,13 +5,13 @@ import moment from 'moment';
 export default class RevisionsList extends Component {
   renderRows(revisions) {
     return revisions.map((revision) => {
-      const uploadDate = moment(revision.timestamp);
+      const uploadDate = moment(revision.uploaded_at);
 
       return (
         <tr key={revision.revision}>
           <td>{ revision.revision }</td>
           <td>{ revision.version }</td>
-          <td>{ revision.arch }</td>
+          <td>{ revision.architectures.join(", ") }</td>
           <td>{ revision.channels.join(", ") }</td>
           <td className="u-align--right">
             <span className="p-tooltip p-tooltip--btm-center" aria-describedby={`revision-uploaded-${revision.revision}`}>

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -49,10 +49,9 @@ export default class RevisionsTable extends Component {
         if (!releasedChannels[channel]) {
           releasedChannels[channel] = {};
         }
-        // some revisions may have multiple architectures listed
-        const archs = revision.arch.split(', ');
 
-        archs.forEach(arch => {
+        // some revisions may have multiple architectures listed
+        revision.architectures.forEach(arch => {
           if (releasedChannels[channel][arch]) {
             if (revision.revision > releasedChannels[channel][arch]) {
               releasedChannels[channel][arch] = revision;
@@ -272,7 +271,7 @@ export default class RevisionsTable extends Component {
               const release = releases[revId];
 
               return <span key={revId}>
-                {release.revision.version} ({release.revision.revision}) {release.revision.arch}
+                {release.revision.version} ({release.revision.revision}) {release.revision.architectures.join(', ')}
                 {' '}
                 to {release.channels.join(', ')}
                 {'\n'}
@@ -303,7 +302,7 @@ export default class RevisionsTable extends Component {
           nextReleaseData[channel] = {};
         }
 
-        revision.arch.split(', ').forEach(arch => {
+        revision.architectures.forEach(arch => {
           nextReleaseData[channel][arch] = revision;
         });
       });

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -5,7 +5,6 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
 {% endblock %}
 
 {% block content %}
-
 <div id="main-content" class="u-no-margin--top">
   {% set selected_tab='release' %}
   {% include "publisher/_header.html" %}
@@ -25,7 +24,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
 {% block scripts %}
   <script src="{{ static_url('js/dist/release.js') }}"></script>
   <script>
-    snapcraft.release.initReleases('#release-history', {{ revision_history|tojson }}, {
+    snapcraft.release.initReleases('#release-history', {{ release_history|tojson }}, {
       releaseUiEnabled: {{ release_ui_enabled|tojson }}
     });
   </script>

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -18,7 +18,10 @@ class GetRevisionGetInfoPage(
     def setUp(self):
         snap_name = "test-snap"
 
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        api_url = (
+            'https://dashboard.snapcraft.io/api/v2/snaps/{}' +
+            '/releases?page=1&size=100'
+        )
         api_url = api_url.format(
             snap_name
         )
@@ -39,22 +42,13 @@ class GetRevisionHistory(
     def setUp(self):
         snap_name = "test-snap"
 
-        self.snap_id = 'complexId'
-        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
-        self.info_url = info_url.format(
+        api_url = (
+            'https://dashboard.snapcraft.io/api/v2/snaps/{}' +
+            '/releases?page=1&size=100'
+        )
+        api_url = api_url.format(
             snap_name
         )
-
-        payload = {
-            'snap_id': 'id',
-            'title': 'Test Snap'
-        }
-
-        responses.add(
-            responses.GET, self.info_url,
-            json=payload, status=200)
-
-        api_url = 'https://dashboard.snapcraft.io/dev/api/snaps/id/history'
         endpoint_url = '/account/snaps/{}/release'.format(snap_name)
 
         super().setUp(
@@ -69,20 +63,14 @@ class GetRevisionHistory(
     def test_get_revision(self):
         responses.add(
             responses.GET, self.api_url,
-            json=[], status=200)
+            json={}, status=200)
 
         response = self.client.get(
             self.endpoint_url,
         )
 
-        self.assertEqual(2, len(responses.calls))
+        self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
-        self.assertEqual(
-            self.info_url,
-            called.request.url)
-        self.assertEqual(
-            self.authorization, called.request.headers.get('Authorization'))
-        called = responses.calls[1]
         self.assertEqual(
             self.api_url,
             called.request.url)
@@ -92,4 +80,4 @@ class GetRevisionHistory(
         self.assertEqual(response.status_code, 200)
         self.assert_template_used('publisher/release-history.html')
         self.assert_context('snap_name', self.snap_name)
-        self.assert_context('revision_history', [])
+        self.assert_context('release_history', {})

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -25,6 +25,11 @@ DASHBOARD_API = os.getenv(
     'https://dashboard.snapcraft.io/dev/api/',
 )
 
+DASHBOARD_API_V2 = os.getenv(
+    'DASHBOARD_API_V2',
+    'https://dashboard.snapcraft.io/api/v2/'
+)
+
 SNAP_PUB_METRICS_URL = ''.join([
     DASHBOARD_API,
     'snaps/metrics',
@@ -68,6 +73,11 @@ REGISTER_NAME_URL = ''.join([
 REVISION_HISTORY_URL = ''.join([
     DASHBOARD_API,
     'snaps/{snap_id}/history'
+])
+
+SNAP_RELEASE_HISTORY_URL = ''.join([
+    DASHBOARD_API_V2,
+    'snaps/{snap_name}/releases?page=1&size=100'
 ])
 
 
@@ -298,6 +308,18 @@ def snap_screenshots(snap_id, session, data=None, files=None):
 def snap_revision_history(session, snap_id):
     response = api_session.get(
         url=REVISION_HISTORY_URL.format(snap_id=snap_id),
+        headers=get_authorization_header(session),
+    )
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired
+
+    return process_response(response)
+
+
+def snap_release_history(session, snap_name):
+    response = api_session.get(
+        url=SNAP_RELEASE_HISTORY_URL.format(snap_name=snap_name),
         headers=get_authorization_header(session),
     )
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -397,16 +397,8 @@ def post_listing_snap(snap_name):
 @publisher_snaps.route('/<snap_name>/release')
 @login_required
 def get_release_history(snap_name):
-    snap_id = ''
     try:
-        snap_id = api.get_snap_id(snap_name, flask.session)
-    except ApiResponseErrorList as api_response_error_list:
-        return _handle_error_list(api_response_error_list.errors)
-    except ApiError as api_error:
-        return _handle_errors(api_error)
-
-    try:
-        revision_history = api.snap_revision_history(flask.session, snap_id)
+        release_history = api.snap_release_history(flask.session, snap_name)
     except ApiResponseErrorList as api_response_error_list:
         return _handle_error_list(api_response_error_list.errors)
     except ApiError as api_error:
@@ -414,7 +406,7 @@ def get_release_history(snap_name):
 
     context = {
         'snap_name': snap_name,
-        'revision_history': revision_history,
+        'release_history': release_history,
         'release_ui_enabled': flask.current_app.config['RELEASE_UI_ENABLED']
     }
 


### PR DESCRIPTION
Fixes #968 

### QA
- ./run or demo
- Go to releases page of some snaps
- Everything should work as before
- You can compare with public view to see that same revisions are shown as released

Also test locally with RELEASE_UI_ENABLED flag turned off. You may compare with public view 