### PR TITLE
Move script tag to a jinja script block

### DIFF
--- a/templates/publisher/developer_programme_agreement.html
+++ b/templates/publisher/developer_programme_agreement.html
@@ -38,20 +38,23 @@
           <button class="p-button--positive" disabled="disabled" type="submit">Continue</button>
         </div>
       </div>
-      <script>
-        Raven.context(function() {
-          var checkbox = document.querySelector('#id_i_agree');
-          var button = document.querySelector('button[type="submit"]');
-          checkbox.addEventListener('change', function (event) {
-            if (this.checked) {
-              button.removeAttribute('disabled');
-            } else {
-              button.setAttribute('disabled', 'disabled');
-            }
-          });
-        });
-      </script>
     </form>
   </div>
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script>
+ Raven.context(function() {
+   var checkbox = document.querySelector('#id_i_agree');
+   var button = document.querySelector('button[type="submit"]');
+   checkbox.addEventListener('change', function (event) {
+     if (this.checked) {
+       button.removeAttribute('disabled');
+     } else {
+       button.setAttribute('disabled', 'disabled');
+     }
+   });
+ });
+</script>
 {% endblock %}


### PR DESCRIPTION
# Summary

in some cases raven is not defined, which blocks the js snippet to enable/disable the continue button on the developer agreement

# QA

- Create new user
- Login in mobile view
- on agreement page tick and untick the checkbox
- Make sure button is enabled/disabled