### PR TITLE
Fix undefined article var

### DIFF
--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -208,7 +208,7 @@ def snap_series(series):
     try:
         blog_articles, total_pages = api.get_articles(series)
     except ApiError:
-        blog_articles = None
+        blog_articles = []
 
     for article in blog_articles:
         transformed_article = logic.transform_article(


### PR DESCRIPTION
# Summary

Fixes #1098 

# QA

- Add `blog_articles = []` after try
- http://127.0.0.1:5000/blog/api/series/3148
- Should return a empty resutl