### PR TITLE
Only initialize blog series if element is present

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -97,15 +97,23 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ static_url('js/dist/public.js') }}"></script>
-  <script>
-    Raven.context(function () {
-      try {
-        snapcraft.public.seriesPosts('[data-js="blog-series"]', '#blog-series-item-template');
-      } catch(e) {
-        console.error(e);
-        Raven.captureException(e);
-      }
-    });
-  </script>
+  {% set hasScript = false %}
+  {% for tag in tags %}
+    {% if not hasScript %}
+      {% if tag.name.startswith('sc:series') %}
+        <script src="{{ static_url('js/dist/public.js') }}"></script>
+        <script>
+          Raven.context(function () {
+            try {
+              snapcraft.public.seriesPosts('[data-js="blog-series"]', '#blog-series-item-template');
+            } catch(e) {
+              console.error(e);
+              Raven.captureException(e);
+            }
+          });
+        </script>
+        {% set hasScript = true %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
 {% endblock %}

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -46,18 +46,20 @@
       <p>by {{ article.author.name }} on {{ article.date }}</p>
       {{ article.content.rendered|safe }}
     </div>
-    {% for tag in tags %}
-      {% if tag.name.startswith('sc:series') %}
-        <div class="col-4 prefix-1 p-blog-aside">
-          <h4>In this series</h4>
-          <ul class="p-list p-blog-list" data-js="blog-series" data-series="{{ tag.id }}" data-currentslug="{{ article.slug }}">
-            <li class="p-list__item u-align--center">
-              <i class="p-icon--spinner u-animation--spin"></i>
-            </li>
-          </ul>
-        </div>
-      {% endif %}
-    {% endfor %}
+    {% if is_in_series %}
+      {% for tag in tags %}
+        {% if tag.name.startswith('sc:series') %}
+          <div class="col-4 prefix-1 p-blog-aside">
+            <h4>In this series</h4>
+            <ul class="p-list p-blog-list" data-js="blog-series" data-series="{{ tag.id }}" data-currentslug="{{ article.slug }}">
+              <li class="p-list__item u-align--center">
+                <i class="p-icon--spinner u-animation--spin"></i>
+              </li>
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   </div>
 </section>
 
@@ -97,23 +99,17 @@
 {% endblock %}
 
 {% block scripts %}
-  {% set hasScript = false %}
-  {% for tag in tags %}
-    {% if not hasScript %}
-      {% if tag.name.startswith('sc:series') %}
-        <script src="{{ static_url('js/dist/public.js') }}"></script>
-        <script>
-          Raven.context(function () {
-            try {
-              snapcraft.public.seriesPosts('[data-js="blog-series"]', '#blog-series-item-template');
-            } catch(e) {
-              console.error(e);
-              Raven.captureException(e);
-            }
-          });
-        </script>
-        {% set hasScript = true %}
-      {% endif %}
-    {% endif %}
-  {% endfor %}
+  {% if is_in_series %}
+    <script src="{{ static_url('js/dist/public.js') }}"></script>
+    <script>
+      Raven.context(function () {
+        try {
+          snapcraft.public.seriesPosts('[data-js="blog-series"]', '#blog-series-item-template');
+        } catch(e) {
+          console.error(e);
+          Raven.captureException(e);
+        }
+      });
+    </script>
+  {% endif %}
 {% endblock %}

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -81,3 +81,17 @@ def get_tag_id_list(tags):
         return tag['id']
 
     return [get_id(tag) for tag in tags]
+
+
+def is_in_series(tags):
+    """Does the list of tags include a tag that starts 'sc:series'
+
+    :param tags: Tag dict
+
+    :returns: Boolean
+    """
+    for tag in tags:
+        if tag['name'].startswith('sc:series'):
+            return True
+
+    return False

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -91,6 +91,8 @@ def article(slug):
                 'name': tag['name']
             })
 
+    is_in_series = logic.is_in_series(tag_names)
+
     try:
         related_articles, total_pages = api.get_articles(
             tags=tags,
@@ -106,7 +108,8 @@ def article(slug):
     context = {
         'article': transformed_article,
         'related_articles': related_articles,
-        'tags': tag_names
+        'tags': tag_names,
+        'is_in_series': is_in_series
     }
 
     return flask.render_template(


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1058

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/blog/your-first-robot-sharing-with-others-5-5
- You should see the sidebar with related blog posts
- Visit http://0.0.0.0:8004/blog/top-10-linux-apps-for-entertainment-and-leisure
- You should not see the sidebar or any errors in the console