### PR TITLE
Add username to detail page

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -56,7 +56,7 @@
           <div class="p-snap-heading__title">
             <h1 class="p-heading--two p-snap-heading__name">{{ snap_title }}</h1>
             <p class="p-snap-heading__publisher">
-              by {{ publisher }}
+              by {{ publisher }} ({{ username }})
               {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
               <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
                 <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -376,6 +376,7 @@ def store_blueprint(store_query=None):
             "version": last_version,
             "license": details["snap"]["license"],
             "publisher": details["snap"]["publisher"]["display-name"],
+            "username": details["snap"]["publisher"]["username"],
             "screenshots": screenshots,
             "prices": details["snap"]["prices"],
             "contact": details["snap"].get("contact"),


### PR DESCRIPTION
# Summary

add username to details page

# qa

- `./run`
- go to toto snap
- tbmb should be displayed next to the displayed name