### PR TITLE
Add close channel endpoint

### DIFF
--- a/tests/publisher/snaps/tests_post_close_channel.py
+++ b/tests/publisher/snaps/tests_post_close_channel.py
@@ -111,18 +111,23 @@ class PostDataCloseChannelPage(BaseTestCases.EndpointLoggedIn):
         response = self.client.post(self.endpoint_url, json=self.json)
         self.check_call_by_api_url(responses.calls)
 
-        assert response.json == payload
+        result = {"success": True}
+        assert response.json == result
 
     @responses.activate
     def test_return_error(self):
-        payload = {"errors": [{"name": ["message"]}]}
+        payload = {"error_list": [{"code": "code", "name": ["message"]}]}
 
         responses.add(responses.POST, self.api_url, json=payload, status=400)
 
         response = self.client.post(self.endpoint_url, json=self.json)
         self.check_call_by_api_url(responses.calls)
 
-        assert response.json == payload
+        expected_response = {
+            "errors": [{"code": "code", "name": ["message"]}],
+            "success": False,
+        }
+        assert response.json == expected_response
 
     @responses.activate
     def test_error_4xx(self):
@@ -132,5 +137,6 @@ class PostDataCloseChannelPage(BaseTestCases.EndpointLoggedIn):
         response = self.client.post(self.endpoint_url, json=self.json)
         self.check_call_by_api_url(responses.calls)
 
+        expected_response = {"errors": [], "success": False}
         assert response.status_code == 400
-        assert response.get_json() == []
+        assert response.get_json() == expected_response

--- a/tests/publisher/snaps/tests_post_close_channel.py
+++ b/tests/publisher/snaps/tests_post_close_channel.py
@@ -1,0 +1,87 @@
+import responses
+
+from tests.publisher.endpoint_testing import BaseTestCases
+
+
+class PostCloseChannelPageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = "/{}/release/close-channel".format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url,
+            method_endpoint="POST",
+        )
+
+
+class PostDataCloseChannelPage(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
+        snap_name = "test-snap"
+        snap_id = "test-id"
+        endpoint_url = "/{}/release/close-channel".format(snap_name)
+        api_url = (
+            "https://dashboard.snapcraft.io/dev/api/"
+            "snaps/{}/close".format(snap_id)
+        )
+        json = {"id": snap_id, "info": "json"}
+
+        super().setUp(
+            snap_name=snap_name,
+            api_url=api_url,
+            endpoint_url=endpoint_url,
+            method_api="POST",
+            method_endpoint="POST",
+            json=json,
+        )
+
+    @responses.activate
+    def test_page_not_found(self):
+        payload = {"error_list": []}
+        responses.add(responses.POST, self.api_url, json=payload, status=404)
+
+        response = self.client.post(self.endpoint_url, json=self.json)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        assert response.status_code == 404
+        self.assert_template_used("404.html")
+
+    @responses.activate
+    def test_post_no_data(self):
+        response = self.client.post(self.endpoint_url)
+
+        assert response.status_code == 200
+        assert response.get_json() == {}
+
+    @responses.activate
+    def test_post_data(self):
+        payload = {}
+
+        responses.add(responses.POST, self.api_url, json=payload, status=200)
+
+        response = self.client.post(self.endpoint_url, json=self.json)
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        assert response.json == payload
+
+    @responses.activate
+    def test_return_error(self):
+        payload = {"errors": [{"name": ["message"]}]}
+
+        responses.add(responses.POST, self.api_url, json=payload, status=400)
+
+        response = self.client.post(self.endpoint_url, json=self.json)
+
+        assert response.json == payload

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -60,6 +60,8 @@ SNAP_RELEASE_HISTORY_URL = "".join(
 
 SNAP_RELEASE = "".join([DASHBOARD_API, "snap-release/"])
 
+CLOSE_CHANNEL = "".join([DASHBOARD_API, "snaps/{snap_id}/close"])
+
 
 def process_response(response):
     try:
@@ -290,6 +292,18 @@ def snap_release_history(session, snap_name):
 def post_snap_release(session, snap_name, json):
     response = api_session.post(
         url=SNAP_RELEASE, headers=get_authorization_header(session), json=json
+    )
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired
+
+    return process_response(response)
+
+
+def post_close_channel(session, snap_id, json):
+    url = CLOSE_CHANNEL.format(snap_id=snap_id)
+    response = api_session.post(
+        url=url, headers=get_authorization_header(session), json=json
     )
 
     if authentication.is_macaroon_expired(response.headers):

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -495,18 +495,18 @@ def post_close_channel(snap_name):
     if not data:
         return flask.jsonify({})
 
-    if data["id"]:
-        snap_id = data["id"]
-    else:
-        return flask.jsonify({})
-
-    if data["info"]:
-        json = "info"
-    else:
-        return flask.jsonify({})
+    try:
+        snap_id = api.get_snap_id(snap_name, flask.session)
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return flask.jsonify(api_response_error_list.errors), 400
+    except ApiError as api_error:
+        return _handle_errors(api_error)
 
     try:
-        response = api.post_close_channel(flask.session, snap_id, json)
+        response = api.post_close_channel(flask.session, snap_id, data)
     except ApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -487,6 +487,37 @@ def post_release(snap_name):
     return flask.jsonify(response)
 
 
+@publisher_snaps.route("/<snap_name>/release/close-channel", methods=["POST"])
+@login_required
+def post_close_channel(snap_name):
+    data = flask.request.json
+
+    if not data:
+        return flask.jsonify({})
+
+    if data["id"]:
+        snap_id = data["id"]
+    else:
+        return flask.jsonify({})
+
+    if data["info"]:
+        json = "info"
+    else:
+        return flask.jsonify({})
+
+    try:
+        response = api.post_close_channel(flask.session, snap_id, json)
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return flask.jsonify(api_response_error_list.errors), 400
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    return flask.jsonify(response)
+
+
 @publisher_snaps.route("/account/register-snap")
 def redirect_get_register_name():
     return flask.redirect(flask.url_for(".get_register_name"))

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -511,10 +511,15 @@ def post_close_channel(snap_name):
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
         else:
-            return flask.jsonify(api_response_error_list.errors), 400
+            response = {
+                "errors": api_response_error_list.errors,
+                "success": False,
+            }
+            return flask.jsonify(response), 400
     except ApiError as api_error:
         return _handle_errors(api_error)
 
+    response["success"] = True
     return flask.jsonify(response)
 
 


### PR DESCRIPTION
# Summary

Fixes #1132 
Add close channel endpoint 
https://dashboard.snapcraft.io/docs/api/snap.html#close-a-channel-for-a-snap-package

# QA

It's written in the same way as the realease endpoint

@bartaz you can try with the frontend you write

```
POST /SNAP_NAME/release/close-channel
{
  info to send to the API
}
```