### PR TITLE
Home page first snap flow

### DIFF
--- a/static/js/public/fsf-language-select.js
+++ b/static/js/public/fsf-language-select.js
@@ -1,0 +1,50 @@
+// TODO:
+// - update style of the links to underlines (with arrow?)
+// - add details data for all languages
+// - add button to the docs
+
+function initFSFLanguageSelect(rootEl) {
+  var flowLinks = [].slice.call(rootEl.querySelectorAll('.p-flow-link'));
+
+  // TODO:
+  // close on click as well
+  flowLinks.forEach(link => {
+    link.addEventListener('click', (event) => {
+      var link = event.target.closest('.p-flow-link');
+
+      if (link && link.dataset.flowLink) {
+        // find where the next row of links starts to insert details panel before
+        var top = link.getBoundingClientRect().top;
+
+        var nextRow = null;
+        for (var i = flowLinks.indexOf(link); i < flowLinks.length && !nextRow; i++) {
+          if (flowLinks[i].getBoundingClientRect().top > top) {
+            nextRow = flowLinks[i];
+          }
+        }
+
+        var flowDetails = [].slice.call(document.querySelectorAll('.p-flow-details'));
+        flowDetails.forEach(e => e.style.display = 'none');
+
+        var details = document.querySelector(`[data-flow-details='${link.dataset.flowLink}'`);
+        if (nextRow) {
+          nextRow.parentNode.insertBefore(details, nextRow);
+        } else {
+          rootEl.appendChild(details);
+        }
+        details.style.display = 'block';
+        event.preventDefault();
+      }
+    });
+  });
+
+  // TODO: debounce
+  window.addEventListener('resize', () => {
+    var flowDetails = [].slice.call(document.querySelectorAll('.p-flow-details'));
+    flowDetails.forEach(e => e.style.display = 'none');
+  });
+}
+
+export {
+  initFSFLanguageSelect
+};

--- a/static/js/public/fsf-language-select.js
+++ b/static/js/public/fsf-language-select.js
@@ -18,11 +18,11 @@ function initFSFLanguageSelect(rootEl) {
 
       if (link && link.dataset.flowLink) {
         // find where the next row of links starts to insert details panel before
-        var top = link.getBoundingClientRect().top;
+        var top = link.offsetTop;
 
         var nextRow = null;
         for (var i = flowLinks.indexOf(link); i < flowLinks.length && !nextRow; i++) {
-          if (flowLinks[i].getBoundingClientRect().top > top) {
+          if (flowLinks[i].offsetTop > top) {
             nextRow = flowLinks[i];
           }
         }
@@ -44,6 +44,7 @@ function initFSFLanguageSelect(rootEl) {
           link.classList.remove('is-open');
         }
 
+        window.scrollTo(0, link.offsetTop);
         event.preventDefault();
       }
     });

--- a/static/js/public/fsf-language-select.js
+++ b/static/js/public/fsf-language-select.js
@@ -1,13 +1,17 @@
 // TODO:
-// - update style of the links to underlines (with arrow?)
 // - add details data for all languages
 // - add button to the docs
+import debounce from '../libs/debounce';
 
 function initFSFLanguageSelect(rootEl) {
-  var flowLinks = [].slice.call(rootEl.querySelectorAll('.p-flow-link'));
+  const flowLinks = [].slice.call(rootEl.querySelectorAll('.p-flow-link'));
+  const flowDetails = [].slice.call(rootEl.querySelectorAll('.p-flow-details'));
 
-  // TODO:
-  // close on click as well
+  const closeDetails = () => {
+    flowDetails.forEach(e => e.style.display = 'none');
+    flowLinks.forEach(l => l.classList.remove('is-open'));
+  };
+
   flowLinks.forEach(link => {
     link.addEventListener('click', (event) => {
       var link = event.target.closest('.p-flow-link');
@@ -22,27 +26,31 @@ function initFSFLanguageSelect(rootEl) {
             nextRow = flowLinks[i];
           }
         }
+        const isOpen = link.classList.contains('is-open');
 
-        var flowDetails = [].slice.call(document.querySelectorAll('.p-flow-details'));
-        flowDetails.forEach(e => e.style.display = 'none');
+        closeDetails();
 
-        var details = document.querySelector(`[data-flow-details='${link.dataset.flowLink}'`);
-        if (nextRow) {
-          nextRow.parentNode.insertBefore(details, nextRow);
+        if (!isOpen) {
+          // find the end of the row of icons to place details panel properly
+          var details = rootEl.querySelector(`[data-flow-details='${link.dataset.flowLink}'`);
+          if (nextRow) {
+            nextRow.parentNode.insertBefore(details, nextRow);
+          } else {
+            rootEl.appendChild(details);
+          }
+          details.style.display = 'block';
+          link.classList.add('is-open');
         } else {
-          rootEl.appendChild(details);
+          link.classList.remove('is-open');
         }
-        details.style.display = 'block';
+
         event.preventDefault();
       }
     });
   });
 
