### PR TITLE
Add blog posts to snap details pages

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -2,5 +2,6 @@ import map from './snap-details/map';
 import screenshots from './snap-details/screenshots';
 import channelMap from './snap-details/channelMap';
 import { storeCategories } from './store-categories';
+import { snapDetailsPosts } from './snap-details/blog-posts';
 
-export { map, screenshots, channelMap, storeCategories };
+export { map, screenshots, channelMap, storeCategories, snapDetailsPosts };

--- a/static/js/public/snap-details/blog-posts.js
+++ b/static/js/public/snap-details/blog-posts.js
@@ -1,0 +1,46 @@
+import 'whatwg-fetch';
+
+function snapDetailsPosts(holderSelector, templateSelector, showOnSuccessSelector) {
+  const URL = '/blog/api/snap-posts/';
+  const holder = document.querySelector(holderSelector);
+  const template = document.querySelector(templateSelector);
+  const showOnSuccess = document.querySelector(showOnSuccessSelector);
+
+  if (!holder) {
+    throw new Error('No holder element');
+  }
+  if (!template) {
+    throw new Error('No template');
+  }
+
+  const snap = holder.dataset.snap;
+  if (!snap) {
+    throw new Error('Snap not defined');
+  }
+
+  fetch(`${URL}${snap}`).then(response => response.json()).then(posts => {
+    if (posts.length === 0) {
+      return;
+    }
+    const postsHTML = [];
+    posts.forEach(post => {
+      let postHTML = template.innerHTML;
+      Object.keys(post).forEach(key => {
+        postHTML = postHTML.split('${' + key + '}').join(post[key]);
+      });
+      postsHTML.push(postHTML);
+    });
+
+    if (postsHTML.length > 0) {
+      holder.innerHTML = postsHTML.join('');
+    }
+
+    if (showOnSuccess) {
+      showOnSuccess.style.display = 'block';
+    }
+  }).catch(error => {
+    throw new Error(error.message);
+  });
+}
+
+export { snapDetailsPosts };

--- a/static/sass/_patterns_card.scss
+++ b/static/sass/_patterns_card.scss
@@ -49,12 +49,15 @@
       z-index: 1;
     }
 
