### PR TITLE
Add brandstores limesdr and sdratcom

### DIFF
--- a/upload_images.py
+++ b/upload_images.py
@@ -1,0 +1,122 @@
+import argparse
+import hashlib
+import json
+import requests
+from pymacaroons import Macaroon
+
+
+def get_hash(filename):
+    h = hashlib.sha256()
+    with open(filename, "rb", buffering=0) as f:
+        for b in iter(lambda: f.read(128 * 1024), b""):
+            h.update(b)
+    return h.hexdigest()
+
+
+def get_authorization_header(root, discharge):
+    """
+    Bind root and discharge macaroons and return the authorization header.
+    """
+
+    bound = Macaroon.deserialize(root).prepare_for_request(
+        Macaroon.deserialize(discharge)
+    )
+
+    return "Macaroon root={}, discharge={}".format(root, bound.serialize())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=" Update images ...")
+    parser.add_argument("snap_name")
+    parser.add_argument(
+        "action", choices=["change", "view", "download", "upload", "remove"]
+    )
+    parser.add_argument("filenames", nargs="*")
+
+    args = parser.parse_args()
+
+    headers = {
+        "Authorization": get_authorization_header(
+            "MDAyOWxvY2F0aW9uIG15YXBwcy5kZXZlbG9wZXIudWJ1bnR1LmNvbQowMDE2aWRlbnRpZmllciBNeUFwcHMKMDA0YmNpZCBteWFwcHMuZGV2ZWxvcGVyLnVidW50dS5jb218dmFsaWRfc2luY2V8MjAxOC0wOS0xM1QxMzozNzoyMS4wNDEyMDIKMDE3ZGNpZCB7InNlY3JldCI6ICJWdFVBU2dyQWVjaWJ3WXZzbTA3U25KNFM1ZStJWWdPYmR4dFFsbjUxd0lsZ0FPZVdoeFd0MEllcVAzMElCaTVURDZTMit6NmdMUTFoak9WNWxxeXdmc3MxWXhocCtrdTQ2RDV0QTRsYkpNcmJsUlcvaEwwSG03ajhkeUZDTXYwbEVVUDdUWmdYcDVSa0FMdG50cVJpanI4V1Q0R1I1Vy9Wc0ZxdHFvU3o4OW1OM2JmK29Cbk1ZQ0dOWnNIL2lycGRiK1U5YmwwSWQ2UVNFRmZBd0FuWlh3cVUzTGMyZTdRMmdqL2NVRlBXSTZiQnBZTWdURmJWYWg0NzFoZy9JdW1GM1RPYUZxaUZnSlNhM1EyVThVdFArSmVycTZEMzRVSVQyOXAydmpzeUFvakRWQ0JvYkFlTklpMVBRc3Nra3NhdXZqK2RsRzhMdDRJb1ZxZDVsdG91MUE9PSIsICJ2ZXJzaW9uIjogMX0KMDA1MXZpZCAAHb7bE_SILtaBd-Xi_7A81GMojYIqJgMcOhV075yEH2bVztjqsQ8w1I5gDHeiOLGf1H3Sz9orQAbw32svQrI1HUoOlCkXbigKMDAxOGNsIGxvZ2luLnVidW50dS5jb20KMDA1ZGNpZCBteWFwcHMuZGV2ZWxvcGVyLnVidW50dS5jb218YWNsfFsicGFja2FnZV9hY2Nlc3MiLCAicGFja2FnZV91cGxvYWQiLCAiZWRpdF9hY2NvdW50Il0KMDAyZnNpZ25hdHVyZSBJtgDwvkm2FjDuL9k4rZvwAJcJKhK1tfE9cWp49pRZhAo",
+            "MDAxZWxvY2F0aW9uIGxvZ2luLnVidW50dS5jb20KMDE4NGlkZW50aWZpZXIgeyJzZWNyZXQiOiAiVnRVQVNnckFlY2lid1l2c20wN1NuSjRTNWUrSVlnT2JkeHRRbG41MXdJbGdBT2VXaHhXdDBJZXFQMzBJQmk1VEQ2UzIrejZnTFExaGpPVjVscXl3ZnNzMVl4aHAra3U0NkQ1dEE0bGJKTXJibFJXL2hMMEhtN2o4ZHlGQ012MGxFVVA3VFpnWHA1UmtBTHRudHFSaWpyOFdUNEdSNVcvVnNGcXRxb1N6ODltTjNiZitvQm5NWUNHTlpzSC9pcnBkYitVOWJsMElkNlFTRUZmQXdBblpYd3FVM0xjMmU3UTJnai9jVUZQV0k2YkJwWU1nVEZiVmFoNDcxaGcvSXVtRjNUT2FGcWlGZ0pTYTNRMlU4VXRQK0plcnE2RDM0VUlUMjlwMnZqc3lBb2pEVkNCb2JBZU5JaTFQUXNza2tzYXV2aitkbEc4THQ0SW9WcWQ1bHRvdTFBPT0iLCAidmVyc2lvbiI6IDF9CjAwY2FjaWQgbG9naW4udWJ1bnR1LmNvbXxhY2NvdW50fGV5SjFjMlZ5Ym1GdFpTSTZJQ0owWW0xaUlpd2dJbTl3Wlc1cFpDSTZJQ0pOTmxKTWFFdDNJaXdnSW1ScGMzQnNZWGx1WVcxbElqb2dJbFJvYjIxaGN5QkNhV3hzWlNJc0lDSmxiV0ZwYkNJNklDSjBiM1J2UUdOaGJtOXVhV05oYkM1amIyMGlMQ0FpYVhOZmRtVnlhV1pwWldRaU9pQjBjblZsZlE9PQowMDQwY2lkIGxvZ2luLnVidW50dS5jb218dmFsaWRfc2luY2V8MjAxOC0wOS0xM1QxMzozNzoyMi45MTY3MzMKMDAzZWNpZCBsb2dpbi51YnVudHUuY29tfGxhc3RfYXV0aHwyMDE4LTA5LTEzVDEzOjM3OjIyLjkxNjczMwowMDNjY2lkIGxvZ2luLnVidW50dS5jb218ZXhwaXJlc3wyMDE5LTA5LTEzVDEzOjM3OjIyLjkxNjc2NAowMDJmc2lnbmF0dXJlIMEZHnwG2CFHbUA_CmEdPE9-p6r-K-5AmrPGWRRkHQ6ZCg",
+        )
+    }
+
+    print("Finding {} snap ...".format(args.snap_name))
+    url = "https://dashboard.snapcraft.io/dev/api/account"
+    r = requests.get(url, headers=headers)
+    try:
+        snap_id = r.json()["snaps"]["16"][args.snap_name]["snap-id"]
+    except KeyError:
+        print("Snap not found!")
+        return
+
+    url = "https://dashboard.snapcraft.io/dev/api/snaps/{}/binary-metadata".format(
+        snap_id
+    )
+    r = requests.get(url, headers=headers)
+    info = r.json()
+    print(info)
+
+    if args.action == "download":
+        for entry in info:
+            print("Downloading {} ...".format(entry["filename"]))
+            with open(entry["filename"], "wb") as fd, requests.get(
+                entry["url"], stream=True
+            ) as r:
+                for chunk in r.iter_content(chunk_size=512):
+                    if chunk:
+                        fd.write(chunk)
+    elif args.action == "view":
+        print()
+        print(info)
+    elif args.action == "upload":
+        files = []
+        for fn in args.filenames:
+            info.append(
+                {
+                    "key": fn,
+                    "filename": fn,
+                    "type": "icon",
+                    "hash": get_hash(fn),
+                }
+            )
+            files.append((fn, (fn, open(fn, "rb"), "image/png")))
+        data = {"info": json.dumps(info)}
+        r = requests.put(url, data=data, files=files, headers=headers)
+        print()
+        print(r.json())
+    elif args.action == "remove":
+        new_info = [e for e in info if e["filename"] not in args.filenames]
+        files = {"info": ("", json.dumps(new_info))}
+        r = requests.put(url, data=None, files=files, headers=headers)
+        print()
+        print(r.json())
+    elif args.action == "change":
+        new_info = [
+            {
+                "hash": "e846d4e48415e3c796ea2cac0837f8811d582da7557e4a3c09d660158c40a661",
+                "filename": "snapcraft.png",
+                "type": "screenshot",
+            },
+            {
+                "hash": "5eb253a70262c0dca5858435f31f80fec5352b48da9e61dde4c391e34aa79e25",
+                "filename": "canteen.png",
+                "type": "screenshot",
+            },
+            {
+                "hash": "25b9679012862667442649513b7200480640d980d20663ba9748c1450d78d397",
+                "filename": "kibana_ssho1.png",
+                "type": "screenshot",
+            },
+        ]
+        files = {"info": ("", json.dumps(new_info))}
+        r = requests.put(url, data=None, files=files, headers=headers)
+        print()
+        print(r.json())
+
+    print("Bye !!")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -62,7 +62,10 @@ def create_app(testing=False):
 
 def init_brandstore(app):
     store = app.config.get("WEBAPP_CONFIG").get("STORE_QUERY")
