### PR TITLE
Add API v2 staging URLs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ To use staging APIs locally you can add the following lines to an `.env.local` f
 
 ```bash
 SNAPCRAFT_IO_API=https://api.staging.snapcraft.io/api/v1/
+SNAPCRAFT_IO_API_V2=https://api.staging.snapcraft.io/v2/
 DASHBOARD_API=https://dashboard.staging.snapcraft.io/dev/api/
+DASHBOARD_API_V2=https://dashboard.staging.snapcraft.io/api/v2/
 LOGIN_URL=https://login.staging.ubuntu.com
 ```
 


### PR DESCRIPTION
Adds missing API v2 staging URLS to README

### QA

- Copy instructions to .env file.
- ./run
- check if staging is used everywhere