### PR TITLE
Release unreleased revisions

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -1,8 +1,7 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
 import ReleasesController from './release/releasesController';
-import RevisionsList from './release/revisionsList';
 
 // getting list of tracks names from channel maps list
 function getTracksFromChannelMap(channelMapsList) {
@@ -97,16 +96,14 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
   const archs = getArchsFromChannelMap(channelMapsList);
 
   ReactDOM.render(
-    <Fragment>
-      <ReleasesController
-        snapName={snapName}
-        releasedChannels={releasedChannels}
-        tracks={tracks}
-        archs={archs}
-        options={options}
-      />
-      <RevisionsList revisions={releasesData.revisions} />
-    </Fragment>,
+    <ReleasesController
+      snapName={snapName}
+      releasedChannels={releasedChannels}
+      revisions={releasesData.revisions}
+      tracks={tracks}
+      archs={archs}
+      options={options}
+    />,
     document.querySelector(id)
   );
 };

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import 'whatwg-fetch';
 
 import RevisionsTable from './revisionsTable';
+import RevisionsList from './revisionsList';
 import Notification from './notification';
 
 export default class ReleasesController extends Component {
@@ -216,6 +217,7 @@ export default class ReleasesController extends Component {
           undoRelease={this.undoRelease.bind(this)}
           clearPendingReleases={this.clearPendingReleases.bind(this)}
         />
+        <RevisionsList revisions={this.props.revisions} />
       </Fragment>
     );
   }
