### PR TITLE
Fix entrypoint logic

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,9 +2,11 @@
 
 set -e
 
-if ${FLASK_DEBUG}; then
-    talisker.gunicorn.gevent webapp.app:create_app\(\) --reload --log-level debug --timeout 9999 --worker-class gevent --bind $1
-else
-    talisker.gunicorn.gevent webapp.app:create_app\(\) --worker-class gevent --name talisker-`hostname`
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --name talisker-`hostname`"
+
+if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
+    RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"
 fi
+
+${RUN_COMMAND}
 


### PR DESCRIPTION
We had a problem that when FLASK_DEBUG was unset, `if ${FLASK_DEBUG}` would evaluate to true.

I've fixed this by using the better syntax of `if [ "${FLASK_DEBUG}" = true ]`. For discussion see https://stackoverflow.com/questions/2953646/how-to-declare-and-use-boolean-variables-in-shell-script.

I've also added a "RUN_COMMAND" variable so we can more clearly show the difference between development and production settings.

QA
--

First, edit `./entrypoint`, and change the line `set -e` to `set -ex`, so we can see what command is being run.

**Test with FLASK_DEBUG=true**

`./run --env FLASK_DEBUG=true`, or simply `./run`, and check you see the development command in the output:

```
$ ./run --env FLASK_DEBUG=true
...
+ '[' true = true ']'
+ talisker.gunicorn.gevent 'webapp.app:create_app()' --worker-class gevent --name talisker-26e29979dbe8 --bind 0.0.0.0:8004 --reload --log-level debug --timeout 9999
```

And that you can access the site on http://0.0.0.0:8004/.

**Test without FLASK_DEBUG=true**

Try with:

- `./run --env FLASK_DEBUG=false`
- `./run --env FLASK_DEBUG=nonsense`
- `./run --env FLASK_DEBUG=`

In all cases, check you see the command *without* `--reload --log-level debug --timeout 9999`:

```
+ talisker.gunicorn.gevent 'webapp.app:create_app()' --worker-class gevent --name talisker-6b9b5ac419cc --bind 0.0.0.0:8004
```

And the site still runs on http://0.0.0.0:8004/.

**Test with Dockerfile**

Now build and run the image:

```
docker build --tag snapcraft --build-arg COMMIT_ID=`git rev-parse --short HEAD` .
docker run -ti -p 8904:80 snapcraft
```

Check you see the command *without* `--reload --log-level debug --timeout 9999`:

```
+ talisker.gunicorn.gevent 'webapp.app:create_app()' --worker-class gevent --name talisker-6b9b5ac419cc --bind 0.0.0.0:80
```

And that the site runs on http://localhost:8904.