-    app.register_blueprint(store_blueprint(store))
+    displayed_snaps = app.config.get("WEBAPP_CONFIG").get(
+        "DISPLAYED_SNAPS_HOMEPAGE"
+    )
+    app.register_blueprint(store_blueprint(store, displayed_snaps))
 
 
 def init_snapcraft(app):

--- a/webapp/configs/limenet.py
+++ b/webapp/configs/limenet.py
@@ -6,8 +6,14 @@ WEBAPP_CONFIG = {
         "COLOUR": "#fff",
     },
     "STORE_LINKS": [
-        {"title": "Lime Micro", "href": "http://www.limemicro.com/"},
-        {"title": "Myriad-RF", "href": "https://myriadrf.org/"},
+        {
+            "title": "Documentation",
+            "href": "https://wiki.myriadrf.org/LimeNET_App_Store",
+        },
+        {
+            "title": "LimeNET",
+            "href": "https://limemicro.com/initiatives/limenet/",
+        },
     ],
     "CUSTOM_STYLES": ".p-navigation__link a,.p-navigation__link a:visited,\
      .p-navigation__link a:focus {color: #000;}\

--- a/webapp/configs/limesdr.py
+++ b/webapp/configs/limesdr.py
@@ -1,8 +1,8 @@
 WEBAPP_CONFIG = {
     "LAYOUT": "_layout-brandstore.html",
-    "STORE_NAME": "LimeNET",
+    "STORE_NAME": "LimeSDR",
     "STORE_BRAND": {
-        "LOGO": "https://assets.ubuntu.com/v1/cc2b2033-lime-logo.svg",
+        "LOGO": "https://assets.ubuntu.com/v1/7cfebe3e-LimeSDR.svg",
         "COLOUR": "#fff",
     },
     "STORE_LINKS": [
@@ -15,6 +15,6 @@ WEBAPP_CONFIG = {
     "STORE_INSTALL_INSTRUCTIONS": True,
     "FOOTER_TEXT": "Copyright 2018  Canonical Ltd.<br/>\
       Ubuntu and Canonical are registered trademarks of Canonical Ltd.",
-    "STORE_QUERY": "LimeNET",
-    "DISPLAYED_SNAPS_HOMEPAGE": "all",
+    "STORE_QUERY": "LimeSDR",
+    "DISPLAYED_SNAPS_HOMEPAGE": "featured",
 }

--- a/webapp/configs/limesdr.py
+++ b/webapp/configs/limesdr.py
@@ -6,8 +6,14 @@ WEBAPP_CONFIG = {
         "COLOUR": "#fff",
     },
     "STORE_LINKS": [
-        {"title": "Lime Micro", "href": "http://www.limemicro.com/"},
-        {"title": "Myriad-RF", "href": "https://myriadrf.org/"},
+        {
+            "title": "Documentation",
+            "href": "https://wiki.myriadrf.org/LimeSDR_App_Store",
+        },
+        {
+            "title": "Myriad-RF",
+            "href": "https://limemicro.com/products/boards/",
+        },
     ],
     "CUSTOM_STYLES": ".p-navigation__link a,.p-navigation__link a:visited,\
      .p-navigation__link a:focus {color: #000;}\

--- a/webapp/configs/sdratcom.py
+++ b/webapp/configs/sdratcom.py
@@ -1,20 +1,17 @@
 WEBAPP_CONFIG = {
     "LAYOUT": "_layout-brandstore.html",
-    "STORE_NAME": "LimeNET",
+    "STORE_NAME": "sdrsatcom",
     "STORE_BRAND": {
-        "LOGO": "https://assets.ubuntu.com/v1/cc2b2033-lime-logo.svg",
-        "COLOUR": "#fff",
+        "LOGO": "https://assets.ubuntu.com/v1/7a1fe153-ESA.png",
+        "COLOUR": "#021728",
     },
-    "STORE_LINKS": [
-        {"title": "Lime Micro", "href": "http://www.limemicro.com/"},
-        {"title": "Myriad-RF", "href": "https://myriadrf.org/"},
-    ],
+    "STORE_LINKS": [{"title": "ESA", "href": "https://www.esa.int/ESA"}],
     "CUSTOM_STYLES": ".p-navigation__link a,.p-navigation__link a:visited,\
      .p-navigation__link a:focus {color: #000;}\
      .p-navigation__link a:hover {color: #049619; background: transparent;}",
     "STORE_INSTALL_INSTRUCTIONS": True,
     "FOOTER_TEXT": "Copyright 2018  Canonical Ltd.<br/>\
       Ubuntu and Canonical are registered trademarks of Canonical Ltd.",
-    "STORE_QUERY": "LimeNET",
+    "STORE_QUERY": "sdrsatcom",
     "DISPLAYED_SNAPS_HOMEPAGE": "all",
 }

--- a/webapp/configs/sdratcom.py
+++ b/webapp/configs/sdratcom.py
@@ -3,12 +3,21 @@ WEBAPP_CONFIG = {
     "STORE_NAME": "sdrsatcom",
     "STORE_BRAND": {
         "LOGO": "https://assets.ubuntu.com/v1/7a1fe153-ESA.png",
-        "COLOUR": "#021728",
+        "COLOUR": "#fff",
     },
-    "STORE_LINKS": [{"title": "ESA", "href": "https://www.esa.int/ESA"}],
+    "STORE_LINKS": [
+        {
+            "title": "Documentation",
+            "href": "https://wiki.myriadrf.org/SDR_Satcom_App_Store",
+        },
+        {
+            "title": "SDR Satcom",
+            "href": "https://wiki.myriadrf.org/SDR_Satcom",
+        },
+    ],
     "CUSTOM_STYLES": ".p-navigation__link a,.p-navigation__link a:visited,\
      .p-navigation__link a:focus {color: #000;}\
-     .p-navigation__link a:hover {color: #049619; background: transparent;}",
+     .p-navigation__link a:hover {color: #002568; background: transparent;}",
     "STORE_INSTALL_INSTRUCTIONS": True,
     "FOOTER_TEXT": "Copyright 2018  Canonical Ltd.<br/>\
       Ubuntu and Canonical are registered trademarks of Canonical Ltd.",

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -17,7 +17,7 @@ from webapp.api.exceptions import (
 from urllib.parse import quote_plus
 
 
-def store_blueprint(store_query=None):
+def store_blueprint(store_query=None, brand_snap_displayed="featured"):
     api = StoreApi(store_query)
 
     store = flask.Blueprint(
@@ -84,7 +84,10 @@ def store_blueprint(store_query=None):
         status_code = 200
 
         try:
-            snaps_results = api.get_all_snaps(size=12)
+            if brand_snap_displayed == "featured":
+                snaps_results = api.get_featured_snaps()
+            else:
+                snaps_results = api.get_all_snaps(size=12)
         except ApiError as api_error:
             snaps_results = []
             status_code, error_info = _handle_errors(api_error)


### PR DESCRIPTION
# Summary

- Add brandstore `limesdr` and `sdratcom`
- limesdr mirrors all the snaps so it doesn't make sense to display all the snaps on the frontpage. After discussion with Celso we decided to display the featured snaps. I added a paramater in the config    `"DISPLAYED_SNAPS_HOMEPAGE"` that can be `featured` or `all`.

Here I just made the config files so that @therealjuan can test and tell me what specificity he wants.

# QA

- in  `.env` change `WEBAPP=snapcraft` to `WEBAPP=sdratcom`
 - `./run` 
- Should have the ESA brandstore with all snaps
- in  `.env` change `WEBAPP=snapcraft` to `WEBAPP=limesdr`
 - `./run` 
- Should have the limesdr brandstore with featured snaps