-    > .p-card__content {
+    .p-card__header + .p-card__content {
       border-top: 1px dotted $color-mid-light;
+    }
+
+    .p-card__content {
       display: flex;
       flex-direction: column;
       height: 100%;
-      margin: 0 $sp-x-small;
+      margin: 0;
       padding: $sp-medium;
 
       > a,
@@ -62,6 +65,11 @@
       p {
         display: block;
         margin: $sp-x-small 0;
+      }
+
+      > *:last-child,
+      > *:first-child {
+        margin: 0;
       }
     }
 

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -21,24 +21,7 @@
       <div class="row u-equal-height u-clearfix">
     {% endif %}
 
-    <div class="col-4 p-card--post">
-      <div class="p-card__content">
-        {% if article.image and article.image.source_url %}
-          <div class="u-crop--16-9">
-            <a href="/blog/{{ article.slug }}">
-              <img src="{{ article.image.source_url }}" />
-            </a>
-          </div>
-        {% endif %}
-        <h3 class="p-heading--four">
-          <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
-        </h3>
-        <p><em>by {{ article.author.name }} on {{ article.date }}</em></p>
-        {% if not article.image %}
-          <p class="u-no-padding--bottom">{{ article.excerpt.raw }}</p>
-        {% endif %}
-      </div>
-    </div>
+    {% include 'partials/blog-card.html' %}
   {% endfor %}
   </div>
 

--- a/templates/partials/blog-card--minimal.html
+++ b/templates/partials/blog-card--minimal.html
@@ -1,0 +1,7 @@
+<div class="col-4 p-card--post">
+  <div class="p-card__content">
+    <h3 class="p-heading--four">
+      <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
+    </h3>
+  </div>
+</div>

--- a/templates/partials/blog-card.html
+++ b/templates/partials/blog-card.html
@@ -1,0 +1,18 @@
+<div class="col-4 p-card--post">
+  <div class="p-card__content">
+    {% if article.image and article.image.source_url %}
+      <div class="u-crop--16-9">
+        <a href="/blog/{{ article.slug }}">
+          <img src="{{ article.image.source_url }}" />
+        </a>
+      </div>
+    {% endif %}
+    <h3 class="p-heading--four">
+      <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
+    </h3>
+    <p><em>by {{ article.author.name }} on {{ article.date }}</em></p>
+    {% if not article.image %}
+      <p class="u-no-padding--bottom">{{ article.excerpt.raw }}</p>
+    {% endif %}
+  </div>
+</div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -160,7 +160,7 @@
       </div>
       <div class="row u-equal-height">
         {% for article in blog_articles %}
-          {% include 'partials/blog-card.html' %}
+          {% include 'partials/blog-card--minimal.html' %}
         {% endfor %}
       </div>
     </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -148,7 +148,7 @@
     </div>
   </div>
 
-  {% if blog_articles %}
+  <div data-js="blog-articles" style="display: none;">
     <div class="row">
       <div class="col-12">
         <hr />
@@ -158,14 +158,13 @@
       <div class="row">
         <h4>Related blog posts</h4>
       </div>
-      <div class="row u-equal-height">
-        {% for article in blog_articles %}
-          {% include 'partials/blog-card--minimal.html' %}
-        {% endfor %}
+      <div class="row u-equal-height" data-js="blog-article-list" data-snap="{{ package_name }}">
       </div>
     </div>
-  {% endif %}
-
+  </div>
+  {% set article_title = {'rendered': '${title}'} %}
+  {% set article = {'slug': '${slug}', 'title': article_title} %}
+  <script type="text/template" id="blog-article-template">{% include 'partials/blog-card--minimal.html' %}</script>
   {% if countries or normalized_os %}
     <div class="row">
       <div class="col-12">
@@ -231,6 +230,12 @@
     Raven.context(function () {
       try {
         snapcraft.public.screenshots('#js-snap-screenshots');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      try {
+        snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
       } catch(e) {
         Raven.captureException(e);
       }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -148,6 +148,24 @@
     </div>
   </div>
 
+  {% if blog_articles %}
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
+    </div>
+    <div class="p-strip is-shallow">
+      <div class="row">
+        <h4>Related blog posts</h4>
+      </div>
+      <div class="row u-equal-height">
+        {% for article in blog_articles %}
+          {% include 'partials/blog-card.html' %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+
   {% if countries or normalized_os %}
     <div class="row">
       <div class="col-12">
@@ -188,15 +206,15 @@
   {% endif %}
 
   {% if api_error %}
-  <div class="row">
-    <div class="col-12">
-      <div class="p-notification--negative">
-        <p class="p-notification__response">
-          <span class="p-notification__status">Error:</span> API request failed
-        </p>
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification--negative">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> API request failed
+          </p>
+        </div>
       </div>
     </div>
-  </div>
   {% endif %}
 {% endblock %}
 

--- a/webapp/api/blog.py
+++ b/webapp/api/blog.py
@@ -45,6 +45,18 @@ def get_article(slug):
     return response.json()
 
 
+def get_tag(name):
+    url = ''.join([
+        API_URL,
+        '/tags?search=',
+        name
+    ])
+
+    response = api_session.get(url)
+
+    return response.json()
+
+
 def get_media(media_id):
     url = ''.join([API_URL, '/media/', str(media_id)])
     response = api_session.get(url)

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -68,3 +68,16 @@ def change_url(feed, host):
     updated_feed = re.sub(url_regex, host, feed)
 
     return updated_feed
+
+
+def get_tag_id_list(tags):
+    """Get a list of tag ids from a list of tag dicts
+
+    :param tags: Tag dict
+
+    :returns: A list of ids
+    """
+    def get_id(tag):
+        return tag['id']
+
+    return [get_id(tag) for tag in tags]

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -99,3 +99,36 @@ def article(slug):
     return flask.render_template(
         'blog/article.html',
         **context)
+
+
+@blog.route('/api/snap-posts/<snap>')
+def snap_posts(snap):
+    try:
+        blog_tags = api.get_tag(''.join(['sc:snap:', snap]))
+    except ApiError:
+        blog_tags = None
+
+    blog_articles = None
+    articles = []
+
+    if blog_tags:
+        blog_tags_ids = logic.get_tag_id_list(blog_tags)
+        try:
+            blog_articles, total_pages = api.get_articles(
+                blog_tags_ids,
+                3
+            )
+        except ApiError:
+            blog_articles = None
+
+        for article in blog_articles:
+            transformed_article = logic.transform_article(
+                article,
+                featured_image=None,
+                author=None)
+            articles.append({
+                'slug': transformed_article['slug'],
+                'title': transformed_article['title']['rendered']
+            })
+
+    return flask.jsonify(articles)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -4,8 +4,6 @@ import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
 from webapp.api.store import StoreApi
 import webapp.store.logic as logic
-import webapp.api.blog as blog_api
-import webapp.blog.logic as blog_logic
 from dateutil import parser
 from math import floor
 from webapp.api.exceptions import (
@@ -278,29 +276,6 @@ def store_blueprint(store_query=None):
         if not details.get('channel-map'):
             flask.abort(404, 'No snap named {}'.format(snap_name))
 
-        try:
-            blog_tags = blog_api.get_tag(''.join(['sc:snap:', snap_name]))
-        except ApiError:
-            blog_tags = None
-
-        blog_articles = None
-
-        if blog_tags:
-            blog_tags_ids = blog_logic.get_tag_id_list(blog_tags)
-            try:
-                blog_articles, total_pages = blog_api.get_articles(
-                    blog_tags_ids,
-                    3
-                )
-            except ApiError:
-                blog_articles = None
-
-            for article in blog_articles:
-                article = blog_logic.transform_article(
-                    article,
-                    featured_image=None,
-                    author=None)
-
         formatted_paragraphs = logic.split_description_into_paragraphs(
             details['snap']['description'])
 
@@ -408,7 +383,6 @@ def store_blueprint(store_query=None):
             'default_track': default_track,
             'lowest_risk_available': lowest_risk_available,
             'confinement': confinement,
-            'blog_articles': blog_articles,
 
             # Transformed API data
             'filesize': humanize.naturalsize(binary_filesize),

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -4,6 +4,8 @@ import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
 from webapp.api.store import StoreApi
 import webapp.store.logic as logic
+import webapp.api.blog as blog_api
+import webapp.blog.logic as blog_logic
 from dateutil import parser
 from math import floor
 from webapp.api.exceptions import (
@@ -276,6 +278,41 @@ def store_blueprint(store_query=None):
         if not details.get('channel-map'):
             flask.abort(404, 'No snap named {}'.format(snap_name))
 
+        try:
+            blog_tags = blog_api.get_tag(''.join(['sc:snap:', snap_name]))
+        except ApiError:
+            blog_tags = None
+
+        blog_articles = None
+
+        if blog_tags:
+            blog_tags_ids = blog_logic.get_tag_id_list(blog_tags)
+            try:
+                blog_articles, total_pages = blog_api.get_articles(
+                    blog_tags_ids,
+                    3
+                )
+            except ApiError:
+                blog_articles = None
+
+            for article in blog_articles:
+                try:
+                    featured_image = blog_api.get_media(
+                        article['featured_media']
+                    )
+                except ApiError:
+                    featured_image = None
+
+                try:
+                    author = blog_api.get_user(article['author'])
+                except ApiError:
+                    author = None
+
+                article = blog_logic.transform_article(
+                    article,
+                    featured_image=featured_image,
+                    author=author)
+
         formatted_paragraphs = logic.split_description_into_paragraphs(
             details['snap']['description'])
 
@@ -383,6 +420,7 @@ def store_blueprint(store_query=None):
             'default_track': default_track,
             'lowest_risk_available': lowest_risk_available,
             'confinement': confinement,
+            'blog_articles': blog_articles,
 
             # Transformed API data
             'filesize': humanize.naturalsize(binary_filesize),

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -296,22 +296,10 @@ def store_blueprint(store_query=None):
                 blog_articles = None
 
             for article in blog_articles:
-                try:
-                    featured_image = blog_api.get_media(
-                        article['featured_media']
-                    )
-                except ApiError:
-                    featured_image = None
-
-                try:
-                    author = blog_api.get_user(article['author'])
-                except ApiError:
-                    author = None
-
                 article = blog_logic.transform_article(
                     article,
-                    featured_image=featured_image,
-                    author=author)
+                    featured_image=None,
+                    author=None)
 
         formatted_paragraphs = logic.split_description_into_paragraphs(
             details['snap']['description'])


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1025 and https://github.com/canonical-websites/snapcraft.io/issues/1030

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store
- Open a few snaps from that page, some will have blog posts, others won't
- Give feedback

# Screenshots (and related issues)
## 1 post
![screenshot_2018-08-21 install discord for linux linux apps in seconds snap store](https://user-images.githubusercontent.com/479384/44390139-7d09cc80-a524-11e8-9c4b-500794cd4aea.png)
Waste of space

## 2 posts
![screenshot_2018-08-21 install skype for linux linux apps in seconds snap store](https://user-images.githubusercontent.com/479384/44390141-7d09cc80-a524-11e8-880a-b773faf5ad1e.png)
Not the worse

## Short description and screenshots
![screenshot_2018-08-21 install zenkit for linux linux apps in seconds snap store](https://user-images.githubusercontent.com/479384/44390144-7da26300-a524-11e8-82d4-266daec0a4b8.png)
Description gets lost
