### PR TITLE
Enable feature flag for canonical users

### DIFF
--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -47,6 +47,13 @@ def after_login(resp):
     if not resp.nickname:
         return flask.redirect(LOGIN_URL)
 
+    if resp.email.endswith("ubuntu.com") or resp.email.endswith(
+        "canonical.com"
+    ):
+        flask.session["features_enabled"] = True
+    else:
+        flask.session["features_enabled"] = False
+
     try:
         account = dashboard.get_account(flask.session)
         flask.session["openid"] = {


### PR DESCRIPTION
# Summary

Add in session `features_enabled` for canonical users. This will help us enable feature flags only for canonical users.

# QA

- `./run`
- Login
- Check if the session has the feature_enabled object
- Try with a non canonical email address