### PR TITLE
Metrics selector fix

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevices.js
+++ b/static/js/publisher/metrics/graphs/activeDevices.js
@@ -110,9 +110,9 @@ const tooltipTemplate = (data, currentHoverKey, colorScale) => {
   ].join('');
 };
 
-function drawGraph(holder, activeDevices) {
+function drawGraph(holderSelector, holder, activeDevices) {
   // Basic svg setup
-  const svg = select('svg');
+  const svg = select(`${holderSelector} svg`);
   svg.attr('width', holder.clientWidth);
   svg.selectAll("*").remove();
 
@@ -254,10 +254,10 @@ export default function activeDevices(holderSelector, activeDevices) {
     return;
   }
 
-  drawGraph(holder, activeDevices);
+  drawGraph(holderSelector, holder, activeDevices);
 
   const resize = debounce(function() {
-    drawGraph(holder, activeDevices);
+    drawGraph(holderSelector, holder, activeDevices);
   }, 100);
 
   select(window).on('resize', resize);

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -76,12 +76,6 @@ Publisher metrics for {{ snap_title }}
   </div>
 {% endblock %}
 
-{% block scripts_modules %}
-  {# still required until implement new graphs in d3 #}
-  <script src="{{ static_url('js/modules/d3.min.js') }}"></script>
-  <script src="{{ static_url('js/modules/billboard.min.js') }}"></script>
-{% endblock %}
-
 {% block scripts %}
   <script src="{{ static_url('js/dist/publisher.js') }}"></script>
   <script>


### PR DESCRIPTION
While working on the settings page, I noticed that the active devices graph stopped working.

I realised the selector for the svg on the page wasn't specific enough (it was just finding the first svg).

This fixes that.... And removes the inclusion of billboard and d3.min in the HTML.

Fixes https://github.com/canonical-websites/snapcraft.io/issues/1092

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/account/snaps/<snap_name>/metrics
- Make sure the active devices graph shows.