### PR TITLE
Release UI: promote channel

### DIFF
--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -42,8 +42,8 @@ export default class PromoteButton extends Component {
     const menuClass =  'p-contextual-menu' + (position ? `--${position}` : '');
 
     return (
-      <button
-        className={`p-promote-button p-icon-button ${menuClass}`}
+      <span
+        className={`p-promote-button p-button--neutral p-icon-button ${menuClass}`}
         onClick={this.dropdownButtonClick.bind(this)}
       >
         &uarr;
@@ -66,7 +66,7 @@ export default class PromoteButton extends Component {
             }
           </span>
         </span>
-      </button>
+      </span>
     );
   }
 }

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -43,10 +43,10 @@ export default class PromoteButton extends Component {
 
     return (
       <button
-        className={`p-promote-button p-button--base p-icon-button ${menuClass}`}
+        className={`p-promote-button p-icon-button ${menuClass}`}
         onClick={this.dropdownButtonClick.bind(this)}
       >
-        <i className="p-icon--contextual-menu"></i>
+        &uarr;
         <span className="p-contextual-menu__dropdown" aria-hidden="true">
           <span className="p-contextual-menu__group">
             <span className="p-contextual-menu__item">Promote to:</span>

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -11,8 +11,8 @@ export default class PromoteButton extends Component {
     window.removeEventListener('click', this.closeAllDropdowns);
   }
 
-  promoteChannelClick(targetChannel, event) {
-    this.props.promoteChannel(targetChannel);
+  promoteToChannelClick(targetChannel, event) {
+    this.props.promoteToChannel(targetChannel);
     this.closeAllDropdowns();
     event.preventDefault(); // prevent link from changing URL
     event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
@@ -38,12 +38,12 @@ export default class PromoteButton extends Component {
   }
 
   render() {
-    const { track } = this.props;
+    const { position, track } = this.props;
+    const menuClass =  'p-contextual-menu' + (position ? `--${position}` : '');
 
     return (
       <button
-        className="p-promote-button p-button--base p-icon-button p-contextual-menu--left"
-
+        className={`p-promote-button p-button--base p-icon-button ${menuClass}`}
         onClick={this.dropdownButtonClick.bind(this)}
       >
         <i className="p-icon--contextual-menu"></i>
@@ -57,7 +57,7 @@ export default class PromoteButton extends Component {
                     className="p-contextual-menu__link is-indented"
                     href="#"
                     key={`promote-to-${track}/${targetRisk}`}
-                    onClick={this.promoteChannelClick.bind(this, `${track}/${targetRisk}`)}
+                    onClick={this.promoteToChannelClick.bind(this, `${track}/${targetRisk}`)}
                   >
                     {`${track}/${targetRisk}`}
                   </a>
@@ -72,7 +72,8 @@ export default class PromoteButton extends Component {
 }
 
 PromoteButton.propTypes = {
+  position: PropTypes.oneOf(['left', 'center']), // right is by default
   track: PropTypes.string.isRequired,
   targetRisks: PropTypes.array.isRequired,
-  promoteChannel: PropTypes.func.isRequired
+  promoteToChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const RISKS = ['stable', 'candidate', 'beta', 'edge'];
+
+export default class PromoteButton extends Component {
+  componentDidMount() {
+    // use window instead of document, as React catches all events in document
+    window.addEventListener('click', this.closeAllDropdowns);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('click', this.closeAllDropdowns);
+  }
+
+  promoteChannelClick(channel, targetChannel, event) {
+    this.props.promoteChannel(channel, targetChannel);
+    this.closeAllDropdowns();
+    event.preventDefault(); // prevent link from changing URL
+    event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
+  }
+
+  dropdownButtonClick(event) {
+    this.closeAllDropdowns();
+    const controlId = event.target.closest('[aria-controls]').getAttribute('aria-controls');
+
+    if (controlId) {
+      const controlsEl = document.getElementById(controlId);
+      controlsEl.setAttribute('aria-hidden', false);
+    }
+
+    event.stopPropagation();
+  }
+
+  closeAllDropdowns() {
+    [].slice.call(document.querySelectorAll(".p-contextual-menu__dropdown")).forEach((dropdown) => {
+      dropdown.setAttribute('aria-hidden', true);
+    });
+  }
+
+  render() {
+    const { track, risk } = this.props;
+    const channel = `${track}/${risk}`;
+
+    const dropdownId = `promote-dropdown-${channel}`;
+
+    return (
+      <button
+        className="p-button--base p-icon-button p-contextual-menu--left"
+        aria-controls={dropdownId}
+        onClick={this.dropdownButtonClick.bind(this)}
+      >
+        <i className="p-icon--contextual-menu"></i>
+        <span className="p-contextual-menu__dropdown" id={dropdownId} aria-hidden="true">
+          <span className="p-contextual-menu__group">
+            <span className="p-contextual-menu__item">Promote to:</span>
+            {
+              RISKS.map((targetRisk, i) => {
+                if (i < RISKS.indexOf(risk)) {
+                  return (
+                    <a
+                      className="p-contextual-menu__link is-indented"
+                      href="#"
+                      key={`promote-to-${track}/${targetRisk}`}
+                      onClick={this.promoteChannelClick.bind(this, channel, `${track}/${targetRisk}`)}
+                    >
+                      {`${track}/${targetRisk}`}
+                    </a>
+                  );
+                } else {
+                  return null;
+                }
+              })
+            }
+          </span>
+        </span>
+      </button>
+    );
+  }
+}
+
+PromoteButton.propTypes = {
+  track: PropTypes.string.isRequired,
+  risk: PropTypes.string.isRequired,
+  // TODO: only needed when not computing tracks from risk (?)
+  // targetChannels: PropTypes.array.isRequired,
+  promoteChannel: PropTypes.func.isRequired
+};

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const RISKS = ['stable', 'candidate', 'beta', 'edge'];
-
 export default class PromoteButton extends Component {
   componentDidMount() {
     // use window instead of document, as React catches all events in document
@@ -13,8 +11,8 @@ export default class PromoteButton extends Component {
     window.removeEventListener('click', this.closeAllDropdowns);
   }
 
-  promoteChannelClick(channel, targetChannel, event) {
-    this.props.promoteChannel(channel, targetChannel);
+  promoteChannelClick(targetChannel, event) {
+    this.props.promoteChannel(targetChannel);
     this.closeAllDropdowns();
     event.preventDefault(); // prevent link from changing URL
     event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
@@ -22,11 +20,12 @@ export default class PromoteButton extends Component {
 
   dropdownButtonClick(event) {
     this.closeAllDropdowns();
-    const controlId = event.target.closest('[aria-controls]').getAttribute('aria-controls');
+    const dropdownEl = event.target
+      .closest('.p-promote-button')
+      .querySelector('.p-contextual-menu__dropdown');
 
-    if (controlId) {
-      const controlsEl = document.getElementById(controlId);
-      controlsEl.setAttribute('aria-hidden', false);
+    if (dropdownEl) {
+      dropdownEl.setAttribute('aria-hidden', false);
     }
 
     event.stopPropagation();
@@ -39,37 +38,30 @@ export default class PromoteButton extends Component {
   }
 
   render() {
-    const { track, risk } = this.props;
-    const channel = `${track}/${risk}`;
-
-    const dropdownId = `promote-dropdown-${channel}`;
+    const { track } = this.props;
 
     return (
       <button
-        className="p-button--base p-icon-button p-contextual-menu--left"
-        aria-controls={dropdownId}
+        className="p-promote-button p-button--base p-icon-button p-contextual-menu--left"
+
         onClick={this.dropdownButtonClick.bind(this)}
       >
         <i className="p-icon--contextual-menu"></i>
-        <span className="p-contextual-menu__dropdown" id={dropdownId} aria-hidden="true">
+        <span className="p-contextual-menu__dropdown" aria-hidden="true">
           <span className="p-contextual-menu__group">
             <span className="p-contextual-menu__item">Promote to:</span>
             {
-              RISKS.map((targetRisk, i) => {
-                if (i < RISKS.indexOf(risk)) {
-                  return (
-                    <a
-                      className="p-contextual-menu__link is-indented"
-                      href="#"
-                      key={`promote-to-${track}/${targetRisk}`}
-                      onClick={this.promoteChannelClick.bind(this, channel, `${track}/${targetRisk}`)}
-                    >
-                      {`${track}/${targetRisk}`}
-                    </a>
-                  );
-                } else {
-                  return null;
-                }
+              this.props.targetRisks.map((targetRisk) => {
+                return (
+                  <a
+                    className="p-contextual-menu__link is-indented"
+                    href="#"
+                    key={`promote-to-${track}/${targetRisk}`}
+                    onClick={this.promoteChannelClick.bind(this, `${track}/${targetRisk}`)}
+                  >
+                    {`${track}/${targetRisk}`}
+                  </a>
+                );
               })
             }
           </span>
@@ -81,8 +73,6 @@ export default class PromoteButton extends Component {
 
 PromoteButton.propTypes = {
   track: PropTypes.string.isRequired,
-  risk: PropTypes.string.isRequired,
-  // TODO: only needed when not computing tracks from risk (?)
-  // targetChannels: PropTypes.array.isRequired,
+  targetRisks: PropTypes.array.isRequired,
   promoteChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -280,6 +280,7 @@ export default class ReleasesController extends Component {
           revisions={this.props.revisions}
           pendingReleases={this.state.pendingReleases}
           releasedChannels={releasedChannels}
+          getNextReleasedChannels={this.getNextReleasedChannels.bind(this)}
           promoteRevision={this.promoteRevision.bind(this)}
           undoRelease={this.undoRelease.bind(this)}
         />

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -2,6 +2,10 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+import PromoteButton from './promoteButton';
+
+const RISKS = ['stable', 'candidate', 'beta', 'edge'];
+
 // TODO:
 // - don't allow releasing multiple revisions into same arch/channel
 
@@ -17,9 +21,7 @@ export default class RevisionsList extends Component {
         canBeReleased = false;
       }
 
-      if (this.isAlreadyReleased(revision)) {
-        canBeReleased = false;
-      }
+      // TODO: disable channels revision is released to currently
 
       return (
         <tr key={revision.revision}>
@@ -38,10 +40,11 @@ export default class RevisionsList extends Component {
 
           <td className="u-align--right">
             { canBeReleased &&
-              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.releaseClick.bind(this, revision)}>
-                &uarr;
-                <span className="p-tooltip__message">{`Promote to ${this.props.currentTrack}/edge`}</span>
-              </button>
+              <PromoteButton
+                track={this.props.currentTrack}
+                targetRisks={RISKS}
+                promoteToChannel={this.onPromoteToChannel.bind(this, revision)}
+              />
             }
             { hasPendingRelease &&
               <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.undoClick.bind(this, revision)}>
@@ -55,12 +58,18 @@ export default class RevisionsList extends Component {
     });
   }
 
-  releaseClick(revision) {
-    this.props.promoteRevision(revision, `${this.props.currentTrack}/edge`);
+  onPromoteToChannel(revision, targetChannel) {
+    this.props.promoteRevision(revision, targetChannel);
   }
 
+  // TODO:
+  // - undo doesn't work if release is in channel different then edge
+  // - do it nicer?
   undoClick(revision) {
     this.props.undoRelease(revision, `${this.props.currentTrack}/edge`);
+    this.props.undoRelease(revision, `${this.props.currentTrack}/beta`);
+    this.props.undoRelease(revision, `${this.props.currentTrack}/candidate`);
+    this.props.undoRelease(revision, `${this.props.currentTrack}/stable`);
   }
 
   isAlreadyReleased(revision) {
@@ -83,7 +92,7 @@ export default class RevisionsList extends Component {
               <th width="12%" scope="col">Architecture</th>
               <th width="30%" scope="col">Channels</th>
               <th width="15%" scope="col" className="u-align--right">Submission date</th>
-              <th width="10%" scope="col" className="u-align--right">Release</th>
+              <th width="10%" scope="col" className="u-align--right">Actions</th>
             </tr>
           </thead>
 

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -2,43 +2,10 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import PromoteButton from './promoteButton';
-
-const RISKS = ['stable', 'candidate', 'beta', 'edge'];
-
-// TODO:
-// - don't allow releasing multiple revisions into same arch/channel
-
 export default class RevisionsList extends Component {
-  isRevisionReleased(revision, channel) {
-    const releasedChannels = this.props.getNextReleasedChannels();
-
-    const channelReleases = releasedChannels[channel];
-    if (channelReleases) {
-      return Object.keys(channelReleases).some((arch) => {
-        return channelReleases[arch].revision === revision.revision;
-      });
-    }
-    return false;
-  }
-
   renderRows(revisions) {
     return revisions.map((revision) => {
       const uploadDate = moment(revision.created_at);
-      let canBeReleased = true;
-      let hasPendingRelease = false;
-
-      const targetRisks = RISKS.filter((risk) => {
-        return !this.isRevisionReleased(revision, `${this.props.currentTrack}/${risk}`);
-      });
-
-      if (targetRisks.length === 0) {
-        canBeReleased = false;
-      }
-
-      if (!canBeReleased && this.props.pendingReleases[revision.revision]) {
-        hasPendingRelease = true;
-      }
 
       return (
         <tr key={revision.revision}>
@@ -54,42 +21,10 @@ export default class RevisionsList extends Component {
               </span>
             </span>
           </td>
-
-          <td className="u-align--right">
-            { canBeReleased &&
-              <PromoteButton
-                track={this.props.currentTrack}
-                targetRisks={targetRisks}
-                promoteToChannel={this.onPromoteToChannel.bind(this, revision)}
-              />
-            }
-            { hasPendingRelease &&
-              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.undoClick.bind(this, revision)}>
-                &#x2715;
-                <span className="p-tooltip__message">Cancel promoting this revision</span>
-              </button>
-            }
-          </td>
         </tr>
       );
     });
   }
-
-  onPromoteToChannel(revision, targetChannel) {
-    this.props.promoteRevision(revision, targetChannel);
-  }
-
-  // TODO:
-  // - undo doesn't work if release is in channel different then edge
-  // - do it nicer?
-  undoClick(revision) {
-    this.props.undoRelease(revision, `${this.props.currentTrack}/edge`);
-    this.props.undoRelease(revision, `${this.props.currentTrack}/beta`);
-    this.props.undoRelease(revision, `${this.props.currentTrack}/candidate`);
-    this.props.undoRelease(revision, `${this.props.currentTrack}/stable`);
-  }
-
-
 
   render() {
     return (
@@ -103,7 +38,6 @@ export default class RevisionsList extends Component {
               <th width="12%" scope="col">Architecture</th>
               <th width="30%" scope="col">Channels</th>
               <th width="15%" scope="col" className="u-align--right">Submission date</th>
-              <th width="10%" scope="col" className="u-align--right">Actions</th>
             </tr>
           </thead>
 
@@ -117,10 +51,5 @@ export default class RevisionsList extends Component {
 }
 
 RevisionsList.propTypes = {
-  currentTrack: PropTypes.string.isRequired,
-  pendingReleases: PropTypes.object.isRequired,
   revisions: PropTypes.object.isRequired,
-  getNextReleasedChannels: PropTypes.func.isRequired,
-  promoteRevision: PropTypes.func.isRequired,
-  undoRelease: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -114,6 +114,10 @@ export default class RevisionsTable extends Component {
     );
   }
 
+  onPromoteChannel(channel, targetChannel) {
+    this.props.promoteChannel(channel, targetChannel);
+  }
+
   renderRows(releasedChannels, archs) {
     const nextChannelReleases = this.props.getNextReleasedChannels();
     const track = this.props.currentTrack;
@@ -139,8 +143,8 @@ export default class RevisionsTable extends Component {
               { canBePromoted &&
                 <PromoteButton
                   track={track}
-                  risk={risk}
-                  promoteChannel={this.props.promoteChannel}
+                  targetRisks={RISKS.slice(0, RISKS.indexOf(risk))}
+                  promoteChannel={this.onPromoteChannel.bind(this, channel)}
                 />
               }
             </span>

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -28,32 +28,8 @@ export default class RevisionsTable extends Component {
   renderRevisionCell(track, risk, arch, releasedChannels, nextChannelReleases) {
     const channel = `${track}/${risk}`;
 
-    let canBePromoted = false;
     let thisRevision = this.getRevisionToDisplay(releasedChannels, nextChannelReleases, channel, arch);
     let thisPreviousRevision = releasedChannels[channel] && releasedChannels[channel][arch];
-
-    // check for revision and pending release in target channel (risk - 1)
-    let targetRisk = RISKS[RISKS.indexOf(risk) - 1];
-    let targetRevision = null;
-    let targetPreviousRevision = null;
-    let targetHasPendingRelease = false;
-    let targetChannel = null;
-
-    if (targetRisk) {
-      targetChannel = `${track}/${targetRisk}`;
-
-      targetRevision = this.getRevisionToDisplay(releasedChannels, nextChannelReleases, targetChannel, arch);
-      targetPreviousRevision = releasedChannels[targetChannel] && releasedChannels[targetChannel][arch];
-      targetHasPendingRelease = (
-        targetRevision && (!targetPreviousRevision || (targetPreviousRevision.revision !== targetRevision.revision))
-      );
-    }
-
-    if (risk !== 'stable' && thisRevision && !targetHasPendingRelease &&
-      (!targetRevision || targetRevision.revision !== thisRevision.revision)
-    ) {
-      canBePromoted = true;
-    }
 
     const hasPendingRelease = (
       thisRevision && (!thisPreviousRevision || (thisPreviousRevision.revision !== thisRevision.revision))
@@ -94,20 +70,12 @@ export default class RevisionsTable extends Component {
             }
           </span>
         </span>
-        { (canBePromoted || hasPendingRelease) &&
+        { hasPendingRelease &&
           <div className="p-release-buttons">
-            { canBePromoted &&
-              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.releaseClick.bind(this, thisRevision, track, risk)}>
-                &uarr;
-                <span className="p-tooltip__message">{`Promote to ${targetChannel}`}</span>
-              </button>
-            }
-            { hasPendingRelease &&
-              <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.undoClick.bind(this, thisRevision, track, risk)}>
-                &#x2715;
-                <span className="p-tooltip__message">Revert promoting this revision</span>
-              </button>
-            }
+            <button className="p-icon-button p-tooltip p-tooltip--btm-center" onClick={this.undoClick.bind(this, thisRevision, track, risk)}>
+              &#x2715;
+              <span className="p-tooltip__message">Revert promoting this revision</span>
+            </button>
           </div>
         }
       </td>
@@ -135,7 +103,6 @@ export default class RevisionsTable extends Component {
         canBePromoted = false;
       }
 
-      // TODO: show cell buttons only on hover
       return (
         <tr key={channel}>
           <td>

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -1,6 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
+import PromoteButton from './promoteButton';
+
 const RISKS = ['stable', 'candidate', 'beta', 'edge'];
 
 export default class RevisionsTable extends Component {
@@ -112,40 +114,6 @@ export default class RevisionsTable extends Component {
     );
   }
 
-  promoteChannelClick(channel, targetChannel, event) {
-    this.props.promoteChannel(channel, targetChannel);
-    this.closeAllDropdowns();
-    event.preventDefault();
-    event.stopPropagation();
-  }
-
-  dropdownButtonClick(event) {
-    this.closeAllDropdowns();
-    const controlId = event.target.closest('[aria-controls]').getAttribute('aria-controls');
-
-    if (controlId) {
-      const controlsEl = document.getElementById(controlId);
-      controlsEl.setAttribute('aria-hidden', false);
-    }
-
-    event.stopPropagation();
-  }
-
-  closeAllDropdowns() {
-    [].slice.call(document.querySelectorAll(".p-contextual-menu__dropdown")).forEach((dropdown) => {
-      dropdown.setAttribute('aria-hidden', true);
-    });
-  }
-
-  componentDidMount() {
-    // use window instead of document, as React catches all events in document
-    window.addEventListener('click', this.closeAllDropdowns);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('click', this.closeAllDropdowns);
-  }
-
   renderRows(releasedChannels, archs) {
     const nextChannelReleases = this.props.getNextReleasedChannels();
     const track = this.props.currentTrack;
@@ -164,42 +132,16 @@ export default class RevisionsTable extends Component {
       }
 
       // TODO: show cell buttons only on hover
-      const dropdownId = `promote-dropdown-${channel}`;
       return (
         <tr key={channel}>
           <td>
             <span className="p-channel-buttons">
               { canBePromoted &&
-                <button
-                  className="p-button--base p-icon-button p-contextual-menu--left"
-                  aria-controls={dropdownId}
-                  onClick={this.dropdownButtonClick.bind(this)}
-                >
-                  <i className="p-icon--contextual-menu"></i>
-                  <span className="p-contextual-menu__dropdown" id={dropdownId} aria-hidden="true">
-                    <span className="p-contextual-menu__group">
-                      <span className="p-contextual-menu__item">Promote to:</span>
-                      {
-                        RISKS.map((targetRisk, i) => {
-                          if (i < RISKS.indexOf(risk)) {
-                            return (
-                              <a
-                                className="p-contextual-menu__link is-indented"
-                                href="#"
-                                key={`promote-to-${track}/${targetRisk}`}
-                                onClick={this.promoteChannelClick.bind(this, channel, `${track}/${targetRisk}`)}
-                              >
-                                {`${track}/${targetRisk}`}
-                              </a>
-                            );
-                          } else {
-                            return null;
-                          }
-                        })
-                      }
-                    </span>
-                  </span>
-                </button>
+                <PromoteButton
+                  track={track}
+                  risk={risk}
+                  promoteChannel={this.props.promoteChannel}
+                />
               }
             </span>
             { channel }

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -114,7 +114,7 @@ export default class RevisionsTable extends Component {
     );
   }
 
-  onPromoteChannel(channel, targetChannel) {
+  onPromoteToChannel(channel, targetChannel) {
     this.props.promoteChannel(channel, targetChannel);
   }
 
@@ -142,9 +142,10 @@ export default class RevisionsTable extends Component {
             <span className="p-channel-buttons">
               { canBePromoted &&
                 <PromoteButton
+                  position="left"
                   track={track}
                   targetRisks={RISKS.slice(0, RISKS.indexOf(risk))}
-                  promoteChannel={this.onPromoteChannel.bind(this, channel)}
+                  promoteToChannel={this.onPromoteToChannel.bind(this, channel)}
                 />
               }
             </span>

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -59,6 +59,7 @@ export default class RevisionsTable extends Component {
 
     return (
       <td
+        className="p-release-table__cell"
         style={ { position: 'relative' } }
         key={`${channel}/${arch}`}
       >
@@ -152,10 +153,13 @@ export default class RevisionsTable extends Component {
     return RISKS.map(risk => {
       const channel = `${track}/${risk}`;
 
-      // TODO: check if there are any revisions in the channel
       let canBePromoted = true;
 
       if (risk === 'stable') {
+        canBePromoted = false;
+      }
+
+      if (!nextChannelReleases[channel]) {
         canBePromoted = false;
       }
 
@@ -163,7 +167,7 @@ export default class RevisionsTable extends Component {
       const dropdownId = `promote-dropdown-${channel}`;
       return (
         <tr key={channel}>
-          <td className="">
+          <td>
             <span className="p-channel-buttons">
               { canBePromoted &&
                 <button

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -56,7 +56,7 @@ export default class RevisionsTable extends Component {
                 {' '}
                 &rarr;
                 {' '}
-                <span className="p-revision-info">{thisRevision.version}
+                <span className="p-revision-info is-pending">{thisRevision.version}
                   <span className="p-revision-info__revision">({thisRevision.revision})</span>
                 </span>
               </span>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -59,4 +59,24 @@
     right: 0;
     top: 10px;
   }
+
+  .p-channel-buttons {
+    display: inline-block;
+    margin-right: .5rem;
+    width: 2rem;
+  }
+
+
+  .p-contextual-menu__item {
+    @extend .p-contextual-menu__link; // sass-lint:disable-line placeholder-in-extend
+
+    &:hover {
+      background: transparent;
+      cursor: default;
+    }
+  }
+
+  .p-contextual-menu__link.is-indented {
+    padding-left: 1rem;
+  }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -38,6 +38,7 @@
 
   .p-revision-info {
     display: inline-block;
+    min-width: 30px;
     padding-bottom: 1.2em;
     position: relative;
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -5,6 +5,9 @@
     }
   }
 
+  .p-release-table__cell {
+    position: relative;
+  }
 
   .p-icon-button {
     padding-left: .5rem;

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -41,6 +41,10 @@
     min-width: 30px;
     padding-bottom: 1.2em;
     position: relative;
+
+    &.is-pending {
+      font-weight: 400;
+    }
   }
 
   .p-revision-info__revision {


### PR DESCRIPTION
Fixes #1119

- Adds possibility to promote whole channel at once (all architectures) - button with dropdown
- Removes buttons from single revisions (we will introduce checkboxes later)

### QA
- ./run or http://snapcraft.io-pr-1120.run.demo.haus/
- go to Release page of any snap
- click on arrow button next to channel to prepare for release of whole channel



<img width="1055" alt="screen shot 2018-09-20 at 18 23 30" src="https://user-images.githubusercontent.com/83575/45832962-b0966d00-bd03-11e8-971f-18174ec2acc7.png">
