### PR TITLE
Ensure images fit on /blog

### DIFF
--- a/static/sass/_utilities_crop.scss
+++ b/static/sass/_utilities_crop.scss
@@ -30,5 +30,9 @@
       justify-content: center;
       text-align: center;
     }
+
+    img {
+      align-self: auto;
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1128

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/blog
- See the images fit

## Screenshot

![screenshot_2018-09-24 blog snapcraft 1](https://user-images.githubusercontent.com/479384/45942712-72d36600-bfdb-11e8-9d6d-ee367ad63172.png)
