### PR TITLE
Add missing custom licenses

### DIFF
--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -12,8 +12,35 @@ class RegexConverter(BaseConverter):
 def get_licenses():
     try:
         with open("webapp/licenses.json") as f:
-            licenses = json.load(f)
+            licenses_file = json.load(f)
+
+        licenses = licenses_file["licenses"]
+
+        def _build_custom_license(license_id, license_name):
+            return {"licenseId": license_id, "name": license_name}
+
+        CUSTOM_LICENSES = [
+            _build_custom_license("Proprietary", "Proprietary"),
+            _build_custom_license("Other Open Source", "Other Open Source"),
+            _build_custom_license(
+                "AGPL-3.0+", "GNU Affero General Public License v3.0 or later"
+            ),
+            _build_custom_license(
+                "GPL-2.0+", "GNU General Public License v2.0 or later"
+            ),
+            _build_custom_license(
+                "GPL-3.0+", "GNU General Public License v3.0 or later"
+            ),
+            _build_custom_license(
+                "LGPL-2.1+", "GNU Lesser General Public License v2.1 or later"
+            ),
+            _build_custom_license(
+                "LGPL-3.0+", "GNU Lesser General Public License v3.0 or later"
+            ),
+        ]
+
+        licenses = licenses + CUSTOM_LICENSES
     except Exception:
-        licenses = {}
+        licenses = []
 
     return licenses


### PR DESCRIPTION
# Summary 

Some custom licenses not part of spdx are missing (Proprietary for ex)
They are added trying to follow the pattern of this [file](https://github.com/spdx/license-list-data/blob/master/json/licenses.json)

# QA

- Print the licenses in the listing page
- `./run`
- http://127.0.0.1:8004/account/snaps/toto/listing
- Make sure the licenses added are in the array