### PR TITLE
Ensure spacing below snap lists is the same

### DIFF
--- a/static/sass/_patterns_snap-row.scss
+++ b/static/sass/_patterns_snap-row.scss
@@ -1,6 +1,9 @@
 @mixin snapcraft-p-snap-row {
+  // Can be removed when vanilla is upgraded to $spv-inter--expanded
+  $margin-bottom: $spv-inter--regular + $spv-inter--condensed;
+
   .p-snap-row {
-    margin-bottom: $spv-inter--regular;
+    margin-bottom: $margin-bottom;
 
     @media screen and (max-width: $breakpoint-navigation-threshold) {
       .col-2 {
@@ -9,7 +12,7 @@
       }
 
       .p-media-object--snap {
-        margin-bottom: $spv-inter--regular;
+        margin-bottom: $margin-bottom;
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1162

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/store and http://0.0.0.0:8004/iot
- Ensure the space between the snap strips is the same