### PR TITLE
Fix closing dropdown when clicking outside

### DIFF
--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 export default class PromoteButton extends Component {
+  constructor() {
+    super();
+    this.closeAllDropdowns = this.closeAllDropdowns.bind(this);
+  }
+
   componentDidMount() {
     // use window instead of document, as React catches all events in document
     window.addEventListener('click', this.closeAllDropdowns);


### PR DESCRIPTION
Fixes the issue that channel dropdown doesn't always close properly when clicked outside of it.

### QA

- go to Release page of some snap
- open dropdowns on any channel
- click outside, dropdowns should close properly
- close any channel (so it's button dissapears)
- click on any other dropdown
- click outside of it
- it should still properly close