### PR TITLE
Default WEBAPP=snapcraft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:bionic
 
+# Set up environment
+ENV LANG C.UTF-8
+WORKDIR /srv
+
 # System dependencies
 RUN apt-get update && apt-get install --yes python3-pip libsodium-dev
 
-# Python dependencies
-ENV LANG C.UTF-8
-
 # Import code, install code dependencies
-WORKDIR /srv
 ADD . .
 RUN pip3 install -r requirements.txt
 
@@ -18,8 +18,7 @@ RUN echo "${COMMIT_ID}" > version-info.txt
 ENV COMMIT_ID "${COMMIT_ID}"
 
 # Set which webapp configuration to load
-ARG WEBAPP
-RUN test -n "${WEBAPP}"
+ARG WEBAPP=snapcraft
 ENV WEBAPP "${WEBAPP}"
 
 # Setup commands to run server


### PR DESCRIPTION
Currently, building the docker image for snapcraft.io requires that you provide `--env WEBAPP=snapcraft`.

Since this is the "snapcraft.io" repository, this shouldn't be the case. The app should just work for snapcraft.io, with customisations is necessary for the brand stores etc.

So here's I'm doing the quicked possible fix, to just default the `WEBAPP` environment variable to be `snapcraft`.

QA
--

``` bash
docker build --tag snapcraft --build-arg COMMIT_ID=`git rev-parse --short HEAD` .
docker run -ti -p 8099:80 snapcraft
```

Go to http://localhost:8099, and see that the site works.