### PR TITLE
Add copydocs to build and blog pages

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -2,6 +2,7 @@
 
 {% block meta_title %}{{ article.title.rendered|safe }} | Snapcraft{% endblock %}
 {% block meta_description %}{{ article.excerpt.raw }}{% endblock %}
+{% block meta_copydoc %}{% endblock %}
 {% block meta_type %}article{% endblock %}
 {% if article.image and article.image.source_url %}
   {% block meta_image %}{{ article.image.source_url }}{% endblock %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -1,6 +1,7 @@
 {% extends webapp_config['LAYOUT'] %}
 
 {% block meta_title %}Blog | Snapcraft{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1YWhw_DlbXrq9CBUtMgjzlzZds0_m8xr-MZlXpXkMvIQ/edit{% endblock %}
 
 {% block content %}
 

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -1,5 +1,7 @@
 {% extends webapp_config['LAYOUT'] %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1EvemWJDOpjL-8ieCSiStKViFx-fgwfTaENueOYlB5ps/edit{% endblock %}
+
 {% block content %}
   <section id="main-content" class="p-strip is-bordered">
     <div class="row">


### PR DESCRIPTION
Adds a copy docs links to /build and /blog pages

### QA

- have a [ubuntu copy docs extension](https://github.com/canonical-webteam/ubuntu-copy-docs) installed in browser
- ./run or demo
- go to /build
- there should be correct link to build page copy doc
- go to /blog
- there should be correct link to blog page copy doc
- go to any blog article
- there should be no copy doc link (blog posts don't have copy docs)