### PR TITLE
Select revisions into fake unassigned channel

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -17,20 +17,6 @@ function getTracksFromChannelMap(channelMapsList) {
   return tracks;
 }
 
-// getting list of tracks names from channel maps list
-function getArchsFromChannelMap(channelMapsList) {
-  const archs = [];
-
-  channelMapsList.map(a => a.architecture).forEach(arch => {
-    // if we haven't saved it yet
-    if (archs.indexOf(arch) === -1) {
-      archs.push(arch);
-    }
-  });
-
-  return archs.sort();
-}
-
 // transforming channel map list data into format used by this component
 function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
   const releasedChannels = {};
@@ -93,7 +79,6 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
 
   const releasedChannels = getReleaseDataFromChannelMap(channelMapsList, revisionsMap);
   const tracks = getTracksFromChannelMap(channelMapsList);
-  const archs = getArchsFromChannelMap(channelMapsList);
 
   ReactDOM.render(
     <ReleasesController
@@ -101,7 +86,6 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
       releasedChannels={releasedChannels}
       revisions={releasesData.revisions}
       tracks={tracks}
-      archs={archs}
       options={options}
     />,
     document.querySelector(id)

--- a/static/js/publisher/release/constants.js
+++ b/static/js/publisher/release/constants.js
@@ -1,0 +1,18 @@
+const STABLE = 'stable';
+const CANDIDATE = 'candidate';
+const BETA = 'beta';
+const EDGE = 'edge';
+const UNASSIGNED = 'unassigned';
+
+const RISKS = [STABLE, CANDIDATE, BETA, EDGE];
+const RISKS_WITH_UNASSIGNED = [STABLE, CANDIDATE, BETA, EDGE, UNASSIGNED];
+
+export {
+  STABLE,
+  CANDIDATE,
+  BETA,
+  EDGE,
+  UNASSIGNED,
+  RISKS,
+  RISKS_WITH_UNASSIGNED
+};

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -6,6 +6,8 @@ import RevisionsTable from './revisionsTable';
 import RevisionsList from './revisionsList';
 import Notification from './notification';
 
+import { UNASSIGNED } from './constants';
+
 export default class ReleasesController extends Component {
   constructor(props) {
     super(props);
@@ -54,8 +56,6 @@ export default class ReleasesController extends Component {
   selectRevision(revision) {
     this.setState((state) => {
       const releasedChannels = state.releasedChannels;
-      // TODO: export as a constant?
-      const UNASSIGNED = 'unassigned';
 
       // TODO: support multiple archs
       const arch = revision.architectures[0];

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -18,6 +18,8 @@ export default class ReleasesController extends Component {
       // released channels contains channel map for each channel in current track
       // also includes 'unassigned' fake channel to show selected unassigned revision
       releasedChannels: this.props.releasedChannels,
+      // list of architectures released to (or selected to be released to)
+      archs: this.getArchsFromReleasedChannels(this.props.releasedChannels),
       // revisions to be released:
       // key is the id of revision to release
       // value is object containing release object and channels to release to
@@ -32,6 +34,21 @@ export default class ReleasesController extends Component {
       // list of selected revisions, to know which ones to render selected
       selectedRevisions: []
     };
+  }
+
+  // update list of architectures based on revisions released (or selected)
+  getArchsFromReleasedChannels(releasedChannels) {
+    let archs = [];
+    Object.keys(releasedChannels).forEach(channel => {
+      Object.keys(releasedChannels[channel]).forEach(arch => {
+        archs.push(arch);
+      });
+    });
+
+    // make archs unique and sorted
+    archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
+
+    return archs.sort();
   }
 
   selectRevision(revision) {
@@ -54,10 +71,12 @@ export default class ReleasesController extends Component {
       }
 
       const selectedRevisions = Object.keys(releasedChannels[UNASSIGNED]).map(arch => releasedChannels[UNASSIGNED][arch].revision);
+      const archs = this.getArchsFromReleasedChannels(releasedChannels);
 
       return {
         selectedRevisions,
-        releasedChannels
+        releasedChannels,
+        archs
       };
     });
   }
@@ -279,8 +298,11 @@ export default class ReleasesController extends Component {
           }
         });
 
+        const archs = this.getArchsFromReleasedChannels(releasedChannels);
+
         return {
-          releasedChannels
+          releasedChannels,
+          archs
         };
       });
     } else {
@@ -375,8 +397,8 @@ export default class ReleasesController extends Component {
   }
 
   render() {
-    const { archs, tracks } = this.props;
-    const { releasedChannels } = this.state;
+    const { tracks } = this.props;
+    const { archs, releasedChannels } = this.state;
 
     return (
       <Fragment>
@@ -417,7 +439,6 @@ ReleasesController.propTypes = {
   snapName: PropTypes.string.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   revisions: PropTypes.array.isRequired,
-  archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
   options: PropTypes.object.isRequired
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import distanceInWords from 'date-fns/distance_in_words_strict';
 import format from 'date-fns/format';
 
+import { UNASSIGNED } from './constants';
+
 export default class RevisionsList extends Component {
   revisionSelectChange(revision) {
     this.props.selectRevision(revision);
@@ -12,8 +14,7 @@ export default class RevisionsList extends Component {
     return revisions.map((revision) => {
       const uploadDate = new Date(revision.created_at);
       const isSelected = this.props.selectedRevisions.includes(revision.revision);
-      // TODO: try not to hardcode 'unassigned' name, better way to check if there are any?
-      const isDisabled = !isSelected && revision.architectures.some((arch) => this.props.releasedChannels['unassigned'] && this.props.releasedChannels['unassigned'][arch]);
+      const isDisabled = !isSelected && revision.architectures.some((arch) => this.props.releasedChannels[UNASSIGNED] && this.props.releasedChannels[UNASSIGNED][arch]);
 
       return (
         <tr key={revision.revision} className={isDisabled ? 'is-disabled' : ''}>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -20,7 +20,7 @@ export default class RevisionsList extends Component {
         <tr key={revision.revision} className={isDisabled ? 'is-disabled' : ''}>
           <td>
             <input type="checkbox" checked={isSelected} id={`revision-check-${revision.revision}`} onChange={this.revisionSelectChange.bind(this, revision)}/>
-            <label htmlFor={`revision-check-${revision.revision}`}>{ revision.revision }</label>
+            <label className="u-no-margin--bottom" htmlFor={`revision-check-${revision.revision}`}>{ revision.revision }</label>
           </td>
           <td>{ revision.version }</td>
           <td>{ revision.architectures.join(", ") }</td>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -4,21 +4,31 @@ import distanceInWords from 'date-fns/distance_in_words_strict';
 import format from 'date-fns/format';
 
 export default class RevisionsList extends Component {
+  revisionSelectChange(revision) {
+    this.props.selectRevision(revision);
+  }
+
   renderRows(revisions) {
     return revisions.map((revision) => {
       const uploadDate = new Date(revision.created_at);
+      const isSelected = this.props.selectedRevisions.includes(revision.revision);
+      // TODO: try not to hardcode 'unassigned' name, better way to check if there are any?
+      const isDisabled = !isSelected && revision.architectures.some((arch) => this.props.releasedChannels['unassigned'] && this.props.releasedChannels['unassigned'][arch]);
 
       return (
-        <tr key={revision.revision}>
-          <td>{ revision.revision }</td>
+        <tr key={revision.revision} className={isDisabled ? 'is-disabled' : ''}>
+          <td>
+            <input type="checkbox" checked={isSelected} id={`revision-check-${revision.revision}`} onChange={this.revisionSelectChange.bind(this, revision)}/>
+            <label htmlFor={`revision-check-${revision.revision}`}>{ revision.revision }</label>
+          </td>
           <td>{ revision.version }</td>
           <td>{ revision.architectures.join(", ") }</td>
           <td>{ revision.channels.join(", ") }</td>
           <td className="u-align--right">
             <span className="p-tooltip p-tooltip--btm-center" aria-describedby={`revision-uploaded-${revision.revision}`}>
               { distanceInWords(
-                new Date(), 
-                uploadDate, 
+                new Date(),
+                uploadDate,
                 { addSuffix: true }
               ) }
               <span className="p-tooltip__message u-align--center" role="tooltip" id={`revision-uploaded-${revision.revision}`}>
@@ -35,10 +45,10 @@ export default class RevisionsList extends Component {
     return (
       <Fragment>
         <h4>Revisions available</h4>
-        <table>
+        <table className="p-revisions-list">
           <thead>
             <tr>
-              <th width="10%" scope="col">Revision</th>
+              <th className="col-has-checkbox" width="10%" scope="col">Revision</th>
               <th width="23%" scope="col">Version</th>
               <th width="12%" scope="col">Architecture</th>
               <th width="30%" scope="col">Channels</th>
@@ -57,4 +67,7 @@ export default class RevisionsList extends Component {
 
 RevisionsList.propTypes = {
   revisions: PropTypes.object.isRequired,
+  selectedRevisions: PropTypes.array.isRequired,
+  releasedChannels: PropTypes.object.isRequired,
+  selectRevision: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -1,9 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
+import { RISKS_WITH_UNASSIGNED as RISKS, UNASSIGNED, STABLE } from './constants';
 import PromoteButton from './promoteButton';
-
-const RISKS = ['stable', 'candidate', 'beta', 'edge', 'unassigned'];
 
 export default class RevisionsTable extends Component {
   getRevisionToDisplay(releasedChannels, nextReleases, channel, arch) {
@@ -27,7 +26,7 @@ export default class RevisionsTable extends Component {
 
   renderRevisionCell(track, risk, arch, releasedChannels, nextChannelReleases) {
     // TODO: extract or try not to duplicate?
-    const channel = risk === 'unassigned' ? risk : `${track}/${risk}`;
+    const channel = risk === UNASSIGNED ? risk : `${track}/${risk}`;
 
     let thisRevision = this.getRevisionToDisplay(releasedChannels, nextChannelReleases, channel, arch);
     let thisPreviousRevision = releasedChannels[channel] && releasedChannels[channel][arch];
@@ -120,11 +119,11 @@ export default class RevisionsTable extends Component {
 
     return RISKS.map(risk => {
       // TODO: extract or try not to duplicate?
-      const channel = risk === 'unassigned' ? risk : `${track}/${risk}`;
+      const channel = risk === UNASSIGNED ? risk : `${track}/${risk}`;
 
       // don't show unassigned revisions until some are selected from the table
       // TODO: always show (when we can click on it)
-      if (risk === 'unassigned' &&
+      if (risk === UNASSIGNED &&
         !releasedChannels[channel] ||
         (releasedChannels[channel] && Object.keys(releasedChannels[channel]).length === 0)) {
         return null;
@@ -133,11 +132,11 @@ export default class RevisionsTable extends Component {
       let canBePromoted = true;
       let canBeClosed = true;
 
-      if (risk === 'stable') {
+      if (risk === STABLE) {
         canBePromoted = false;
       }
 
-      if (risk === 'unassigned') {
+      if (risk === UNASSIGNED) {
         canBeClosed = false;
       }
 
@@ -182,7 +181,7 @@ export default class RevisionsTable extends Component {
                 />
               }
             </span>
-            { risk === 'unassigned'
+            { risk === UNASSIGNED
               ? <em>Unassigned revisions</em>
               : channel
             }

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import PromoteButton from './promoteButton';
 
-const RISKS = ['stable', 'candidate', 'beta', 'edge'];
+const RISKS = ['stable', 'candidate', 'beta', 'edge', 'unassigned'];
 
 export default class RevisionsTable extends Component {
   getRevisionToDisplay(releasedChannels, nextReleases, channel, arch) {
@@ -26,7 +26,8 @@ export default class RevisionsTable extends Component {
   }
 
   renderRevisionCell(track, risk, arch, releasedChannels, nextChannelReleases) {
-    const channel = `${track}/${risk}`;
+    // TODO: extract or try not to duplicate?
+    const channel = risk === 'unassigned' ? risk : `${track}/${risk}`;
 
     let thisRevision = this.getRevisionToDisplay(releasedChannels, nextChannelReleases, channel, arch);
     let thisPreviousRevision = releasedChannels[channel] && releasedChannels[channel][arch];
@@ -118,7 +119,16 @@ export default class RevisionsTable extends Component {
     const track = this.props.currentTrack;
 
     return RISKS.map(risk => {
-      const channel = `${track}/${risk}`;
+      // TODO: extract or try not to duplicate?
+      const channel = risk === 'unassigned' ? risk : `${track}/${risk}`;
+
+      // don't show unassigned revisions until some are selected from the table
+      // TODO: always show (when we can click on it)
+      if (risk === 'unassigned' &&
+        !releasedChannels[channel] ||
+        (releasedChannels[channel] && Object.keys(releasedChannels[channel]).length === 0)) {
+        return null;
+      }
 
       let canBePromoted = true;
       let canBeClosed = true;
@@ -168,7 +178,10 @@ export default class RevisionsTable extends Component {
                 />
               }
             </span>
-            { channel }
+            { risk === 'unassigned'
+              ? <em>Unassigned revisions</em>
+              : channel
+            }
           </td>
           {
             archs.map(arch => this.renderRevisionCell(track, risk, arch, releasedChannels, nextChannelReleases))

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -137,6 +137,10 @@ export default class RevisionsTable extends Component {
         canBePromoted = false;
       }
 
+      if (risk === 'unassigned') {
+        canBeClosed = false;
+      }
+
       if (!nextChannelReleases[channel]) {
         canBePromoted = false;
         canBeClosed = false;
@@ -172,8 +176,8 @@ export default class RevisionsTable extends Component {
                   position="left"
                   track={track}
                   targetRisks={targetRisks}
-                  closeRisk={risk}
-                  closeChannel={canBeClosed && this.onCloseChannel.bind(this, channel)}
+                  closeRisk={canBeClosed ? risk : null}
+                  closeChannel={canBeClosed ? this.onCloseChannel.bind(this, channel) : null}
                   promoteToChannel={this.onPromoteToChannel.bind(this, channel)}
                 />
               }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -74,7 +74,6 @@
     width: 2rem;
   }
 
-
   .p-contextual-menu__item {
     @extend .p-contextual-menu__link; // sass-lint:disable-line placeholder-in-extend
 
@@ -86,5 +85,20 @@
 
   .p-contextual-menu__link.is-indented {
     padding-left: 1rem;
+  }
+
+  .p-revisions-list {
+    // TODO: instead of fighting vanilla specificity add a class name
+    input+label {
+      margin-bottom: 0;
+    }
+
+    .col-has-checkbox {
+      padding-left: 2rem;
+    }
+
+    .is-disabled {
+      opacity: .5;
+    }
   }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -88,11 +88,6 @@
   }
 
   .p-revisions-list {
-    // TODO: instead of fighting vanilla specificity add a class name
-    input+label {
-      margin-bottom: 0;
-    }
-
     .col-has-checkbox {
       padding-left: 2rem;
     }

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -11,9 +11,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
 
   <section class="p-strip is-shallow">
     <div class="row">
-
       <div id="release-history"></div>
-
     </div>
   </section>
 </div>


### PR DESCRIPTION
Fixes #1134

Adds checkboxes to revisions list, so any unreleased revision can be selected into 'unassigned' channel and then released.

Also makes sure revisions from unreleased architectures can be selected and released, even if they are not currently in channel map.

### QA
- ./run or http://snapcraft.io-canonical-websites-pr-1145.run.demo.haus/
- go to Releases page of any snap you own
- you should see checkboxes on the revisions table
- select any revision by clicking on checkbox (or revision number)
- revision should get selected (into 'unassigned' channel)
- revisions from same architecture should be grayed out (as one revision per architecture can be selected)
- select other revisions (from other architectures) if you have them
- release 'unassigned' revisions to any channel using context menu

<img width="1032" alt="screen shot 2018-09-26 at 17 09 27" src="https://user-images.githubusercontent.com/83575/46089510-f7c2a900-c1ae-11e8-8abe-fb629f99e28c.png">
