### PR TITLE
Rollup upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "raven-js": "^3.24.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "rollup": "^0.52.1",
+    "rollup": "^0.66.2",
     "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "8.3.0",
     "rollup-plugin-node-resolve": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,14 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
+"@types/node@*":
+  version "10.10.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.10.3.tgz#09c75a4ad84d6a3d286790bdd9489a4f8ee9906c"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -5480,9 +5488,12 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-rollup@^0.52.1:
-  version "0.52.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.52.1.tgz#610e8e1be432f18fcfbfa865408a1cd7618cd707"
+rollup@^0.66.2:
+  version "0.66.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.66.2.tgz#77acdb9f4093f5f035ce75480577c40a81ea7999"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Upgrades `rollup` to latest version to fix issues with rollup watch.

### QA

- ./run build
- everything should build properly as before
- please note there will be some 'circular dependency' warnings that rollup didn't show before
- ./run exec yarn watch-js
- rollup watch should run and should properly update on change in any JS file that is part of any bundle