### PR TITLE
On map error, throw a useful error

### DIFF
--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -108,7 +108,11 @@ export default function renderMap(el, snapData) {
   function ready(error, world) {
     if (error) {
       // let sentry catch it, so we get notified why it fails
-      throw error;
+      if (error instanceof ProgressEvent) {
+        throw new Error(`${error.target.status}: ${error.target.statusText} (${error.target.responseURL})`);
+      } else {
+        throw new Error(error);
+      }
     }
 
     render(mapEl, snapData, world);


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1029

# QA

- To force the most likely error that occurs:
  - Pull the branch
  - Change `static/js/public/snap-details/map.js:9` to a json file that doesn't exist
  - `./run`
  - Visit http://0.0.0.0:8004/vscode with the console open
  - See a useful error