### PR TITLE
Updated copy and copydoc link on store page

### DIFF
--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -1,5 +1,8 @@
 <section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
   <div class="row">
+    <h3>Search thousands of snaps used by millions of users across 50 distributions</h3>
+  </div>
+  <div class="row">
     <form action="/search" class="p-form p-form--inline p-form--search">
       {% if categories %}
         <div class="p-form__group p-form__group--no-grow">

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -1,8 +1,6 @@
 <section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
   <div class="row">
     <h3>Search thousands of snaps used by millions of users across 50 distributions</h3>
-  </div>
-  <div class="row">
     <form action="/search" class="p-form p-form--inline p-form--search">
       {% if categories %}
         <div class="p-form__group p-form__group--no-grow">

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -1,7 +1,5 @@
 {% extends webapp_config['LAYOUT'] %}
 
-{% block meta_copydoc %}{% endblock %}
-
 {% block meta_title %}
   {% if query %}
     Snap search results for "{{ query }}"

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -2,6 +2,8 @@
 
 {% block meta_title %}Install Linux apps in seconds | Snap Store{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/10j4xltRGXrqp1e3mJicSft3vHpzpnCdCRXMNpspvJ2c/edit{% endblock %}
+
 {% block meta_description %}Find and install the best Linux software for all major Linux distributions.{% endblock %}
 
 {% block meta_schema %}


### PR DESCRIPTION
QA

1. Pull the branch
2. Go to `/store`
3. Check you can access the correspondent [copydoc document](https://docs.google.com/document/d/10j4xltRGXrqp1e3mJicSft3vHpzpnCdCRXMNpspvJ2c/edit)
4. You should notice a new heading intro above the Search bar

**Note:** Make sure you have installed the copydoc extension for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/ubuntu-copy-docs/) or [Chrome](https://chrome.google.com/webstore/detail/ubuntu-copy-docs/cmljegnknolilmjdconnapgllmefigfl?hl=en)