### PR TITLE
Ignore branch releases

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -77,7 +77,7 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
 
   // go through releases from older to newest
   releasesData.releases.slice().reverse().forEach(release => {
-    if (release.revision) {
+    if (release.revision && !release.branch) {
       const rev = revisionsMap[release.revision];
 
       if (rev) {
@@ -85,7 +85,7 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
           ? release.risk
           : `${release.track}/${release.risk}`;
 
-        if (rev.channels.indexOf(`${release.track}/${release.risk}`) === -1) {
+        if (rev.channels.indexOf(channel) === -1) {
           rev.channels.push(channel);
         }
       }


### PR DESCRIPTION
Fixes #1071 

Properly making sure that there are no duplicated entries on channels list. Also ignores releases into branches.

### QA
- ./run or http://snapcraft.io-pr-1083.run.demo.haus/
- go to a snap that has some releases into branches
- releases into branches shouldn't show up on releases list in channels column

Example snap http://snapcraft.io-pr-1083.run.demo.haus/account/snaps/currate/release:
<img width="1021" alt="screen shot 2018-09-12 at 13 40 45" src="https://user-images.githubusercontent.com/83575/45422755-7c7ed480-b691-11e8-901c-767bf1bb110d.png">
