### PR TITLE
Add /_status/check endpoint

### DIFF
--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -50,4 +50,8 @@ def snapcraft_blueprint():
     def robots():
         return flask.Response("", mimetype="text/plain")
 
+    @snapcraft.route("/_status/check")
+    def check():
+        return "OK"
+
     return snapcraft


### PR DESCRIPTION
# Summary

By default talisker's endpoint /_status/check makes a request to the flask app to check if it has this endpoint. This generates a 404 that is not logged by talisker but prometheus logs it. This generates a lot of 404 since this endpoint is hitted every 5sec by k8s

I added a custom /_status/check endpoint to have clean prometheus metrics

# QA

- `./run`
- http://127.0.0.1:8004/_status/check
- Should have a page with OK