### PR TITLE
Use cloudinary for snap-details images

### DIFF
--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -8,10 +8,10 @@ export default function initScreenshots(screenshotsId) {
     return;
   }
 
-  const images = Array.from(screenshotsEl.querySelectorAll('img')).map(image => image.src);
+  const images = Array.from(screenshotsEl.querySelectorAll('img')).map(image => image.dataset.original);
 
   screenshotsEl.addEventListener('click', (event) => {
-    const url = event.target.src;
+    const url = event.target.dataset.original;
 
     if (url) {
       if (isMobile()) {

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -110,7 +110,12 @@
           <div class="p-screenshots__wrapper">
             {% for screenshot in screenshots %}
               <div class="p-screenshot">
-                <img src="{{ screenshot }}" alt="" />
+                <img src="https://res.cloudinary.com/canonical/image/fetch/w_430/{{ screenshot }}"
+                  srcset="https://res.cloudinary.com/canonical/image/fetch/w_430/{{ screenshot }} 215w,
+                    https://res.cloudinary.com/canonical/image/fetch/w_860/{{ screenshot }} 430w"
+                  sizes="(min-width: 1031px) 430px,
+                    (max-width: 1030px) and (min-width: 876px) 430px,
+                    (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/w_1170/{{ screenshot }}" alt="">
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1164

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/skype
- Inspect the screenshots to see the URL's
- View the Network tab and reload the page
- See a lower download size
- Click on an image to open it in the lightbox
- Click through the lightbox
- Make sure everything works and appears as expected