### PR TITLE
Remove useless featured snaps api call

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -61,18 +61,9 @@ def store_blueprint(store_query=None):
 
         categories = logic.get_categories(categories_results)
 
-        try:
-            featured_snaps_results = api.get_featured_snaps()
-        except ApiError as api_error:
-            featured_snaps_results = []
-            status_code, error_info = _handle_errors(api_error)
-
-        featured_snaps = logic.get_searched_snaps(featured_snaps_results)
-
         return (
             flask.render_template(
                 "store/store.html",
-                featured_snaps=featured_snaps,
                 categories=categories,
                 error_info=error_info,
             ),


### PR DESCRIPTION
# Summary

Remove useless featured snaps api call
Handled but the categories now

# QA

- `./run`
- http://0.0.0.0:8004/store
- Make sure featured snaps are still there