### PR TITLE
Remove RELEASE_UI_ENABLED feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,4 @@ DEVEL=True
 BLOG_ENABLED=true
 BLOG_CATEGORIES_ENABLED=false
 WEBAPP=snapcraft
-RELEASE_UI_ENABLED=True
 BSI_URL=https://build.snapcraft.io

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -61,11 +61,6 @@ export default class RevisionsTable extends Component {
       canBePromoted = true;
     }
 
-    // if feature is disabled don't show the buttons
-    if (!this.props.options.releaseUiEnabled) {
-      canBePromoted = false;
-    }
-
     const hasPendingRelease = (
       thisRevision && (!thisPreviousRevision || (thisPreviousRevision.revision !== thisRevision.revision))
     );

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -29,7 +29,6 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
       {{ release_history|tojson }},
       {{ channel_maps_list|tojson }},
       {
-        releaseUiEnabled: {{ release_ui_enabled|tojson }},
         csrfToken: {{ csrf_token()|tojson }}
       }
     );

--- a/webapp/configs/snapcraft.py
+++ b/webapp/configs/snapcraft.py
@@ -2,6 +2,4 @@ import os
 
 WEBAPP_CONFIG = {"LAYOUT": "_layout.html", "STORE_NAME": "Snap store"}
 
-RELEASE_UI_ENABLED = os.getenv("RELEASE_UI_ENABLED", "").lower() == "true"
-
 BLOG_CATEGORIES_ENABLED = os.getenv("BLOG_CATEGORIES_ENABLED", "false")

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -431,7 +431,6 @@ def get_release_history(snap_name):
         "snap_name": snap_name,
         "release_history": release_history,
         "channel_maps_list": info.get("channel_maps_list"),
-        "release_ui_enabled": flask.current_app.config["RELEASE_UI_ENABLED"],
     }
 
     return flask.render_template("publisher/release-history.html", **context)


### PR DESCRIPTION
Removes `RELEASE_UI_ENABLED` feature flag making releasing UI enabled for everyone.

### QA

Make sure feature flag is removed or turned off and see if release UI is there on Releases page.