### PR TITLE
Add release post endpoint

### DIFF
--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -97,6 +97,7 @@ class BaseTestCases:
             method_endpoint="GET",
             method_api="GET",
             data=None,
+            json=None,
         ):
 
             super().setUp(
@@ -106,6 +107,7 @@ class BaseTestCases:
             self.method_endpoint = method_endpoint
             self.method_api = method_api
             self.data = data
+            self.json = json
             self.authorization = self._log_in(self.client)
 
         @responses.activate
@@ -122,7 +124,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -146,7 +155,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -169,7 +185,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -193,7 +216,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -224,7 +254,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(
@@ -251,7 +288,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -281,7 +325,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -313,7 +364,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)
@@ -345,7 +403,14 @@ class BaseTestCases:
             if self.method_endpoint == "GET":
                 response = self.client.get(self.endpoint_url)
             else:
-                response = self.client.post(self.endpoint_url, data=self.data)
+                if self.data:
+                    response = self.client.post(
+                        self.endpoint_url, data=self.data
+                    )
+                else:
+                    response = self.client.post(
+                        self.endpoint_url, json=self.json
+                    )
 
             called = responses.calls[len(responses.calls) - 1]
             self.assertEqual(self.api_url, called.request.url)

--- a/tests/publisher/snaps/tests_post_release.py
+++ b/tests/publisher/snaps/tests_post_release.py
@@ -1,0 +1,117 @@
+import responses
+
+from tests.publisher.endpoint_testing import BaseTestCases
+
+
+class PostReleasePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = "/account/snaps/{}/release".format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url,
+            method_endpoint="POST",
+        )
+
+
+class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = "/account/snaps/{}/release".format(snap_name)
+        api_url = "https://dashboard.snapcraft.io/dev/api/snap-release/"
+
+        super().setUp(
+            snap_name=snap_name,
+            api_url=api_url,
+            endpoint_url=endpoint_url,
+            method_api="POST",
+            method_endpoint="POST",
+            json={"json": "josn"},
+        )
+
+    @responses.activate
+    def test_page_not_found(self):
+        payload = {"error_list": []}
+        responses.add(responses.POST, self.api_url, json=payload, status=404)
+
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "name": self.snap_name,
+                "revision": "1",
+                "channels": ["stable"],
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        assert response.status_code == 404
+        self.assert_template_used("404.html")
+
+    @responses.activate
+    def test_post_no_data(self):
+        response = self.client.post(self.endpoint_url)
+
+        assert response.status_code == 200
+        assert response.get_json() == {}
+
+    @responses.activate
+    def test_post_data(self):
+        payload = {
+            "success": True,
+            "channel_map": [
+                {
+                    "info": "specific",
+                    "version": "2.7",
+                    "channel": "stable",
+                    "revision": 1,
+                },
+                {"info": "none", "channel": "candidate"},
+                {"info": "tracking", "channel": "beta"},
+                {"info": "tracking", "channel": "edge"},
+            ],
+            "opened_channels": ["candidate"],
+        }
+
+        responses.add(responses.POST, self.api_url, json=payload, status=200)
+
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "name": self.snap_name,
+                "revision": "1",
+                "channels": ["stable"],
+            },
+        )
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        assert response.json == payload
+
+    @responses.activate
+    def test_return_error(self):
+        payload = {"success": False, "errors": [{"name": ["message"]}]}
+
+        responses.add(responses.POST, self.api_url, json=payload, status=400)
+
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "name": self.snap_name,
+                "revision": "1",
+                "channels": ["stable"],
+            },
+        )
+
+        assert response.json == payload

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -58,6 +58,9 @@ SNAP_RELEASE_HISTORY_URL = "".join(
 )
 
 
+SNAP_RELEASE = "".join([DASHBOARD_API, "snap-release/"])
+
+
 def process_response(response):
     try:
         body = response.json()
@@ -81,7 +84,7 @@ def process_response(response):
                 response.status_code,
                 body["error_list"],
             )
-        else:
+        elif not body:
             raise ApiResponseError(
                 "Unknown error from api", response.status_code
             )
@@ -276,6 +279,17 @@ def snap_release_history(session, snap_name):
     response = api_session.get(
         url=SNAP_RELEASE_HISTORY_URL.format(snap_name=snap_name),
         headers=get_authorization_header(session),
+    )
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired
+
+    return process_response(response)
+
+
+def post_snap_release(session, snap_name, json):
+    response = api_session.post(
+        url=SNAP_RELEASE, headers=get_authorization_header(session), json=json
     )
 
     if authentication.is_macaroon_expired(response.headers):

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -425,3 +425,22 @@ def get_release_history(snap_name):
     }
 
     return flask.render_template("publisher/release-history.html", **context)
+
+
+@publisher_snaps.route("/<snap_name>/release", methods=["POST"])
+@login_required
+def post_release(snap_name):
+    data = flask.request.json
+
+    if not data:
+        return flask.jsonify({})
+
+    try:
+        response = api.post_snap_release(flask.session, snap_name, data)
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    return flask.jsonify(response)


### PR DESCRIPTION
# Summary
Fixes #948 
Add post release endpoint
I had to adapt the BaseTests to be able to have some api style endpoints

# QA

@bartaz you can try to rebase your [PR](https://github.com/canonical-websites/snapcraft.io/pull/1059) on this to try the data you are posting
It uses and returns the same info that the api: https://dashboard.snapcraft.io/docs/api/snap.html#release-a-snap-build-to-a-channel