### PR TITLE
Use real channel map data

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -31,9 +31,10 @@ const initReleases = (id, data, channelMaps, options) => {
     }
   });
 
+  data.revisionsMap = revisionsMap;
   ReactDOM.render(
     <Fragment>
-      <RevisionsTable revisions={data.revisions} options={options}/>
+      <RevisionsTable data={data} channelMaps={channelMaps} options={options}/>
       <RevisionsList revisions={data.revisions} />
     </Fragment>,
     document.querySelector(id)

--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -5,17 +5,80 @@ import RevisionsList from './release/revisionsList';
 import RevisionsTable from './release/revisionsTable';
 
 
-const initReleases = (id, data, channelMaps, options) => {
+// getting list of tracks names from channel maps list
+function getTracksFromChannelMap(channelMapsList) {
+  const tracks = ['latest'];
+
+  channelMapsList.map(t => t.track).forEach(track => {
+    // if we haven't saved it yet
+    if (tracks.indexOf(track) === -1) {
+      tracks.push(track);
+    }
+  });
+
+  return tracks;
+}
+
+// getting list of tracks names from channel maps list
+function getArchsFromChannelMap(channelMapsList) {
+  const archs = [];
+
+  channelMapsList.map(a => a.architecture).forEach(arch => {
+    // if we haven't saved it yet
+    if (archs.indexOf(arch) === -1) {
+      archs.push(arch);
+    }
+  });
+
+  return archs.sort();
+}
+
+// transforming channel map list data into format used by this component
+function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
+  const releasedChannels = {};
+  const releasedArchs = {};
+
+  channelMapsList.forEach((mapInfo) => {
+    const { track, architecture, map } = mapInfo;
+    map.forEach((channelInfo) => {
+      if (channelInfo.info === 'released') {
+        const channel = track === 'latest' ? `${track}/${channelInfo.channel}` : channelInfo.channel;
+
+        if (!releasedChannels[channel]) {
+          releasedChannels[channel] = {};
+        }
+
+        // XXX bartaz
+        // this may possibly lead to issues with revisions in multiple architectures
+        // if we have data about given revision in revision history we can store it
+        if (revisionsMap[channelInfo.revision]) {
+          releasedChannels[channel][architecture] = revisionsMap[channelInfo.revision];
+        // but if for some reason we don't have full data about revision in channel map
+        // we need to ducktype it from channel info
+        } else {
+          releasedChannels[channel][architecture] = channelInfo;
+          releasedChannels[channel][architecture].architectures = [ architecture ];
+        }
+
+        releasedArchs[architecture] = true;
+      }
+    });
+  });
+
+  return releasedChannels;
+}
+
+const initReleases = (id, releasesData, channelMapsList, options) => {
 
   // init channel data in revisions list
   const revisionsMap = {};
-  data.revisions.forEach(rev => {
+  releasesData.revisions.forEach(rev => {
     rev.channels = [];
     revisionsMap[rev.revision] = rev;
   });
 
   // go through releases from older to newest
-  data.releases.slice().reverse().forEach(release => {
+  releasesData.releases.slice().reverse().forEach(release => {
     if (release.revision) {
       const rev = revisionsMap[release.revision];
 
@@ -31,11 +94,14 @@ const initReleases = (id, data, channelMaps, options) => {
     }
   });
 
-  data.revisionsMap = revisionsMap;
+  const releasedChannels = getReleaseDataFromChannelMap(channelMapsList, revisionsMap);
+  const tracks = getTracksFromChannelMap(channelMapsList);
+  const archs = getArchsFromChannelMap(channelMapsList);
+
   ReactDOM.render(
     <Fragment>
-      <RevisionsTable data={data} channelMaps={channelMaps} options={options}/>
-      <RevisionsList revisions={data.revisions} />
+      <RevisionsTable releasedChannels={releasedChannels} tracks={tracks} archs={archs} options={options} />
+      <RevisionsList revisions={releasesData.revisions} />
     </Fragment>,
     document.querySelector(id)
   );


### PR DESCRIPTION
Fixes #947 

Updates release UI to use channel map data from API instead of (mis)calculating it from incomplete release history.

###  QA

- ./run or http://snapcraft.io-pr-1053.run.demo.haus/
- go to release page of some snaps (some with many releases, different tracks)
- make sure channel map shows correct versions (compare with details page channel map)
- make sure release UI prototype buttons (promote, cancel) still work