### PR TITLE
Closing channel in release UI

### DIFF
--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -18,6 +18,13 @@ export default class PromoteButton extends Component {
     event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
   }
 
+  closeChannelClick(channel, event) {
+    this.props.closeChannel(channel);
+    this.closeAllDropdowns();
+    event.preventDefault(); // prevent link from changing URL
+    event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
+  }
+
   dropdownButtonClick(event) {
     this.closeAllDropdowns();
     const dropdownEl = event.target
@@ -65,6 +72,17 @@ export default class PromoteButton extends Component {
               })
             }
           </span>
+          { this.props.closeRisk &&
+            <span className="p-contextual-menu__group">
+              <a
+                className="p-contextual-menu__link"
+                href="#"
+                onClick={this.closeChannelClick.bind(this, `${track}/${this.props.closeRisk}`)}
+              >
+                Close {`${track}/${this.props.closeRisk}`}
+              </a>
+            </span>
+          }
         </span>
       </span>
     );
@@ -75,5 +93,7 @@ PromoteButton.propTypes = {
   position: PropTypes.oneOf(['left', 'center']), // right is by default
   track: PropTypes.string.isRequired,
   targetRisks: PropTypes.array.isRequired,
-  promoteToChannel: PropTypes.func.isRequired
+  closeRisk: PropTypes.string,
+  promoteToChannel: PropTypes.func.isRequired,
+  closeChannel: PropTypes.func
 };

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -55,23 +55,25 @@ export default class PromoteButton extends Component {
       >
         &uarr;
         <span className="p-contextual-menu__dropdown" aria-hidden="true">
-          <span className="p-contextual-menu__group">
-            <span className="p-contextual-menu__item">Promote to:</span>
-            {
-              this.props.targetRisks.map((targetRisk) => {
-                return (
-                  <a
-                    className="p-contextual-menu__link is-indented"
-                    href="#"
-                    key={`promote-to-${track}/${targetRisk}`}
-                    onClick={this.promoteToChannelClick.bind(this, `${track}/${targetRisk}`)}
-                  >
-                    {`${track}/${targetRisk}`}
-                  </a>
-                );
-              })
-            }
-          </span>
+          { (this.props.targetRisks.length > 0) &&
+            <span className="p-contextual-menu__group">
+              <span className="p-contextual-menu__item">Promote to:</span>
+              {
+                this.props.targetRisks.map((targetRisk) => {
+                  return (
+                    <a
+                      className="p-contextual-menu__link is-indented"
+                      href="#"
+                      key={`promote-to-${track}/${targetRisk}`}
+                      onClick={this.promoteToChannelClick.bind(this, `${track}/${targetRisk}`)}
+                    >
+                      {`${track}/${targetRisk}`}
+                    </a>
+                  );
+                })
+              }
+            </span>
+          }
           { this.props.closeRisk &&
             <span className="p-contextual-menu__group">
               <a

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -53,7 +53,7 @@ export default class PromoteButton extends Component {
         className={`p-promote-button p-button--neutral p-icon-button ${menuClass}`}
         onClick={this.dropdownButtonClick.bind(this)}
       >
-        &uarr;
+        <i className="p-icon--contextual-menu"></i>
         <span className="p-contextual-menu__dropdown" aria-hidden="true">
           { (this.props.targetRisks.length > 0) &&
             <span className="p-contextual-menu__group">

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -289,7 +289,7 @@ export default class ReleasesController extends Component {
               channel = `latest/${channel}`;
             }
 
-            releasedChannels[channel] = {};
+            delete releasedChannels[channel];
           });
         }
 

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -259,7 +259,6 @@ export default class ReleasesController extends Component {
   }
 
   handleReleaseError(error) {
-    console.log(error, error.json);
     let message = error.message || "Error while performing the release. Please try again later.";
 
     // try to find error messages in response json

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -205,9 +205,6 @@ export default class RevisionsTable extends Component {
     const releasesCount = Object.keys(pendingReleases).length;
     const closesCount = pendingCloses.length;
 
-    // TODO:
-    // add closes to tooltip
-    // undo close
     return ((releasesCount > 0 || closesCount > 0) &&
       <div className="p-release-confirm">
         <span className="p-tooltip">

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -231,6 +231,11 @@ export default class RevisionsTable extends Component {
                 {'\n'}
               </span>;
             })}
+            { closesCount > 0 &&
+              <span>
+                Close channels: {pendingCloses.join(', ')}
+              </span>
+            }
           </span>
         </span>
         {' '}

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -35,6 +35,8 @@ export default class RevisionsTable extends Component {
       thisRevision && (!thisPreviousRevision || (thisPreviousRevision.revision !== thisRevision.revision))
     );
 
+    const isChannelClosed = this.props.pendingCloses.includes(channel);
+
     return (
       <td
         className="p-release-table__cell"
@@ -43,7 +45,7 @@ export default class RevisionsTable extends Component {
       >
         <span className="p-tooltip p-tooltip--btm-center">
           <span className="p-release-version">
-            <span className={ hasPendingRelease ? 'p-previous-revision' : '' }>
+            <span className={ (hasPendingRelease || isChannelClosed) ? 'p-previous-revision' : '' }>
               { thisPreviousRevision ?
                 <span className="p-revision-info">{thisPreviousRevision.version}
                   <span className="p-revision-info__revision">({thisPreviousRevision.revision})</span>
@@ -51,14 +53,17 @@ export default class RevisionsTable extends Component {
                 '–'
               }
             </span>
-            { hasPendingRelease &&
+            { (hasPendingRelease || isChannelClosed) &&
               <span>
                 {' '}
                 &rarr;
                 {' '}
-                <span className="p-revision-info is-pending">{thisRevision.version}
-                  <span className="p-revision-info__revision">({thisRevision.revision})</span>
-                </span>
+                { hasPendingRelease ?
+                  <span className="p-revision-info is-pending">{thisRevision.version}
+                    <span className="p-revision-info__revision">({thisRevision.revision})</span>
+                  </span> :
+                  <em>close channel</em>
+                }
               </span>
             }
           </span>
@@ -67,6 +72,9 @@ export default class RevisionsTable extends Component {
             { thisPreviousRevision ? `${thisPreviousRevision.version} (${thisPreviousRevision.revision})` : 'None' }
             { hasPendingRelease &&
               <span> &rarr; { `${thisRevision.version} (${thisRevision.revision})` }</span>
+            }
+            { isChannelClosed &&
+              <span> &rarr; <em>close channel</em></span>
             }
           </span>
         </span>
@@ -84,6 +92,10 @@ export default class RevisionsTable extends Component {
 
   onPromoteToChannel(channel, targetChannel) {
     this.props.promoteChannel(channel, targetChannel);
+  }
+
+  onCloseChannel(channel) {
+    this.props.closeChannel(channel);
   }
 
   compareChannels(channel, targetChannel) {
@@ -139,6 +151,8 @@ export default class RevisionsTable extends Component {
                   position="left"
                   track={track}
                   targetRisks={targetRisks}
+                  closeRisk={risk}
+                  closeChannel={this.onCloseChannel.bind(this, channel)}
                   promoteToChannel={this.onPromoteToChannel.bind(this, channel)}
                 />
               }
@@ -176,15 +190,27 @@ export default class RevisionsTable extends Component {
   }
 
   renderReleasesConfirm() {
-    const { pendingReleases, isLoading } = this.props;
+    const { pendingReleases, pendingCloses, isLoading } = this.props;
     const releasesCount = Object.keys(pendingReleases).length;
+    const closesCount = pendingCloses.length;
 
-    return (releasesCount > 0 &&
+    // TODO:
+    // add closes to tooltip
+    // add close to all channels
+    // no close if already closed
+    // undo close
+    return ((releasesCount > 0 || closesCount > 0) &&
       <div className="p-release-confirm">
         <span className="p-tooltip">
           <i className="p-icon--question" />
           {' '}
-          { releasesCount } revision{ releasesCount > 1 ? 's' : '' } to release
+          { releasesCount > 0 &&
+            <span>{ releasesCount } revision{ releasesCount > 1 ? 's' : '' } to release.</span>
+          }
+          {' '}
+          { closesCount > 0 &&
+            <span>{ closesCount } channel{ closesCount > 1 ? 's' : '' } to close.</span>
+          }
           <span className="p-tooltip__message" role="tooltip" id="default-tooltip">
             { Object.keys(pendingReleases).map(revId => {
               const release = pendingReleases[revId];
@@ -251,6 +277,7 @@ export default class RevisionsTable extends Component {
 RevisionsTable.propTypes = {
   releasedChannels: PropTypes.object.isRequired,
   pendingReleases: PropTypes.object.isRequired,
+  pendingCloses: PropTypes.object.isRequired,
   currentTrack: PropTypes.string.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
@@ -262,4 +289,5 @@ RevisionsTable.propTypes = {
   promoteChannel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
   clearPendingReleases: PropTypes.func.isRequired,
+  closeChannel: PropTypes.func.isRequired
 };


### PR DESCRIPTION
Fixes #1133 

Adds possibility to close a channel from Release UI dropdown.

<img width="1031" alt="screen shot 2018-10-03 at 13 08 33" src="https://user-images.githubusercontent.com/83575/46408046-1bd33c80-c711-11e8-8e1f-87d40e692d19.png">


### QA
- ./run or http://snapcraft.io-canonical-websites-pr-1166.run.demo.haus/
- go to Releases page 
- if there are any releases in a channel you should be able to close it from the dropdown button
- try releasing some revisions, closing multiple channels at once, etc

