### PR TITLE
Add missing metadata to templates

### DIFF
--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -58,6 +58,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "website": "website_url",
             "public_metrics_enabled": True,
             "public_metrics_blacklist": False,
+            "video_urls": [],
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -83,6 +84,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("is_on_stable", False)
         self.assert_context("public_metrics_enabled", True)
         self.assert_context("public_metrics_blacklist", False)
+        self.assert_context("video_urls", [])
 
     @responses.activate
     def test_icon(self):
@@ -100,6 +102,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "website": "website_url",
             "public_metrics_enabled": True,
             "public_metrics_blacklist": True,
+            "video_urls": [],
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -129,6 +132,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "website": "website_url",
             "public_metrics_enabled": True,
             "public_metrics_blacklist": True,
+            "video_urls": [],
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_post_listing.py
+++ b/tests/publisher/snaps/tests_post_listing.py
@@ -131,6 +131,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "website": "website_url",
             "public_metrics_enabled": True,
             "public_metrics_blacklist": True,
+            "video_urls": [],
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -177,6 +178,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         self.assert_context("is_on_stable", False)
         self.assert_context("public_metrics_enabled", True)
         self.assert_context("public_metrics_blacklist", True)
+        self.assert_context("video_urls", [])
 
     @responses.activate
     def test_return_error_udpate_all_field(self):
@@ -205,6 +207,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "website": "website_url",
             "public_metrics_enabled": False,
             "public_metrics_blacklist": True,
+            "video_urls": [],
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -253,6 +256,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         self.assert_context("is_on_stable", False)
         self.assert_context("public_metrics_enabled", False)
         self.assert_context("public_metrics_blacklist", True)
+        self.assert_context("video_urls", [])
 
         # All updatable fields
         self.assert_context("summary", "New summary")
@@ -293,6 +297,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "website": "website_url",
             "public_metrics_enabled": True,
             "public_metrics_blacklist": True,
+            "video_urls": [],
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_post_settings.py
+++ b/tests/publisher/snaps/tests_post_settings.py
@@ -172,6 +172,10 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "snap_name": self.snap_name,
             "license": "license",
             "private": True,
+            "price": 0,
+            "store": "stotore",
+            "keywords": [],
+            "status": "published",
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -204,6 +208,10 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
         self.assert_context("snap_name", self.snap_name)
         self.assert_context("private", True)
         self.assert_context("license", "license")
+        self.assert_context("price", 0)
+        self.assert_context("store", "stotore")
+        self.assert_context("keywords", [])
+        self.assert_context("status", "published")
 
     @responses.activate
     def test_return_error_udpate_all_field(self):
@@ -226,6 +234,10 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "private": True,
             "public_metrics_enabled": False,
             "public_metrics_blacklist": True,
+            "price": 0,
+            "store": "stotore",
+            "keywords": [],
+            "status": "published",
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -258,6 +270,10 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
         self.assert_context("snap_name", self.snap_name)
         self.assert_context("license", "license")
         self.assert_context("private", True)
+        self.assert_context("price", 0)
+        self.assert_context("store", "stotore")
+        self.assert_context("keywords", [])
+        self.assert_context("status", "published")
 
     @responses.activate
     def test_return_error_invalid_field(self):
@@ -290,6 +306,10 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "private": True,
             "contact": "contact adress",
             "website": "website_url",
+            "price": 0,
+            "store": "stotore",
+            "keywords": [],
+            "status": "published",
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_settings.py
+++ b/tests/publisher/snaps/tests_settings.py
@@ -50,6 +50,10 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "snap_name": snap_name,
             "private": True,
             "license": "License",
+            "price": 0,
+            "store": "stotore",
+            "keywords": [],
+            "status": "published",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -66,6 +70,10 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("snap_name", snap_name)
         self.assert_context("private", True)
         self.assert_context("license", "License")
+        self.assert_context("price", 0)
+        self.assert_context("store", "stotore")
+        self.assert_context("keywords", [])
+        self.assert_context("status", "published")
 
 
 if __name__ == "__main__":

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -250,6 +250,7 @@ def get_listing_snap(snap_name):
         "website": snap_details["website"] or "",
         "public_metrics_enabled": details_metrics_enabled,
         "public_metrics_blacklist": details_blacklist,
+        "video_urls": snap_details["video_urls"],
         "is_on_stable": is_on_stable,
     }
 
@@ -402,6 +403,7 @@ def post_listing_snap(snap_name):
                     else snap_details["website"] or ""
                 ),
                 "public_metrics_enabled": details_metrics_enabled,
+                "video_urls": snap_details["video_urls"],
                 "public_metrics_blacklist": details_blacklist,
                 "is_on_stable": is_on_stable,
                 # errors
@@ -648,6 +650,10 @@ def get_settings(snap_name):
         "countries": countries,
         "whitelist_country_codes": whitelist_country_codes,
         "blacklist_country_codes": blacklist_country_codes,
+        "price": snap_details["price"],
+        "store": snap_details["store"],
+        "keywords": snap_details["keywords"],
+        "status": snap_details["status"],
     }
 
     return flask.render_template("publisher/settings.html", **context)
@@ -737,6 +743,10 @@ def post_settings(snap_name):
                 "countries": countries,
                 "whitelist_country_codes": whitelist_country_codes,
                 "blacklist_country_codes": blacklist_country_codes,
+                "price": snap_details["price"],
+                "store": snap_details["store"],
+                "keywords": snap_details["keywords"],
+                "status": snap_details["status"],
                 # errors
                 "error_list": error_list,
                 "field_errors": field_errors,


### PR DESCRIPTION
# Summary

Fixes #1130 
Add missing metadata to templates

# QA

- `./run`
- Go on listing page and make sure you can display the metadata added
- same for the setitngs page