### PR TITLE
Fix talisker entrypoint

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,5 +2,9 @@
 
 set -e
 
-talisker.gunicorn.gevent webapp.app:create_app\(\) --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1
+if ${FLASK_DEBUG}; then
+    talisker.gunicorn.gevent webapp.app:create_app\(\) --reload --log-level debug --timeout 9999 --worker-class gevent --bind $1
+else
+    talisker.gunicorn.gevent webapp.app:create_app\(\) --worker-class gevent --name talisker-`hostname`
+fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,6 @@ raven[flask]==6.5.0
 requests==2.18.4
 requests-cache==0.4.13
 responses==0.9.0
-talisker==0.9.8
+gunicorn[gevent]
+statsd<3.3.0
+talisker==0.9.14


### PR DESCRIPTION
- Use statsd < 3.3 (fixes https://github.com/canonical-websites/snapcraft.io/issues/1042)
- Only use Talisker development settings in development

QA
--

``` bash
./run
```

Go to http://127.0.0.1:8004, check it works.

``` bash
docker build --tag snapcraft --build-arg COMMIT_ID=`git rev-parse --short HEAD` .
docker run -ti -p 8904:80 snapcraft
```

Go to http://0.0.0.0:8904/, check it works.