### PR TITLE
Consistent and thinner weight headings

### DIFF
--- a/static/sass/_snapcraft_custom-typography.scss
+++ b/static/sass/_snapcraft_custom-typography.scss
@@ -1,15 +1,4 @@
 @mixin snapcraft-custom-typography {
-  // Sizing fixes for headings on home page
-  h2,
-  .p-heading--two {
-    line-height: 1.3333;
-  }
-
-  h5,
-  .p-heading--five {
-    line-height: 1.4;
-  }
-
   // max-width based on font size for better readability
   %heading-copy--short {
     max-width: 20em;
@@ -25,8 +14,10 @@
 
   h1,
   h2,
+  .p-heading--one,
   .p-heading--two {
     @extend %heading-copy--short;
+    font-weight: 100;
   }
 
   h3,
@@ -41,12 +32,5 @@
   .p-heading--five,
   .p-heading--six {
     @extend %paragraph-copy;
-  }
-
-  // This can be removed when
-  // https://github.com/vanilla-framework/vanilla-framework/issues/1627
-  // is resolved.
-  br {
-    margin-top: 0;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
       </div>
     {% endif %}
     <div class="col-12">
-      <p class="p-heading--two">A Universal App Store for Linux</p>
+      <h2>A Universal App Store for Linux</h2>
       <p>Deliver and update your app on any Linux distribution - for desktop, cloud,  and Internet of Things.</p>
       <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Publish your app</a>
     </div>
@@ -92,7 +92,7 @@
 <div class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-6">
-      <h3>One build for all Linux and IoT</h3>
+      <h3 class="p-heading--two">One build for all Linux and IoT</h3>
     </div>
     <div class="col-6">
       <p>Snaps work across many distributions and versions of Linux. Bundle your dependencies and config, simplifying installs to a single standard command.</p>
@@ -129,7 +129,7 @@
         <img class="u-image-position--bottom" src="https://assets.ubuntu.com/v1/8e6188f0-skype.jpg" alt="" style="max-height: 80%;" />
     </div>
     <div class="col-6">
-      <h3>Showcase to millions</h3>
+      <h3 class="p-heading--two">Showcase to millions</h3>
       <p>Reach beyond your website with a listing on the Snap Store, the front page for app discovery on Ubuntu and other popular distros.</p>
       <p><a class="p-button--neutral" href="/store">Browse the Snap Store</a></p>
     </div>
@@ -139,7 +139,7 @@
 <section class="p-strip is-deep is-bordered u-image-position">
     <div class="row u-vertically-center">
       <div class="col-6">
-        <h3>Measure growth and retention</h3>
+        <h3 class="p-heading--two">Measure growth and retention</h3>
         <p>Make data-driven decisions with active install metrics. Watch as automatic updates migrate users to your latest release. Understand your audience with demographic breakdowns.</p>
       </div>
       <div class="col-6">
@@ -151,7 +151,7 @@
 <div class="p-strip is-deep is-bordered">
     <div class="row">
       <div class="col-12">
-        <h3>Snap any application</h3>
+        <h3 class="p-heading--two">Snap any application</h3>
         <p>Snapcraft works with your language or framework to make preparing your software for the Snap Store easy.</p>
       </div>
     </div>
@@ -237,7 +237,7 @@
 <section class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
-      <h3>Take 15 minutes to publish your first app</h3>
+      <h3 class="p-heading--two">Take 15 minutes to publish your first app</h3>
       <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Get Started</a>
     </div>
   </div>

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -1,7 +1,7 @@
 <section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
   <div class="row">
     {% if not webapp_config['STORE_QUERY'] %}
-      <h1 class="p-heading--three">Search thousands of snaps used by millions of people across 50 Linux distributions</h1>
+      <h1 class="p-heading--two">Search thousands of snaps used by millions of people across 50 Linux distributions</h1>
     {% endif %}
     <form action="/search" class="p-form p-form--inline p-form--search">
       {% if categories %}

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -10,7 +10,7 @@
     </div>
     <div class="row p-tabs__group">
       <div class="col-6">
-        <h1 class="u-float--left p-heading--three u-no-margin--bottom">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
+        <h1 class="u-float--left p-heading--four u-no-margin--bottom">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
       </div>
       <div class="col-6">
         <ul class="p-tabs__list u-float--right" role="tablist">

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -10,7 +10,7 @@
     </div>
     <div class="row p-tabs__group">
       <div class="col-6">
-        <h1 class="u-float--left p-heading--four u-no-margin--bottom">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
+        <h1 class="u-float--left p-heading--three u-no-margin--bottom">{% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}</h1>
       </div>
       <div class="col-6">
         <ul class="p-tabs__list u-float--right" role="tablist">

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -25,7 +25,7 @@ My published snaps — Linux software in the Snap Store
   {% endwith %}
   <div class="row">
     <div class="col-12">
-      <h1 class="p-heading--three u-float--left">My published snaps</h1>
+      <h1 class="p-heading--four u-float--left">My published snaps</h1>
       {% if snaps %}
         <a href="/account/register-snap" class="p-button--neutral u-float--right p-snap-list__register">Register snap</a>
       {% endif %}

--- a/templates/publisher/developer_programme_agreement.html
+++ b/templates/publisher/developer_programme_agreement.html
@@ -8,7 +8,7 @@
 {% include "publisher/_beta-notification.html" %}
 <section class="p-strip">
   <div class="row">
-    <h1 class="p-heading--three">Developer Programme Agreement</h1>
+    <h1 class="p-heading--two">Developer Programme Agreement</h1>
   </div>
 
   <div class="row">

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -10,13 +10,13 @@ Register new Snap name
   {% if conflict %}
     <div class="row">
       <div class="col-8 push-2">
-        <h1 class="p-heading--three">{{ snap_name }} is already taken</h1>
+        <h1 class="p-heading--two">{{ snap_name }} is already taken</h1>
       </div>
     </div>
   {% else %}
     <div class="row">
         <div class="col-8 push-2">
-          <h1 class="p-heading--three">Register snap</h1>
+          <h1 class="p-heading--two">Register snap</h1>
         </div>
     </div>
   {% endif %}

--- a/templates/publisher/username.html
+++ b/templates/publisher/username.html
@@ -10,7 +10,7 @@ Choose username — Linux software in the Snap Store
 
 <section class="p-strip">
   <div class="row">
-    <h1 class="p-heading--three">Choose a snap store username</h1>
+    <h1 class="p-heading--two">Choose a snap store username</h1>
     {% if error_list %}
       {% for error in error_list %}
         <div class="p-notification--negative">

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -5,9 +5,9 @@
 {% block content %}
   <section id="main-content" class="p-strip is-bordered">
     <div class="row">
-      <p class="p-heading--two">
+      <h2 class="p-heading--one">
         Auto-build and publish software for any Linux system or device
-      </p>
+      </h2>
     </div>
     <div class="row">
       <div class="col-12">
@@ -36,7 +36,7 @@
 
   <section class="p-strip">
     <div class="row">
-      <h3>Publish your software for</h3>
+      <h3 class="p-heading--two">Publish your software for</h3>
     </div>
     <div class="row">
       <div class="col-12 p-fluid-grid--centered">
@@ -82,7 +82,7 @@
 
   <section class="p-strip--light">
     <div class="row">
-      <h3>Why use Snapcraft?</h3>
+      <h3 class="p-heading--two">Why use Snapcraft?</h3>
     </div>
     <div class="row">
       <ul class="p-list is-split">
@@ -98,7 +98,7 @@
 
   <section class="p-strip">
     <div class="row">
-      <h3>How Snapcraft fits your workflow</h3>
+      <h3 class="p-heading--two">How Snapcraft fits your workflow</h3>
     </div>
     <div class="row">
       <div class="u-align--center">
@@ -117,7 +117,7 @@
   <section class="p-strip--light">
     <div class="row">
       <div class="col-8">
-        <h3>Fast to install, easy to create, safe to run</h3>
+        <h3 class="p-heading--two">Fast to install, easy to create, safe to run</h3>
         <p>With Snapcraft, it’s easy to get your software published in the snap store. This store lets people safely install apps from any vendor on mission-critical devices and PCs. Snaps are secure, sandboxed, containerised applications, packaged with their dependencies for predictable behaviour.</p>
         <p><a href="/">More about snaps &rsaquo;</a></p>
       </div>
@@ -128,7 +128,7 @@
   </section>
   <section class="p-strip">
     <div class="row">
-      <h3>What people are saying about snaps</h3>
+      <h3 class="p-heading--two">What people are saying about snaps</h3>
     </div>
     <div class="row">
       <div class="col-4">

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -35,7 +35,7 @@
       {% endif %}
 
       <div class="row">
-        <h2 class="p-heading--three"><a href="/search?category={{ category.slug }}">{{ category.name }}&nbsp;&rsaquo;</a></h2>
+        <h3 class="p-heading--four"><a href="/search?category={{ category.slug }}">{{ category.name }}&nbsp;&rsaquo;</a></h3>
       </div>
       <div data-category="{{ category.slug }}" class="row js-store-category">
         {# _category-partial.html loaded via JS #}


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1155
Supercedes https://github.com/canonical-websites/snapcraft.io/pull/1147

# QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004
- Visit all the pages affected by this PR (see the file list)
- Ensure the h1's and h2's are the thinner weight