### PR TITLE
Only show title above search bar if not a brand store

### DIFF
--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -1,6 +1,8 @@
 <section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
   <div class="row">
-    <h1 class="p-heading--three">Search thousands of snaps used by millions of people across 50 Linux distributions</h1>
+    {% if not webapp_config['STORE_QUERY'] %}
+      <h1 class="p-heading--three">Search thousands of snaps used by millions of people across 50 Linux distributions</h1>
+    {% endif %}
     <form action="/search" class="p-form p-form--inline p-form--search">
       {% if categories %}
         <div class="p-form__group p-form__group--no-grow">


### PR DESCRIPTION
We added a heading to the /store page, this isn't really relevant for brand stores.