### PR TITLE
Use rollup watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
-    "watch-js": "watch -p 'static/js/**/*.js' -c 'yarn run build-js'",
+    "watch-js": "rollup -c -w",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp webapp/licenses.json"
   },
   "husky": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,9 @@ import commonjs from 'rollup-plugin-commonjs';
 import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 
+/* global process */
+const production = process.env.ENVIRONMENT !== 'devel';
+
 export default [
   {
     input: 'static/js/base/base.js',
@@ -15,7 +18,7 @@ export default [
         exclude: 'node_modules/**',
         plugins: ['external-helpers']
       }),
-      uglify()
+      production && uglify()
     ],
     output: {
       file: 'static/js/dist/base.js',
@@ -34,7 +37,7 @@ export default [
         exclude: 'node_modules/**',
         plugins: ['external-helpers']
       }),
-      uglify(),
+      production && uglify(),
       commonjs({
         include: [
           'node_modules/polylabel/**',
@@ -59,7 +62,7 @@ export default [
         exclude: 'node_modules/**',
         plugins: ['external-helpers']
       }),
-      uglify()
+      production && uglify()
     ],
     output: {
       file: 'static/js/dist/public.js',
@@ -107,7 +110,7 @@ export default [
       replace({
         'process.env.NODE_ENV': JSON.stringify( 'production' )
       }),
-      uglify()
+      production && uglify()
     ],
     output: {
       file: 'static/js/dist/release.js',


### PR DESCRIPTION
Use rollup built in watch not to rebuild all JS on every change.

### QA

- ./run build
- all should build as before, but without uglifying js
- ./run exec yarn watch-js
- rollup watch should run, uglify plugin should be disabled, when file is changed only one bundle should be rebuilt
- only on production env (based on ENVIRONMENT variable) uglify will be enabled