### PR TITLE
Hide public metrics on brand stores

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -187,7 +187,6 @@
     </div>
   {% endif %}
 
-
   {% if api_error %}
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
# Done

Don't show metrics on public brand store details pages.

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/core
- See the metrics
- Stop the app
- Change `.env` `WEBAPP=limenet`
- `./run`
- Visit http://0.0.0.0:8004/core
- Don't see the metrics