### PR TITLE
Add circuit breaker to the application

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ gunicorn[gevent]
 humanize==0.5.1
 prometheus_client
 prometheus-flask-exporter==0.2.0
+pybreaker==0.4.4
 pycountry==17.9.23
 pymacaroons==0.12.0
 python-dateutil==2.6.1

--- a/templates/503.html
+++ b/templates/503.html
@@ -1,0 +1,16 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block meta_title %}Maintenance mode enabled{% endblock %}
+
+{% block content %}
+<div class="p-strip">
+  <div class="row">
+    <div class="col-10">
+      <h1>We're experiencing issues or doing maintenance</h1>
+      <h2>Please try again later</h2>
+      <p>You can check the service status at <a href="https://status.snapcraft.io">https://status.snapcraft.io</a>.</p>
+      <p>If the problem persists please check the Snapcraft <a href="https://forum.snapcraft.io">forum</a> or <a href="https://github.com/canonical-websites/snapcraft.io/issues/new">report an issue</a>.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/webapp/api/exceptions.py
+++ b/webapp/api/exceptions.py
@@ -74,3 +74,7 @@ class MacaroonRefreshRequired(ApiError):
 
     def __init__(self):
         return super().__init__("The Macaroon needs to be refreshed")
+
+
+class ApiCircuitBreaker(ApiError):
+    pass

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -52,6 +52,10 @@ def set_handlers(app):
 
         return flask.render_template("404.html", error=error.description), 404
 
+    @app.errorhandler(503)
+    def service_unavailable(error):
+        return flask.render_template("503.html"), 503
+
     # Global tasks for all requests
     # ===
     @app.before_request

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -13,6 +13,7 @@ from webapp.api.exceptions import (
     ApiResponseError,
     ApiResponseErrorList,
     ApiTimeoutError,
+    ApiCircuitBreaker,
     MacaroonRefreshRequired,
     MissingUsername,
 )
@@ -54,6 +55,8 @@ def _handle_errors(api_error: ApiError):
         return flask.redirect(flask.url_for("account.get_agreement"))
     elif type(api_error) is MacaroonRefreshRequired:
         return refresh_redirect(flask.request.path)
+    elif type(api_error) is ApiCircuitBreaker:
+        return flask.abort(503)
     else:
         return flask.abort(502, str(api_error))
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -4,6 +4,7 @@ import webapp.api.dashboard as api
 from webapp.decorators import login_required
 from webapp.api.exceptions import (
     AgreementNotSigned,
+    ApiCircuitBreaker,
     ApiError,
     ApiResponseError,
     ApiResponseErrorList,
@@ -44,6 +45,8 @@ def _handle_errors(api_error: ApiError):
         return flask.redirect(flask.url_for(".get_agreement"))
     elif type(api_error) is MacaroonRefreshRequired:
         return refresh_redirect(flask.request.path)
+    elif type(api_error) is ApiCircuitBreaker:
+        return flask.abort(503)
     else:
         return flask.abort(502, str(api_error))
 


### PR DESCRIPTION
# Summary

Fixes #1142 
- Add circtuit breaker to the requests class. After a 100 failures the requests are blocked and returns an excpection `ApiCircuitBreaker` which when catched goes to a 503 page: 

![screenshot_2018-10-02 maintenance mode enabled](https://user-images.githubusercontent.com/2707508/46345795-bfebb380-c63d-11e8-9cd4-b96a05da52b1.png)

# QA

- in `webapp/api/requests.py` modify `db_breaker = CircuitBreaker(fail_max=100)` to `db_breaker = CircuitBreaker(fail_max=5)`
- Disconnect from network
- `./run`
- reload 5 times page http://127.0.0.1:8004/toto
- you should be redirected after 5 times to the maintenance page :heart: 