### PR TITLE
Get channel maps data into releases template

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -5,7 +5,7 @@ import RevisionsList from './release/revisionsList';
 import RevisionsTable from './release/revisionsTable';
 
 
-const initReleases = (id, data, options) => {
+const initReleases = (id, data, channelMaps, options) => {
 
   // init channel data in revisions list
   const revisionsMap = {};

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -24,8 +24,10 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
 {% block scripts %}
   <script src="{{ static_url('js/dist/release.js') }}"></script>
   <script>
-    snapcraft.release.initReleases('#release-history', {{ release_history|tojson }}, {
-      releaseUiEnabled: {{ release_ui_enabled|tojson }}
+    snapcraft.release.initReleases('#release-history',
+      {{ release_history|tojson }},
+      {{ channel_maps_list|tojson }},
+      { releaseUiEnabled: {{ release_ui_enabled|tojson }}
     });
   </script>
 {% endblock %}

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -61,6 +61,20 @@ class GetRevisionHistory(
 
     @responses.activate
     def test_get_revision(self):
+        info_url = 'https://dashboard.snapcraft.io/dev/api/snaps/info/{}'
+        self.info_url = info_url.format(
+            self.snap_name
+        )
+
+        payload = {
+            'snap_id': 'id',
+            'title': 'Test Snap'
+        }
+
+        responses.add(
+            responses.GET, self.info_url,
+            json=payload, status=200)
+
         responses.add(
             responses.GET, self.api_url,
             json={}, status=200)
@@ -69,14 +83,19 @@ class GetRevisionHistory(
             self.endpoint_url,
         )
 
-        self.assertEqual(1, len(responses.calls))
+        self.assertEqual(2, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(
             self.api_url,
             called.request.url)
         self.assertEqual(
             self.authorization, called.request.headers.get('Authorization'))
-
+        called = responses.calls[1]
+        self.assertEqual(
+            self.info_url,
+            called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get('Authorization'))
         self.assertEqual(response.status_code, 200)
         self.assert_template_used('publisher/release-history.html')
         self.assert_context('snap_name', self.snap_name)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -404,9 +404,20 @@ def get_release_history(snap_name):
     except ApiError as api_error:
         return _handle_errors(api_error)
 
+    try:
+        info = api.get_snap_info(snap_name, flask.session)
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, 'No snap named {}'.format(snap_name))
+        else:
+            return _handle_error_list(api_response_error_list.errors)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
     context = {
         'snap_name': snap_name,
         'release_history': release_history,
+        'channel_maps_list': info.get('channel_maps_list'),
         'release_ui_enabled': flask.current_app.config['RELEASE_UI_ENABLED']
     }
 


### PR DESCRIPTION
Fixes #946

Gets `channel_maps_list` data from published info api to releases page, so we could use it to accurately build releases matrix.

### QA

- ./run or http://snapcraft.io-pr-1048.run.demo.haus/
- go to Releases page of any snap
- View source, see if channel map data is passed to `initReleases` JS function on the page.