### PR TITLE
Fix release date

### DIFF
--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 export default class RevisionsList extends Component {
   renderRows(revisions) {
     return revisions.map((revision) => {
-      const uploadDate = moment(revision.uploaded_at);
+      const uploadDate = moment(revision.created_at);
 
       return (
         <tr key={revision.revision}>


### PR DESCRIPTION
Fixes #1010

Uses correct revision date field when displaying list of releases.

### QA

- ./run or http://snapcraft.io-pr-1012.run.demo.haus/
- sign in to Developer account
- go to Releases page of any of your snap
- look at revisions date - correct dates should be shown instead of 'few seconds ago'

<img width="890" alt="screen shot 2018-08-10 at 20 23 43" src="https://user-images.githubusercontent.com/83575/43974581-4ea23c5c-9cdb-11e8-946a-3b77d793d02e.png">
