### PR TITLE
Show gifs on snap-details pages

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -110,12 +110,17 @@
           <div class="p-screenshots__wrapper">
             {% for screenshot in screenshots %}
               <div class="p-screenshot">
-                <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }}"
-                  srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }} 215w,
-                    https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_860/{{ screenshot }} 430w"
-                  sizes="(min-width: 1031px) 430px,
-                    (max-width: 1030px) and (min-width: 876px) 430px,
-                    (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_1170/{{ screenshot }}" alt="">
+                {% if screenshot.endswith('.gif') %}
+                <img src="{{ screenshot }}"
+                  data-original="{{ screenshot }}" alt="">
+                {% else %}
+                  <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }}"
+                    srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }} 215w,
+                      https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_860/{{ screenshot }} 430w"
+                    sizes="(min-width: 1031px) 430px,
+                      (max-width: 1030px) and (min-width: 876px) 430px,
+                      (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_1170/{{ screenshot }}" alt="">
+                {% endif %}
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
Publishers are reporting gifs are no longer working. This fixes it