### PR TITLE
Fix undefined var

### DIFF
--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -184,7 +184,7 @@ def snap_posts(snap):
         try:
             blog_articles, total_pages = api.get_articles(blog_tags_ids, 3)
         except ApiError:
-            blog_articles = None
+            blog_articles = []
 
         for article in blog_articles:
             transformed_article = logic.transform_article(


### PR DESCRIPTION
Fixes #1115 
Fixes https://sentry.io/canonical-bm/snapcraftio/issues/668749462

When API fails the objcet should be an empty array to be iterable for the loop.

# qa

You can make sure it works by assigning the variable with an empty array after the try catch and go on http://127.0.0.1:8004/lxd No article should be displayed