@@ -224,6 +226,7 @@ export default class ReleasesController extends Component {
 ReleasesController.propTypes = {
   snapName: PropTypes.string.isRequired,
   releasedChannels: PropTypes.object.isRequired,
+  revisions: PropTypes.array.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
   options: PropTypes.object.isRequired

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -230,6 +230,7 @@ export default class ReleasesController extends Component {
           revisions={this.props.revisions}
           pendingReleases={this.state.pendingReleases}
           promoteRevision={this.promoteRevision.bind(this)}
+          undoRelease={this.undoRelease.bind(this)}
         />
       </Fragment>
     );

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -11,6 +11,9 @@ export default class ReleasesController extends Component {
     super(props);
 
     this.state = {
+      // default to latest track
+      currentTrack: 'latest',
+
       error: null,
       isLoading: false,
       releasedChannels: this.props.releasedChannels,
@@ -26,6 +29,10 @@ export default class ReleasesController extends Component {
       // }
       pendingReleases: {}
     };
+  }
+
+  setCurrentTrack(track) {
+    this.setState({ currentTrack: track });
   }
 
   promoteRevision(revision, channel) {
@@ -194,7 +201,7 @@ export default class ReleasesController extends Component {
   }
 
   render() {
-    const { archs, tracks, options } = this.props;
+    const { archs, tracks } = this.props;
     const { releasedChannels } = this.state;
 
     return (
@@ -206,13 +213,14 @@ export default class ReleasesController extends Component {
         }
         <RevisionsTable
           releasedChannels={releasedChannels}
+          currentTrack={this.state.currentTrack}
           tracks={tracks}
           archs={archs}
-          options={options}
-          releaseRevisions={this.releaseRevisions.bind(this)}
-          fetchStatus={this.state}
-
+          isLoading={this.state.isLoading}
           pendingReleases={this.state.pendingReleases}
+
+          setCurrentTrack={this.setCurrentTrack.bind(this)}
+          releaseRevisions={this.releaseRevisions.bind(this)}
           promoteRevision={this.promoteRevision.bind(this)}
           undoRelease={this.undoRelease.bind(this)}
           clearPendingReleases={this.clearPendingReleases.bind(this)}

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -13,11 +13,9 @@ export default class ReleasesController extends Component {
     this.state = {
       // default to latest track
       currentTrack: 'latest',
-
       error: null,
       isLoading: false,
       releasedChannels: this.props.releasedChannels,
-
       // revisions to be released:
       // key is the id of revision to release
       // value is object containing release object and channels to release to
@@ -45,8 +43,8 @@ export default class ReleasesController extends Component {
           const pendingRelease = pendingReleases[revisionId];
 
           if (
-            pendingRelease.channels.indexOf(channel) !== -1 &&
-            pendingRelease.revision.architectures.indexOf(arch) !== -1
+            pendingRelease.channels.includes(channel) &&
+            pendingRelease.revision.architectures.includes(arch)
           ) {
             this.undoRelease(pendingRelease.revision, channel);
           }
@@ -81,7 +79,8 @@ export default class ReleasesController extends Component {
 
       if (pendingReleases[revision.revision]) {
         const channels = pendingReleases[revision.revision].channels;
-        if (channels.indexOf(channel) !== -1) {
+
+        if (channels.includes(channel)) {
           channels.splice(channels.indexOf(channel), 1);
         }
 
@@ -232,7 +231,6 @@ export default class ReleasesController extends Component {
           archs={archs}
           isLoading={this.state.isLoading}
           pendingReleases={this.state.pendingReleases}
-
           setCurrentTrack={this.setCurrentTrack.bind(this)}
           releaseRevisions={this.releaseRevisions.bind(this)}
           promoteRevision={this.promoteRevision.bind(this)}

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -225,7 +225,12 @@ export default class ReleasesController extends Component {
           undoRelease={this.undoRelease.bind(this)}
           clearPendingReleases={this.clearPendingReleases.bind(this)}
         />
-        <RevisionsList revisions={this.props.revisions} />
+        <RevisionsList
+          currentTrack={this.state.currentTrack}
+          revisions={this.props.revisions}
+          pendingReleases={this.state.pendingReleases}
+          promoteRevision={this.promoteRevision.bind(this)}
+        />
       </Fragment>
     );
   }

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -12,7 +12,7 @@ export default class ReleasesController extends Component {
 
     this.state = {
       // default to latest track
-      currentTrack: 'latest',
+      currentTrack: this.props.options.defaultTrack || 'latest',
       error: null,
       isLoading: false,
       releasedChannels: this.props.releasedChannels,

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -39,6 +39,20 @@ export default class ReleasesController extends Component {
     this.setState((state) => {
       const { pendingReleases } = state;
 
+      // cancel any other pending release for the same channel in same architectures
+      revision.architectures.forEach((arch) => {
+        Object.keys(pendingReleases).forEach((revisionId) => {
+          const pendingRelease = pendingReleases[revisionId];
+
+          if (
+            pendingRelease.channels.indexOf(channel) !== -1 &&
+            pendingRelease.revision.architectures.indexOf(arch) !== -1
+          ) {
+            this.undoRelease(pendingRelease.revision, channel);
+          }
+        });
+      });
+
       if (!pendingReleases[revision.revision]) {
         pendingReleases[revision.revision] = {
           revision: revision,

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -229,6 +229,7 @@ export default class ReleasesController extends Component {
           currentTrack={this.state.currentTrack}
           revisions={this.props.revisions}
           pendingReleases={this.state.pendingReleases}
+          releasedChannels={releasedChannels}
           promoteRevision={this.promoteRevision.bind(this)}
           undoRelease={this.undoRelease.bind(this)}
         />

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 // TODO:
-// - don't allow releasing something already released
 // - don't allow releasing multiple revisions into same arch/channel
 
 export default class RevisionsList extends Component {
@@ -39,10 +38,16 @@ export default class RevisionsList extends Component {
 
           <td className="u-align--right">
             { canBeReleased &&
-              <button className="p-icon-button" onClick={this.releaseClick.bind(this, revision)} title={`Release ${revision.version} (${revision.revision}) to ${this.props.currentTrack}/edge`}>&uarr;</button>
+              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.releaseClick.bind(this, revision)}>
+                &uarr;
+                <span className="p-tooltip__message">{`Promote to ${this.props.currentTrack}/edge`}</span>
+              </button>
             }
             { hasPendingRelease &&
-              <button className="p-icon-button" onClick={this.undoClick.bind(this, revision)} title={`Undo this release`}>&#x2715;</button>
+              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.undoClick.bind(this, revision)}>
+                &#x2715;
+                <span className="p-tooltip__message">Revert promoting this revision</span>
+              </button>
             }
           </td>
         </tr>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -18,6 +18,10 @@ export default class RevisionsList extends Component {
         canBeReleased = false;
       }
 
+      if (this.isAlreadyReleased(revision)) {
+        canBeReleased = false;
+      }
+
       return (
         <tr key={revision.revision}>
           <td>{ revision.revision }</td>
@@ -54,6 +58,14 @@ export default class RevisionsList extends Component {
     this.props.undoRelease(revision, `${this.props.currentTrack}/edge`);
   }
 
+  isAlreadyReleased(revision) {
+    return Object.keys(this.props.releasedChannels).some((channel) => {
+      return Object.keys(this.props.releasedChannels[channel]).some((arch) => {
+        return this.props.releasedChannels[channel][arch].revision === revision.revision;
+      });
+    });
+  }
+
   render() {
     return (
       <Fragment>
@@ -83,6 +95,7 @@ RevisionsList.propTypes = {
   currentTrack: PropTypes.string.isRequired,
   pendingReleases: PropTypes.object.isRequired,
   revisions: PropTypes.object.isRequired,
+  releasedChannels: PropTypes.object.isRequired,
   promoteRevision: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -2,6 +2,10 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+// TODO:
+// - don't allow releasing something already released
+// - don't allow releasing multiple revisions into same arch/channel
+
 export default class RevisionsList extends Component {
   renderRows(revisions) {
     return revisions.map((revision) => {
@@ -21,9 +25,17 @@ export default class RevisionsList extends Component {
               </span>
             </span>
           </td>
+
+          <td className="u-align--right">
+            <button className="p-icon-button" onClick={this.releaseClick.bind(this, revision)}>&uarr;</button>
+          </td>
         </tr>
       );
     });
+  }
+
+  releaseClick(revision) {
+    this.props.promoteRevision(revision, `${this.props.currentTrack}/edge`);
   }
 
   render() {
@@ -34,10 +46,11 @@ export default class RevisionsList extends Component {
           <thead>
             <tr>
               <th width="10%" scope="col">Revision</th>
-              <th width="28%" scope="col">Version</th>
+              <th width="23%" scope="col">Version</th>
               <th width="12%" scope="col">Architecture</th>
-              <th width="35%" scope="col">Channels</th>
+              <th width="30%" scope="col">Channels</th>
               <th width="15%" scope="col" className="u-align--right">Submission date</th>
+              <th width="10%" scope="col" className="u-align--right">Release</th>
             </tr>
           </thead>
 
@@ -51,5 +64,7 @@ export default class RevisionsList extends Component {
 }
 
 RevisionsList.propTypes = {
-  revisions: PropTypes.object.isRequired
+  currentTrack: PropTypes.string.isRequired,
+  revisions: PropTypes.object.isRequired,
+  promoteRevision: PropTypes.func.isRequired,
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -10,6 +10,13 @@ export default class RevisionsList extends Component {
   renderRows(revisions) {
     return revisions.map((revision) => {
       const uploadDate = moment(revision.created_at);
+      let canBeReleased = true;
+      let hasPendingRelease = false;
+
+      if (this.props.pendingReleases[revision.revision]) {
+        hasPendingRelease = true;
+        canBeReleased = false;
+      }
 
       return (
         <tr key={revision.revision}>
@@ -27,7 +34,12 @@ export default class RevisionsList extends Component {
           </td>
 
           <td className="u-align--right">
-            <button className="p-icon-button" onClick={this.releaseClick.bind(this, revision)}>&uarr;</button>
+            { canBeReleased &&
+              <button className="p-icon-button" onClick={this.releaseClick.bind(this, revision)} title={`Release ${revision.version} (${revision.revision}) to ${this.props.currentTrack}/edge`}>&uarr;</button>
+            }
+            { hasPendingRelease &&
+              <button className="p-icon-button" onClick={this.undoClick.bind(this, revision)} title={`Undo this release`}>&#x2715;</button>
+            }
           </td>
         </tr>
       );
@@ -36,6 +48,10 @@ export default class RevisionsList extends Component {
 
   releaseClick(revision) {
     this.props.promoteRevision(revision, `${this.props.currentTrack}/edge`);
+  }
+
+  undoClick(revision) {
+    this.props.undoRelease(revision, `${this.props.currentTrack}/edge`);
   }
 
   render() {
@@ -65,6 +81,8 @@ export default class RevisionsList extends Component {
 
 RevisionsList.propTypes = {
   currentTrack: PropTypes.string.isRequired,
+  pendingReleases: PropTypes.object.isRequired,
   revisions: PropTypes.object.isRequired,
   promoteRevision: PropTypes.func.isRequired,
+  undoRelease: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -65,10 +65,22 @@ export default class RevisionsTable extends Component {
         <span className="p-tooltip p-tooltip--btm-center">
           <span className="p-release-version">
             <span className={ hasPendingRelease ? 'p-previous-revision' : '' }>
-              { thisPreviousRevision ? thisPreviousRevision.version : '-' }
+              { thisPreviousRevision ?
+                <span className="p-revision-info">{thisPreviousRevision.version}
+                  <span className="p-revision-info__revision">({thisPreviousRevision.revision})</span>
+                </span> :
+                '–'
+              }
             </span>
             { hasPendingRelease &&
-              <span> &rarr; { thisRevision.version }</span>
+              <span>
+                {' '}
+                &rarr;
+                {' '}
+                <span className="p-revision-info">{thisRevision.version}
+                  <span className="p-revision-info__revision">({thisRevision.revision})</span>
+                </span>
+              </span>
             }
           </span>
 
@@ -144,7 +156,7 @@ export default class RevisionsTable extends Component {
     const releasesCount = Object.keys(pendingReleases).length;
 
     return (releasesCount > 0 &&
-      <p>
+      <div className="p-release-confirm">
         <span className="p-tooltip">
           <i className="p-icon--question" />
           {' '}
@@ -163,9 +175,11 @@ export default class RevisionsTable extends Component {
           </span>
         </span>
         {' '}
-        <button className="p-button--positive is-inline" disabled={ isLoading } onClick={ this.onApplyClick.bind(this) }>{ isLoading ? 'Loading...' : 'Apply' }</button>
-        <button className="p-button--neutral" onClick={ this.onRevertClick.bind(this) }>Cancel</button>
-      </p>
+        <div className="p-release-confirm__buttons">
+          <button className="p-button--positive is-inline u-no-margin--bottom" disabled={ isLoading } onClick={ this.onApplyClick.bind(this) }>{ isLoading ? 'Loading...' : 'Apply' }</button>
+          <button className="p-button--neutral u-no-margin--bottom" onClick={ this.onRevertClick.bind(this) }>Cancel</button>
+        </div>
+      </div>
     );
   }
 

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -4,15 +4,6 @@ import PropTypes from 'prop-types';
 const RISKS = ['stable', 'candidate', 'beta', 'edge'];
 
 export default class RevisionsTable extends Component {
-  constructor() {
-    super();
-
-    this.state = {
-      // default to latest track
-      currentTrack: 'latest',
-    };
-  }
-
   getRevisionToDisplay(releasedChannels, nextReleases, channel, arch) {
     const pendingRelease = nextReleases[channel] && nextReleases[channel][arch];
     const currentRelease = releasedChannels[channel] && releasedChannels[channel][arch];
@@ -103,7 +94,7 @@ export default class RevisionsTable extends Component {
 
   renderRows(releasedChannels, archs) {
     const nextChannelReleases = this.getNextReleasesData(releasedChannels, this.props.pendingReleases);
-    const track = this.state.currentTrack;
+    const track = this.props.currentTrack;
 
     return RISKS.map(risk => {
       const channel = `${track}/${risk}`;
@@ -142,10 +133,9 @@ export default class RevisionsTable extends Component {
   }
 
   renderReleasesConfirm() {
-    const { pendingReleases } = this.props;
+    const { pendingReleases, isLoading } = this.props;
     const releasesCount = Object.keys(pendingReleases).length;
 
-    const { isLoading } = this.props.fetchStatus;
     return (releasesCount > 0 &&
       <p>
         <span className="p-tooltip">
@@ -173,7 +163,7 @@ export default class RevisionsTable extends Component {
   }
 
   onTrackChange(event) {
-    this.setState({ currentTrack: event.target.value });
+    this.props.setCurrentTrack(event.target.value);
   }
 
   getNextReleasesData(currentReleaseData, releases) {
@@ -237,12 +227,14 @@ export default class RevisionsTable extends Component {
 RevisionsTable.propTypes = {
   releasedChannels: PropTypes.object.isRequired,
   pendingReleases: PropTypes.object.isRequired,
+  currentTrack: PropTypes.string.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
-  options: PropTypes.object.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+
+  setCurrentTrack:  PropTypes.func.isRequired,
   releaseRevisions: PropTypes.func.isRequired,
   promoteRevision: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
   clearPendingReleases: PropTypes.func.isRequired,
-  fetchStatus: PropTypes.object.isRequired
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -35,9 +35,10 @@ export default class RevisionsTable extends Component {
     let targetRevision = null;
     let targetPreviousRevision = null;
     let targetHasPendingRelease = false;
+    let targetChannel = null;
 
     if (targetRisk) {
-      const targetChannel = `${track}/${targetRisk}`;
+      targetChannel = `${track}/${targetRisk}`;
 
       targetRevision = this.getRevisionToDisplay(releasedChannels, nextChannelReleases, targetChannel, arch);
       targetPreviousRevision = releasedChannels[targetChannel] && releasedChannels[targetChannel][arch];
@@ -81,10 +82,16 @@ export default class RevisionsTable extends Component {
         { (canBePromoted || hasPendingRelease) &&
           <div className="p-release-buttons">
             { canBePromoted &&
-              <button className="p-icon-button" onClick={this.releaseClick.bind(this, thisRevision, track, risk)} title={`Promote ${thisRevision.version} (${thisRevision.revision})`}>&uarr;</button>
+              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.releaseClick.bind(this, thisRevision, track, risk)}>
+                &uarr;
+                <span className="p-tooltip__message">{`Promote to ${targetChannel}`}</span>
+              </button>
             }
             { hasPendingRelease &&
-              <button className="p-icon-button" onClick={this.undoClick.bind(this, thisRevision, track, risk)} title={`Undo this release`}>&#x2715;</button>
+              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.undoClick.bind(this, thisRevision, track, risk)}>
+                &#x2715;
+                <span className="p-tooltip__message">Revert promoting this revision</span>
+              </button>
             }
           </div>
         }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -32,4 +32,31 @@
     right: 1rem; // match table padding
     top: .5rem;
   }
+
+  .p-revision-info {
+    display: inline-block;
+    padding-bottom: 1.2em;
+    position: relative;
+  }
+
+  .p-revision-info__revision {
+    color: $color-mid-dark;
+    font-size: .8em;
+    left: 0;
+    position: absolute;
+    top: 1.6em;
+  }
+
+  .p-release-confirm {
+    background: $color-light;
+    margin-bottom: 1em;
+    padding: 1em;
+    position: relative;
+  }
+
+  .p-release-confirm__buttons {
+    position: absolute;
+    right: 0;
+    top: 10px;
+  }
 }

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -29,6 +29,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
       {{ release_history|tojson }},
       {{ channel_maps_list|tojson }},
       {
+        defaultTrack: 'latest',
         csrfToken: {{ csrf_token()|tojson }}
       }
     );


### PR DESCRIPTION
Fixes #1069 

Adds ability to release unreleased revisions (from Revision history table) to edge

### QA

- ./run or http://snapcraft.io-pr-1085.run.demo.haus/
- go to Release page of snap you own
- Click on arrow (Promote) button next to revision from revisions table
- it should be displayed in releases table as pending release
- try to cancel it, or promote to other channel

<img width="1140" alt="screen shot 2018-09-17 at 15 44 11" src="https://user-images.githubusercontent.com/83575/45626760-92750680-ba90-11e8-86f2-65c4696cfca2.png">
