### PR TITLE
Add scope=wide for featured snaps

### DIFF
--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -44,7 +44,7 @@ FEATURE_SNAPS_URL = "".join(
     [
         SNAPCRAFT_IO_API,
         "snaps/search",
-        "?confinement=strict,classic&section=featured",
+        "?confinement=strict,classic&section=featured&scope=wide",
         "&fields=package_name,title,icon_url",
     ]
 )


### PR DESCRIPTION
Add scope wide for featured snaps, allows us to display snaps not on stable (e.g. node)

# QA

- `./run`
- http://127.0.0.1:8004/
- Make sure node is displayed in the feature snaps section on the homepage