### PR TITLE
Use licenses from spdx github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ env[23]/
 static/js/modules
 static/js/dist
 cache.tmp/
+webapp/licenses.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test-js": "jest",
     "test-js-all": "yarn run lint-js && yarn run test-js",
     "test-python": "python3 -m unittest discover tests",
-    "build": "yarn run build-js && yarn run build-css",
+    "get-licenses": "curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json -o webapp/licenses.json",
+    "build": "yarn run get-licenses && yarn run build-js && yarn run build-css",
     "build-css": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css'",
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",
     "copy-3rd-party-js": "cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/billboard.js/dist/billboard.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
@@ -16,7 +17,7 @@
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp"
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp webapp/licenses.json"
   },
   "husky": {
     "hooks": {

--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -70,6 +70,18 @@ class BaseTestCases:
                 root.serialize(), discharge.serialize()
             )
 
+        def check_call_by_api_url(self, calls):
+            found = False
+            for called in calls:
+                if self.api_url == called.request.url:
+                    found = True
+                    self.assertEqual(
+                        self.authorization,
+                        called.request.headers.get("Authorization"),
+                    )
+
+            assert found
+
     class EndpointLoggedOut(BaseAppTesting):
         def setUp(self, snap_name, endpoint_url, method_endpoint="GET"):
 
@@ -124,11 +136,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             assert response.status_code == 504
 
@@ -148,11 +156,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             assert response.status_code == 502
 
@@ -171,11 +175,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             assert response.status_code == 502
 
@@ -195,11 +195,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             assert response.status_code == 502
 
@@ -253,11 +249,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             assert response.status_code == 502
 
@@ -283,11 +275,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             assert response.status_code == 502
 
@@ -315,11 +303,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             self.assertEqual(302, response.status_code)
             self.assertEqual(
@@ -347,11 +331,7 @@ class BaseTestCases:
             else:
                 response = self.client.post(self.endpoint_url, data=self.data)
 
-            called = responses.calls[len(responses.calls) - 1]
-            self.assertEqual(self.api_url, called.request.url)
-            self.assertEqual(
-                self.authorization, called.request.headers.get("Authorization")
-            )
+            self.check_call_by_api_url(responses.calls)
 
             self.assertEqual(302, response.status_code)
             self.assertEqual(

--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -35,12 +35,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(self.api_url, called.request.url)
-        self.assertEqual(
-            self.authorization, called.request.headers.get("Authorization")
-        )
+        self.check_call_by_api_url(responses.calls)
 
         assert response.status_code == 404
         self.assert_template_used("404.html")
@@ -70,12 +65,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(self.api_url, called.request.url)
-        self.assertEqual(
-            self.authorization, called.request.headers.get("Authorization")
-        )
+        self.check_call_by_api_url(responses.calls)
 
         assert response.status_code == 200
         self.assert_template_used("publisher/listing.html")
@@ -118,12 +108,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(self.api_url, called.request.url)
-        self.assertEqual(
-            self.authorization, called.request.headers.get("Authorization")
-        )
+        self.check_call_by_api_url(responses.calls)
 
         assert response.status_code == 200
         self.assert_template_used("publisher/listing.html")
@@ -153,12 +138,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         response = self.client.get(self.endpoint_url)
 
-        self.assertEqual(1, len(responses.calls))
-        called = responses.calls[0]
-        self.assertEqual(self.api_url, called.request.url)
-        self.assertEqual(
-            self.authorization, called.request.headers.get("Authorization")
-        )
+        self.check_call_by_api_url(responses.calls)
 
         assert response.status_code == 200
         self.assert_template_used("publisher/listing.html")

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -1,3 +1,5 @@
+import json
+
 from werkzeug.routing import BaseConverter
 
 
@@ -5,3 +7,13 @@ class RegexConverter(BaseConverter):
     def __init__(self, url_map, *items):
         super(RegexConverter, self).__init__(url_map)
         self.regex = items[0]
+
+
+def get_licenses():
+    try:
+        with open("webapp/licenses.json") as f:
+            licenses = json.load(f)
+    except Exception:
+        licenses = {}
+
+    return licenses

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1,5 +1,6 @@
 import flask
 from webapp import authentication
+from webapp.helpers import get_licenses
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
 import webapp.api.dashboard as api
@@ -212,6 +213,8 @@ def get_listing_snap(snap_name):
         m["url"] for m in snap_details["media"] if m["type"] == "screenshot"
     ]
 
+    licenses = get_licenses()
+
     context = {
         "snap_id": snap_details["snap_id"],
         "snap_name": snap_details["snap_name"],
@@ -228,6 +231,7 @@ def get_listing_snap(snap_name):
         "public_metrics_enabled": snap_details["public_metrics_enabled"],
         "public_metrics_blacklist": snap_details["public_metrics_blacklist"],
         "is_on_stable": is_on_stable,
+        "licenses": licenses,
     }
 
     return flask.render_template("publisher/listing.html", **context)


### PR DESCRIPTION
# Summary

Fixes #1031
We are getting the licenses from this file to always get the last licenses updates: https://github.com/spdx/license-list-data/blob/master/json/licenses.json

- First commit is a little improvement for my tests.
- The file is fetched at build time (`yarn build`)

# QA

For now I am just giving the licenses to the frontend, so you can check that the array is well passed to the frontend (by just displaying it for now)