### PR TITLE
Fail fast on not having d3 defined

### DIFF
--- a/static/js/public/snap-details/map.js
+++ b/static/js/public/snap-details/map.js
@@ -3,6 +3,10 @@
 import SnapEvents from '../../libs/events';
 
 export default function renderMap(el, snapData) {
+  // Fail fast
+  if (!d3) {
+    return;
+  }
   const mapEl = d3.select(el);
 
   d3.queue()


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1028, hopefully

There's no easy way to reproduce there's no way I've found to reproduce this issue, even with the d3 script removed from the HTML it works as expected. This will hopefully mitigate some of the errors we've been receiving.