### PR TITLE
Escape only html tags in description

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -1,6 +1,8 @@
-import bleach
 import re
+from html import escape
 from urllib.parse import parse_qs, urlparse
+
+import bleach
 
 
 def get_searched_snaps(search_results):
@@ -133,7 +135,7 @@ def split_description_into_paragraphs(unformatted_description):
         callbacks = bleach.linkifier.DEFAULT_CALLBACKS
         callbacks.append(external)
 
-        paragraph = bleach.clean(paragraph, tags=[])
+        paragraph = escape(paragraph)
         paragraph = bleach.linkify(paragraph, callbacks=callbacks)
 
         formatted_paragraphs.append(paragraph.replace('\n', '<br />'))


### PR DESCRIPTION
# Summary

Fixes #1021 
`bleach.clean` has a weird behaviour:
```python
from bleach import clean
clean("<IP-Address>") # OUTPUT '&lt;ip-address&gt;&lt;/ip-address&gt;'
```

We just want to escape the html tags, so instead I use the core library: `xml.sax.saxutils` to escape the <  and >

# QA

- `./run`
- http://localhost:8004/tvheadend
- Make sure in the description the tag `<IP-Adress>` is well displayed
- http://localhost:8004/tbmb-bsi-test-2
- Make sure links still work