### PR TITLE
Don't download licenses if file already here

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test-js": "jest",
     "test-js-all": "yarn run lint-js && yarn run test-js",
     "test-python": "python3 -m unittest discover tests",
-    "get-licenses": "curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json -o webapp/licenses.json",
+    "get-licenses": "if [ ! -f webapp/licenses.json ] ; then curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json -o webapp/licenses.json; fi",
     "build": "yarn run get-licenses && yarn run build-js && yarn run build-css",
     "build-css": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css'",
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-transpile",


### PR DESCRIPTION
# Summary

On build if `licenses.json` already here, don't download it.

# QA

- `yarn clean`
- `yarn build`
- license.json should be downloaded
- `yarn build`
- licenses.json shouldn't be downloaded