### PR TITLE
Redirect if user has no usernames

### DIFF
--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -44,6 +44,9 @@ def login_handler():
 def after_login(resp):
     flask.session["macaroon_discharge"] = resp.extensions["macaroon"].discharge
 
+    if not resp.nickname:
+        return flask.redirect(LOGIN_URL)
+
     try:
         account = dashboard.get_account(flask.session)
         flask.session["openid"] = {


### PR DESCRIPTION
# Summary

Redirect to login.ubuntu.com if username is not set

# QA

- Create an account without username
- `./run`
- Try to login
- You should be redirected to login.ubuntu.com 