### PR TITLE
Remove feature snaps api call from homepage

### DIFF
--- a/tests/snapcraft/tests_public.py
+++ b/tests/snapcraft/tests_public.py
@@ -22,19 +22,10 @@ class StorePage(TestCase):
 
     @responses.activate
     def test_index(self):
-        url = (
-            "https://api.snapcraft.io/api/v1/snaps/search"
-            "?confinement=strict,classic&q=&section=featured."
-        )
-
-        responses.add(responses.GET, url, json={}, status=200)
-
         response = self.client.get("/")
 
         assert response.status_code == 200
         self.assert_template_used("index.html")
-        self.assert_context("featured_snaps", [])
-        self.assert_context("error_info", {})
 
 
 if __name__ == "__main__":

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -1,20 +1,7 @@
 import flask
 
-from webapp.api.store import StoreApi
-from webapp.store import logic
-from webapp.api.exceptions import (
-    ApiError,
-    ApiTimeoutError,
-    ApiResponseDecodeError,
-    ApiResponseError,
-    ApiResponseErrorList,
-    ApiConnectionError,
-)
-
 
 def snapcraft_blueprint():
-    api = StoreApi()
-
     snapcraft = flask.Blueprint(
         "snapcraft",
         __name__,
@@ -22,43 +9,11 @@ def snapcraft_blueprint():
         static_folder="/static",
     )
 
-    def _handle_errors(api_error: ApiError):
-        status_code = 502
-        error = {"message": str(api_error)}
-
-        if type(api_error) is ApiTimeoutError:
-            status_code = 504
-        elif type(api_error) is ApiResponseDecodeError:
-            status_code = 502
-        elif type(api_error) is ApiResponseErrorList:
-            error["errors"] = api_error.errors
-            status_code = 502
-        elif type(api_error) is ApiResponseError:
-            status_code = 502
-        elif type(api_error) is ApiConnectionError:
-            status_code = 502
-        return status_code, error
-
     @snapcraft.route("/")
     def homepage():
-        featured_snaps = []
-        error_info = {}
-        status_code = 200
         nps = flask.request.args.get("nps")
-        try:
-            featured_snaps = logic.get_searched_snaps(api.get_featured_snaps())
-        except ApiError as api_error:
-            status_code, error_info = _handle_errors(api_error)
 
-        return (
-            flask.render_template(
-                "index.html",
-                featured_snaps=featured_snaps,
-                error_info=error_info,
-                nps=nps,
-            ),
-            status_code,
-        )
+        return flask.render_template("index.html", nps=nps)
 
     @snapcraft.route("/iot")
     def iot():


### PR DESCRIPTION
# Summary

we don't diplay the feature snaps in the homepage
remove the api call

# QA

- `./run`
- http://127.0.0.1:8004/
- Homepage should still work
