### PR TITLE
Enable access log and remove sentry dependency

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --name talisker-`hostname` --access-logfile -"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -12,7 +12,7 @@ import prometheus_flask_exporter
 import talisker.flask
 import webapp.helpers as helpers
 from webapp.blog.views import blog
-from webapp.extensions import csrf, sentry
+from webapp.extensions import csrf
 from webapp.handlers import set_handlers
 from webapp.login.views import login
 from webapp.publisher.snaps.views import publisher_snaps
@@ -77,4 +77,3 @@ def init_snapcraft(app):
 
 def init_extensions(app):
     csrf.init_app(app)
-    sentry.init_app(app)

--- a/webapp/extensions.py
+++ b/webapp/extensions.py
@@ -1,6 +1,4 @@
 from flask_wtf.csrf import CSRFProtect
-from raven.contrib.flask import Sentry
 
 
 csrf = CSRFProtect()
-sentry = Sentry()


### PR DESCRIPTION
# Summary

- enable access log on talisker.gunicorn
- Remove sentry dependency that was overwritting talisker"s configuration 

# QA

- `./run`
- Navigate in the website and make sure there is more info on the console