-  // TODO: debounce
-  window.addEventListener('resize', () => {
-    var flowDetails = [].slice.call(document.querySelectorAll('.p-flow-details'));
-    flowDetails.forEach(e => e.style.display = 'none');
-  });
+  const onResize = debounce(closeDetails, 500);
+  window.addEventListener('resize', onResize);
 }
 
 export {

--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -3,6 +3,7 @@ import screenshots from './snap-details/screenshots';
 import channelMap from './snap-details/channelMap';
 import { storeCategories } from './store-categories';
 import { snapDetailsPosts, seriesPosts } from './snap-details/blog-posts';
+import { initFSFLanguageSelect } from './fsf-language-select';
 
 export {
   map,
@@ -10,5 +11,6 @@ export {
   channelMap,
   storeCategories,
   snapDetailsPosts,
-  seriesPosts
+  seriesPosts,
+  initFSFLanguageSelect
 };

--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -1,4 +1,12 @@
 @mixin snapcraft-p-first-snap-flow {
+  .p-flow-details {
+    width: 100%;
+  }
+
+  .p-flow-details__continue {
+    clear: both;
+  }
+
   .p-code-yaml {
     font-size: 14px;
     line-height: 1.5em;

--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -1,0 +1,10 @@
+@mixin snapcraft-p-first-snap-flow {
+  .p-code-yaml {
+    font-size: 14px;
+    line-height: 1.5em;
+
+    b {
+      color: $color-positive;
+    }
+  }
+}

--- a/static/sass/_patterns_logo-links.scss
+++ b/static/sass/_patterns_logo-links.scss
@@ -24,4 +24,46 @@
     align-items: center;
     display: flex;
   }
+
+  // first snap flow details link styles
+  .is-open {
+    border-bottom: 1px solid $color-mid-light;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    overflow: visible;
+    position: relative;
+  }
+
+  // bordered arrow
+  .is-open::after,
+  .is-open::before {
+    border-style: solid;
+    content: '';
+    display: block;
+    height: 0;
+    left: 100%;
+    position: absolute;
+    width: 0;
+  }
+
+  .is-open::after {
+    border-color: transparent transparent $color-x-light transparent;
+    border-width: 12px;
+    bottom: -1px;
+    left: 50%;
+    margin-left: -12px;
+  }
+
+  .is-open::before {
+    border-color: transparent transparent $color-mid-light transparent;
+    border-width: 12px;
+    bottom: 0;
+    left: 50%;
+    margin-left: -12px;
+  }
+
+  // disable focus outline on open link to make border more visible
+  .is-open:focus {
+    outline: none;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -187,3 +187,6 @@ $color-navigation-background: #252525;
 
 @import 'patterns_form-multiselect';
 @include snapcraft-p-multiselect;
+
+@import 'patterns_first-snap-flow';
+@include snapcraft-p-first-snap-flow;

--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -1,0 +1,48 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="c">
+  <div class='col-6'>
+    <h4>Why are snaps good for C/C++ projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle the exact versions of your app’s dependencies.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here’s how dosbox uses it:</h4>
+    <code class="p-code-yaml"><pre><b>name</b>: dosbox
+<b>version</b>: "0.74-svn"
+<b>summary</b>: DOS emulator
+<b>description</b>: |
+  DOSBox is a x86 emulator with Tandy/Hercules/CGA/EGA/VGA/SVGA graphics
+  sound and DOS. It's been designed to run old DOS games under platforms that
+  don't support it.
+
+<b>confinement</b>: devmode
+
+<b>parts</b>:
+  <b>dosbox</b>:
+    <b>plugin</b>: autotools
+    <b>source-type</b>: tar
+    <b>source</b>: http://source.dosbox.com/dosboxsvn.tgz
+    <b>build-package</b>s:
+      - g++
+      - make
+      - libsdl1.2-dev
+      - libpng12-dev
+      - libsdl-net1.2-dev
+      - libsdl-sound1.2-dev
+      - libasound2-dev
+
+<b>apps</b>:
+  <b>dosbox</b>:
+    <b>command</b>: dosbox</pre></code>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example C/C++ app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/c">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_electron.html
+++ b/templates/home/_fsf_electron.html
@@ -1,0 +1,45 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="electron">
+  <div class='col-6'>
+    <h4>Why are snaps good for Electron projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle Electron and all of your app’s dependencies, be they Node modules or system libraries.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here's how to use it with electron-quick-start:</h4>
+    <code class="p-code-yaml"><pre>{
+  <b>"name"</b>: "electron-quick-start",
+  <b>"version"</b>: "1.0.0",
+  <b>"description"</b>: "A minimal Electron application",
+  <b>"main"</b>: "main.js",
+  <b>"scripts"</b>: {
+    <b>"start"</b>: "electron .",
+    <b>"dist"</b>: "build --linux snap"
+  },
+  <b>"repository"</b>: "https://github.com/electron/electron-quick-start",
+  <b>"keywords"</b>: [
+    "Electron",
+    "quick",
+    "start",
+    "tutorial",
+    "demo"
+  ],
+  <b>"author"</b>: "GitHub",
+  <b>"license"</b>: "CC0-1.0",
+  <b>"devDependencies"</b>: {
+    <b>"electron"</b>: "^2.0.0",
+    <b>"electron-builder"</b>: "^20.27.1"
+  }
+}</pre></code>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Electron app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/electron">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -1,0 +1,16 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="go">
+  <div class='col-6'>
+    <h4>Why are snaps good for Go projects?</h4>
+    <ul>
+      <li>Simplify installation instructions, regardless of distribution, to snap install mygoapp.</li>
+      <li>Directly control the delivery of application updates.</li>
+      <li>Extremely simple creation of daemons.</li>
+      <li>Deliver assets such as images or static web content inside the snap.</li>
+    </ul>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Go app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/go">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -1,0 +1,14 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="java">
+  <div class='col-6'>
+    <h4>Why are snaps good for Java projects?</h4>
+    <ul>
+      <li>Simplify installation instructions, regardless of distribution, to snap install myjavaapp.</li>
+      <li>Directly control the delivery of automatic application updates.</li>
+    </ul>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Java app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/java">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -1,0 +1,17 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="moos">
+  <div class='col-6'>
+    <h4>Why are snaps good for MOOS projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle the exact version of MOOS/MOOS-IvP required and your app’s library dependencies.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example MOOS app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/moos">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -1,0 +1,42 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="node">
+  <div class='col-6'>
+    <h4>Why are snaps good for Node.js projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle the exact version of Node required and all of your app’s dependencies, be they Node modules or other applications.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here's how wethr uses it:</h4>
+    <code class="p-code-yaml"><pre><b>name</b>: wethr
+<b>version</b>: git
+<b>summary</b>: Command line weather tool.
+<b>description</b>: >
+  Get current weather:-
+    $ wethr
+  Get current weather in metric units
+    $ wethr --metric
+  Get current weather in imperial units
+    $ wethr --imperial
+
+<b>confinement</b>: devmode
+
+<b>parts</b>:
+  <b>wethr</b>:
+    <b>plugin</b>: nodejs
+    <b>source</b>: .
+
+<b>apps</b>:
+  <b>wethr</b>:
+    <b>command</b>: wethr</pre></code>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Node.js app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/node">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -1,0 +1,40 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="pre-built">
+  <div class='col-6'>
+    <h4>Why are snaps good for pre-built apps projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle your app’s exact versioned dependencies.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here's how geekbench uses it:</h4>
+    <code class="p-code-yaml"><pre><b>name</b>: geekbench4
+<b>version</b>: 4.2.0
+<b>summary</b>: Cross-Platform Benchmark
+<b>description</b>: >
+  Geekbench 4 measures your system's power and tells you whether your
+  computer is ready to roar. How strong is your mobile device or desktop
+  computer? How will it perform when push comes to crunch? These are the
+  questions that Geekbench can answer.
+
+<b>confinement</b>: devmode
+
+<b>parts</b>:
+  <b>geekbench4</b>:
+    <b>plugin</b>: dump
+    <b>source</b>: http://cdn.geekbench.com/Geekbench-$SNAPCRAFT_PROJECT_VERSION-Linux.tar.gz
+
+<b>apps</b>:
+  <b>geekbench4</b>:
+    <b>command</b>: geekbench4</pre></code>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example pre-built app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/pre-built">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -1,6 +1,6 @@
 <div class="col-12 p-flow-details" style="display: none" data-flow-details="pre-built">
   <div class='col-6'>
-    <h4>Why are snaps good for pre-built apps projects?</h4>
+    <h4>Why are snaps good for pre-built apps?</h4>
     <ul>
       <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
       <li>Snaps install and run the same across Linux. They bundle your app’s exact versioned dependencies.</li>

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -31,4 +31,9 @@
   <b>offlineimap</b>:
     <b>command</b>: bin/offlineimap</pre></code>
   </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Python app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/python">Continue</a>
+  </div>
 </div>

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -1,0 +1,34 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="python">
+  <div class='col-6'>
+    <h4>Why are snaps good for Python projects?</h4>
+    <ul>
+      <li>Snaps are easy to discover and install. Millions of users can browse and install snaps graphically in the Snap Store or from the command-line.</li>
+      <li>Snaps install and run the same across Linux. They bundle the exact version of Python required and all of your app’s dependencies, be they Python modules or system libraries.</li>
+      <li>Snaps automatically update to the latest version. Four times a day, users’ systems will check for new versions and upgrade in the background.</li>
+      <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
+      <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
+    </ul>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here’s how offlineimap uses it:</h4>
+    <code><pre>name: offlineimap
+version: git
+summary: OfflineIMAP
+description: >
+  OfflineIMAP is software that downloads your email mailbox(es) as local
+  Maildirs. OfflineIMAP will synchronize both sides via IMAP.
+
+confinement: devmode
+
+parts:
+  offlineimap:
+    plugin: python
+    python-version: python2
+    source: .
+
+apps:
+  offlineimap:
+    command: bin/offlineimap</pre></code>
+  </div>
+</div>

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -12,23 +12,23 @@
 
   <div class='col-6'>
     <h4>Here’s how offlineimap uses it:</h4>
-    <code><pre>name: offlineimap
-version: git
-summary: OfflineIMAP
-description: >
+    <code class="p-code-yaml"><pre><b>name</b>: offlineimap
+<b>version</b>: git
+<b>summary</b>: OfflineIMAP
+<b>description</b>: >
   OfflineIMAP is software that downloads your email mailbox(es) as local
   Maildirs. OfflineIMAP will synchronize both sides via IMAP.
 
-confinement: devmode
+<b>confinement</b>: devmode
 
-parts:
-  offlineimap:
-    plugin: python
-    python-version: python2
-    source: .
+<b>parts</b>:
+  <b>offlineimap</b>:
+    <b>plugin</b>: python
+    <b>python-version</b>: python2
+    <b>source</b>: .
 
-apps:
-  offlineimap:
-    command: bin/offlineimap</pre></code>
+<b>apps</b>:
+  <b>offlineimap</b>:
+    <b>command</b>: bin/offlineimap</pre></code>
   </div>
 </div>

--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -1,0 +1,16 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="ros">
+  <div class='col-6'>
+    <h4>Why are snaps good for ROS projects?</h4>
+    <ul>
+      <li>Bundle all the runtime requirements, including the exact version of ROS, system libraries, etc.</li>
+      <li>Expand the distributions supported beyond just Ubuntu.</li>
+      <li>Directly control the delivery of application updates.</li>
+      <li>Extremely simple creation of daemons.</li>
+    </ul>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example ROS app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/ros">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -1,0 +1,16 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="ros2">
+  <div class='col-6'>
+    <h4>Why are snaps good for ROS2 projects?</h4>
+    <ul>
+      <li>Bundle all the runtime requirements, including the exact version of ROS, system libraries, etc.</li>
+      <li>Expand the distributions supported beyond just Ubuntu.</li>
+      <li>Directly control the delivery of application updates.</li>
+      <li>Extremely simple creation of daemons.</li>
+    </ul>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example ROS2 app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/ros2">Continue</a>
+  </div>
+</div>

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -29,4 +29,9 @@
   <b>mdl</b>:
     <b>command</b>: mdl</pre></code>
   </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Ruby app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/ruby">Continue</a>
+  </div>
 </div>

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -11,22 +11,22 @@
 
   <div class='col-6'>
     <h4>Here’s how mdl uses it:</h4>
-    <code><pre>name: mdl
-version: "0.5.0"
-summary: Markdown lint tool
-description: >
+    <code class="p-code-yaml"><pre><b>name</b>: mdl
+<b>version</b>: "0.5.0"
+<b>summary</b>: Markdown lint tool
+<b>description</b>: >
   Style checker/lint tool for markdown files
 
-confinement: devmode
+<b>confinement</b>: devmode
 
-parts:
-  mdl:
-    plugin: ruby
-    gems:
+<b>parts</b>:
+  <b>mdl</b>:
+    <b>plugin</b>: ruby
+    <b>gems</b>:
       - mdl
 
-apps:
-  mdl:
-    command: mdl</pre></code>
+<b>apps</b>:
+  <b>mdl</b>:
+    <b>command</b>: mdl</pre></code>
   </div>
 </div>

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -1,0 +1,32 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="ruby">
+  <div class='col-6'>
+    <h4>Why are snaps good for Ruby projects?</h4>
+    <ul>
+      <li>Bundle all the runtime requirements.</li>
+      <li>Simplify installation instructions, regardless of distribution, to snap install myrubyapp.</li>
+      <li>Directly control the delivery of automatic application updates.</li>
+      <li>Extremely simple creation of services.</li>
+    </ul>
+  </div>
+
+  <div class='col-6'>
+    <h4>Here’s how mdl uses it:</h4>
+    <code><pre>name: mdl
+version: "0.5.0"
+summary: Markdown lint tool
+description: >
+  Style checker/lint tool for markdown files
+
+confinement: devmode
+
+parts:
+  mdl:
+    plugin: ruby
+    gems:
+      - mdl
+
+apps:
+  mdl:
+    command: mdl</pre></code>
+  </div>
+</div>

--- a/templates/home/_fsf_rust.html
+++ b/templates/home/_fsf_rust.html
@@ -1,0 +1,17 @@
+<div class="col-12 p-flow-details" style="display: none" data-flow-details="rust">
+  <div class='col-6'>
+    <h4>Why are snaps good for Rust projects?</h4>
+    <ul>
+      <li>Bundle all the runtime requirements, with support for multiple architectures.</li>
+      <li>Simplify installation instructions, regardless of distribution, to snap install myrustapp.</li>
+      <li>Directly control the delivery of automatic application updates.</li>
+      <li>Extremely simple creation of services.</li>
+      <li>No complex installation shell scripts to maintain.</li>
+    </ul>
+  </div>
+
+  <div class="p-flow-details__continue">
+    In just a few steps, you’ll have an example Rust app in the Snap Store.
+    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/rust">Continue</a>
+  </div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -177,37 +177,37 @@
   </div>
   <div class="row js-fsf-language-select">
     <div class="col-12 p-fluid-grid--centered">
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/pre-built">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/pre-built">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/701da9c0-icon-prepackaged-apps.svg" alt="">
         </header>
         <span>Pre-built apps</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/c">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/c">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/dcc8c108-logo-cpp.svg" alt="">
         </header>
         <span>C/C++</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/go">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/go">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/158bd625-logo-go.svg" alt="">
         </header>
         <span>Go</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/java">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/java">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/f6840095-logo-java.svg" alt="">
         </header>
         <span>Java</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/node">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/node">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/7a4dcddb-logo-node.svg" alt="">
         </header>
         <span>Node.js</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/electron">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/electron">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/4ab5c788-logo-electron.svg" alt="">
         </header>
@@ -225,25 +225,25 @@
         </header>
         <span>Ruby</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/rust">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/rust">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/6677836e-logo-rust.svg" alt="">
         </header>
         <span>Rust</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/moos">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/moos">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/4c371ff8-logo-moos.svg" alt="">
         </header>
         <span>MOOS</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/ros">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/f2b40fc0-logo-ros.svg" alt="">
         </header>
         <span>ROS</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/ros2">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros2">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/7dad0dcc-logo-ros2.svg" alt="">
         </header>

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,7 +175,7 @@
       <p>Snapcraft works with your language or framework to make preparing your software for the Snap Store easy.</p>
     </div>
   </div>
-  <div class="row">
+  <div class="row js-fsf-language-select">
     <div class="col-12 p-fluid-grid--centered">
       <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/pre-built">
         <header class="p-card__header">
@@ -213,13 +213,13 @@
         </header>
         <span>Electron</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/python">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/python" data-flow-link="python">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/5398ed20-logo-python.svg" alt="">
         </header>
         <span>Python</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card" href="https://docs.snapcraft.io/build-snaps/ruby">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ruby" data-flow-link="ruby">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/eacdd4e1-logo-ruby.svg" alt="">
         </header>
@@ -249,6 +249,9 @@
         </header>
         <span>ROS 2</span>
       </a>
+
+      {% include "home/_fsf_python.html" %}
+      {% include "home/_fsf_ruby.html" %}
     </div>
   </div>
 </div>
@@ -267,4 +270,13 @@
     </div>
   </div>
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ static_url('js/dist/public.js') }}"></script>
+<script>
+  Raven.context(function () {
+    snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
+  });
+</script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -177,37 +177,37 @@
   </div>
   <div class="row js-fsf-language-select">
     <div class="col-12 p-fluid-grid--centered">
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/pre-built">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/pre-built" data-flow-link="pre-built">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/701da9c0-icon-prepackaged-apps.svg" alt="">
         </header>
         <span>Pre-built apps</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/c">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/c" data-flow-link="c">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/dcc8c108-logo-cpp.svg" alt="">
         </header>
         <span>C/C++</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/go">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/go" data-flow-link="go">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/158bd625-logo-go.svg" alt="">
         </header>
         <span>Go</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/java">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/java" data-flow-link="java">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/f6840095-logo-java.svg" alt="">
         </header>
         <span>Java</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/node">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/node" data-flow-link="node">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/7a4dcddb-logo-node.svg" alt="">
         </header>
         <span>Node.js</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/electron">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/electron" data-flow-link="electron">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/4ab5c788-logo-electron.svg" alt="">
         </header>
@@ -225,33 +225,43 @@
         </header>
         <span>Ruby</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/rust">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/rust" data-flow-link="rust">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/6677836e-logo-rust.svg" alt="">
         </header>
         <span>Rust</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/moos">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/moos" data-flow-link="moos">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/4c371ff8-logo-moos.svg" alt="">
         </header>
         <span>MOOS</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros" data-flow-link="ros">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/f2b40fc0-logo-ros.svg" alt="">
         </header>
         <span>ROS</span>
       </a>
-      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros2">
+      <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros2" data-flow-link="ros2">
         <header class="p-card__header">
           <img src="https://assets.ubuntu.com/v1/7dad0dcc-logo-ros2.svg" alt="">
         </header>
         <span>ROS 2</span>
       </a>
 
+      {% include "home/_fsf_c.html" %}
+      {% include "home/_fsf_electron.html" %}
+      {% include "home/_fsf_go.html" %}
+      {% include "home/_fsf_java.html" %}
+      {% include "home/_fsf_moos.html" %}
+      {% include "home/_fsf_node.html" %}
+      {% include "home/_fsf_pre-built.html" %}
       {% include "home/_fsf_python.html" %}
+      {% include "home/_fsf_ros.html" %}
+      {% include "home/_fsf_ros2.html" %}
       {% include "home/_fsf_ruby.html" %}
+      {% include "home/_fsf_rust.html" %}
     </div>
   </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,8 +171,8 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-12">
-      <h3 class="p-heading--two">Snap any application</h3>
-      <p>Snapcraft works with your language or framework to make preparing your software for the Snap Store easy.</p>
+      <h3 class="p-heading--two">Try it yourself</h3>
+      <p>What language or framework does your app use?</p>
     </div>
   </div>
   <div class="row js-fsf-language-select">


### PR DESCRIPTION
Fixes #1135 

Adds more details and examples to languages/tools on home page, as a first step of future first snap flow.

Copy doc: https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506

### QA

- ./run or http://snapcraft.io-canonical-websites-pr-1178.run.demo.haus/
- go to 'Snap any application' section of the home page
- click on language/tool - a panel should open with the details
- clicking on 'Continue' button should lead to a docs page for given tool
- click around, make sure panels open and close properly
- try different screen sizes

<img width="1063" alt="screen shot 2018-10-05 at 14 18 50" src="https://user-images.githubusercontent.com/83575/46535299-43f6a300-c8ab-11e8-8465-f2eb89c5aead.png">
