### PR TITLE
Cache blog api calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ requests==2.18.4
 requests-cache==0.4.13
 responses==0.9.0
 talisker==0.9.8
-Flask-Caching==1.4.0

--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -2,7 +2,7 @@ import responses
 import requests
 
 from webapp.app import create_app
-from webapp.extensions import cache
+from webapp import api
 from flask_testing import TestCase
 
 
@@ -21,7 +21,7 @@ class BlogPage(TestCase):
         return app
 
     def setUp(self):
-        cache.clear()
+        api.blog.api_session = api.requests.Session()
         self.api_url = 'https://admin.insights.ubuntu.com/wp-json/wp/v2'
 
     @responses.activate

--- a/webapp/api/blog.py
+++ b/webapp/api/blog.py
@@ -4,7 +4,7 @@ API_URL = 'https://admin.insights.ubuntu.com/wp-json/wp/v2'
 TAGS = [2996]  # 'snapcraft.io'
 
 
-api_session = api.requests.Session()
+api_session = api.requests.CachedSession(expire_after=300)
 
 
 def get_articles(tags=TAGS, per_page=12, page=1, exclude=None):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -12,7 +12,7 @@ import prometheus_flask_exporter
 import talisker.flask
 import webapp.helpers as helpers
 from webapp.blog.views import blog
-from webapp.extensions import cache, csrf, sentry
+from webapp.extensions import csrf, sentry
 from webapp.handlers import set_handlers
 from webapp.login.views import login
 from webapp.publisher.snaps.views import publisher_snaps
@@ -48,9 +48,6 @@ def create_app(testing=False):
         init_extensions(app)
 
     app.config.from_object('webapp.configs.' + app.config['WEBAPP'])
-    cache.init_app(app)
-    with app.app_context():
-        cache.clear()
 
     set_handlers(app)
 

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -3,7 +3,6 @@ import flask
 import webapp.api.blog as api
 from webapp.api.exceptions import ApiError
 from webapp.blog import logic
-from webapp.extensions import cache
 
 blog = flask.Blueprint(
     'blog', __name__,
@@ -11,7 +10,6 @@ blog = flask.Blueprint(
 
 
 @blog.route('/')
-@cache.cached(timeout=300)
 def homepage():
     page_param = flask.request.args.get('page', default=1, type=int)
 
@@ -46,7 +44,6 @@ def homepage():
 
 
 @blog.route('/feed')
-@cache.cached(timeout=300)
 def feed():
     try:
         feed = api.get_feed()
@@ -62,7 +59,6 @@ def feed():
 
 
 @blog.route('/<slug>')
-@cache.cached(timeout=300)
 def article(slug):
     try:
         articles = api.get_article(slug)

--- a/webapp/extensions.py
+++ b/webapp/extensions.py
@@ -1,8 +1,6 @@
 from flask_wtf.csrf import CSRFProtect
 from raven.contrib.flask import Sentry
-from flask_caching import Cache
 
 
 csrf = CSRFProtect()
 sentry = Sentry()
-cache = Cache(config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': 'cache.tmp'})


### PR DESCRIPTION
# Summary

Cache api calls in snapcraft's blog. Use our own caching system

# QA

- `./run`
- /blog
- make sure pages are cached