### PR TITLE
Release UI: detect devmode revisions

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -85,6 +85,7 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
       snapName={snapName}
       releasedChannels={releasedChannels}
       revisions={releasesData.revisions}
+      revisionsMap={revisionsMap}
       tracks={tracks}
       options={options}
     />,

--- a/static/js/publisher/release/devmodeIcon.js
+++ b/static/js/publisher/release/devmodeIcon.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function isInDevmode(revision) {
+  return revision.confinement === 'devmode' || revision.grade === 'devel';
+}
+
+export default function DevmodeIcon({ revision, showTooltip }) {
+  return isInDevmode(revision) && (
+    <span className="p-tooltip p-tooltip--btm-center" aria-describedby={`revision-devmode-${revision.revision}`}>
+      <i className="p-icon--warning"></i>
+
+      { showTooltip &&
+        <span className="p-tooltip__message u-align--center" role="tooltip" id={`revision-devmode-${revision.revision}`}>
+          Revisions with { revision.confinement === 'devmode' ? 'devmode confinement' : 'devel grade'} cannot<br/>
+          be released to stable or beta channels.
+        </span>
+      }
+    </span>
+  );
+}
+
+DevmodeIcon.propTypes = {
+  revision: PropTypes.object.isRequired,
+  showTooltip: PropTypes.bool
+};

--- a/static/js/publisher/release/devmodeIcon.js
+++ b/static/js/publisher/release/devmodeIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function isInDevmode(revision) {
+export function isInDevmode(revision) {
   return revision.confinement === 'devmode' || revision.grade === 'devel';
 }
 

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -417,7 +417,7 @@ export default class ReleasesController extends Component {
           <Notification appearance="caution">
             Revisions in development mode cannot be released to stable or candidate channels.
             <br/>
-            You can read more about <code>devmode</code> confinement and <code>devel</code> grade in <a href="https://docs.snapcraft.io/build-snaps/syntax">the Snapraft docs</a>.
+            You can read more about <a href="https://docs.snapcraft.io/t/snap-confinement/6233"><code>devmode</code> confinement</a> and <a href="https://docs.snapcraft.io/t/snapcraft-yaml-reference/4276"><code>devel</code> grade</a>.
           </Notification>
 
         }

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -5,7 +5,7 @@ import 'whatwg-fetch';
 import RevisionsTable from './revisionsTable';
 import RevisionsList from './revisionsList';
 import Notification from './notification';
-
+import { isInDevmode } from './devmodeIcon';
 import { UNASSIGNED } from './constants';
 
 export default class ReleasesController extends Component {
@@ -401,12 +401,25 @@ export default class ReleasesController extends Component {
     const { tracks } = this.props;
     const { archs, releasedChannels } = this.state;
 
+    const hasDevmodeRevisions = Object.values(releasedChannels).some(archReleases => {
+      return Object.values(archReleases).some(isInDevmode);
+    });
+
+
     return (
       <Fragment>
         { this.state.error &&
           <Notification status="error" appearance="negative">
             {this.state.error}
           </Notification>
+        }
+        { hasDevmodeRevisions &&
+          <Notification appearance="caution">
+            Revisions in development mode cannot be released to stable or candidate channels.
+            <br/>
+            You can read more about <code>devmode</code> confinement and <code>devel</code> grade in <a href="https://docs.snapcraft.io/build-snaps/syntax">the Snapraft docs</a>.
+          </Notification>
+
         }
         <RevisionsTable
           releasedChannels={releasedChannels}

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -263,16 +263,13 @@ export default class ReleasesController extends Component {
 
         // update releasedChannels based on channel map from the response
         json.channel_map.forEach(map => {
-          // TODO:
-          // possible improvements but not needed for functionality:
-          // - close channels when there is no release?
-          // - ignore revisions other then the one just released?
-          // - get revision data from revisionsMap?
           if (map.revision) {
-
             let revision;
-            if (map.revision === release.id) {
+
+            if (map.revision === (+release.id)) { // release.id is a string so turn it into a number for comparison
               revision = release.revision;
+            } else if (this.props.revisionsMap[map.revision]) {
+              revision = this.props.revisionsMap[map.revision];
             } else {
               revision = {
                 revision: map.revision,
@@ -290,9 +287,13 @@ export default class ReleasesController extends Component {
               releasedChannels[channel] = {};
             }
 
-
             revision.architectures.forEach(arch => {
-              releasedChannels[channel][arch] = revision;
+              const currentlyReleased = releasedChannels[channel][arch];
+
+              // only update revision in channel map if it changed since last time
+              if (!currentlyReleased || currentlyReleased.revision !== revision.revision) {
+                releasedChannels[channel][arch] = revision;
+              }
             });
 
           }
@@ -439,6 +440,7 @@ ReleasesController.propTypes = {
   snapName: PropTypes.string.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   revisions: PropTypes.array.isRequired,
+  revisionsMap: PropTypes.object.isRequired,
   tracks: PropTypes.array.isRequired,
   options: PropTypes.object.isRequired
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -24,9 +24,10 @@ export default class RevisionsList extends Component {
             <label className="u-no-margin--bottom" htmlFor={`revision-check-${revision.revision}`}>{ revision.revision }</label>
           </td>
           <td>
-            { revision.version }
-            {' '}
             <DevmodeIcon revision={revision} showTooltip={true} />
+          </td>
+          <td>
+            { revision.version }
           </td>
           <td>{ revision.architectures.join(", ") }</td>
           <td>{ revision.channels.join(", ") }</td>
@@ -55,6 +56,7 @@ export default class RevisionsList extends Component {
           <thead>
             <tr>
               <th className="col-has-checkbox" width="10%" scope="col">Revision</th>
+              <th width="20px"></th>
               <th width="23%" scope="col">Version</th>
               <th width="12%" scope="col">Architecture</th>
               <th width="30%" scope="col">Channels</th>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -26,7 +26,7 @@ export default class RevisionsList extends Component {
           <td>
             { revision.version }
             {' '}
-            <DevmodeIcon revision={revision} />
+            <DevmodeIcon revision={revision} showTooltip={true} />
           </td>
           <td>{ revision.architectures.join(", ") }</td>
           <td>{ revision.channels.join(", ") }</td>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -3,15 +3,12 @@ import PropTypes from 'prop-types';
 import distanceInWords from 'date-fns/distance_in_words_strict';
 import format from 'date-fns/format';
 
+import DevmodeIcon from './devmodeIcon';
 import { UNASSIGNED } from './constants';
 
 export default class RevisionsList extends Component {
   revisionSelectChange(revision) {
     this.props.selectRevision(revision);
-  }
-
-  isInDevmode(revision) {
-    return revision.confinement === 'devmode' || revision.grade === 'devel';
   }
 
   renderRows(revisions) {
@@ -29,15 +26,7 @@ export default class RevisionsList extends Component {
           <td>
             { revision.version }
             {' '}
-            { this.isInDevmode(revision) &&
-              <span className="p-tooltip p-tooltip--btm-center" aria-describedby={`revision-devmode-${revision.revision}`}>
-                <i className="p-icon--warning"></i>
-                <span className="p-tooltip__message u-align--center" role="tooltip" id={`revision-devmode-${revision.revision}`}>
-                  Revisions with { revision.confinement === 'devmode' ? 'devmode confinement' : 'devel grade'} cannot<br/>
-                  be released to stable or beta channels.
-                </span>
-              </span>
-            }
+            <DevmodeIcon revision={revision} />
           </td>
           <td>{ revision.architectures.join(", ") }</td>
           <td>{ revision.channels.join(", ") }</td>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -10,6 +10,10 @@ export default class RevisionsList extends Component {
     this.props.selectRevision(revision);
   }
 
+  isInDevmode(revision) {
+    return revision.confinement === 'devmode' || revision.grade === 'devel';
+  }
+
   renderRows(revisions) {
     return revisions.map((revision) => {
       const uploadDate = new Date(revision.created_at);
@@ -22,7 +26,19 @@ export default class RevisionsList extends Component {
             <input type="checkbox" checked={isSelected} id={`revision-check-${revision.revision}`} onChange={this.revisionSelectChange.bind(this, revision)}/>
             <label className="u-no-margin--bottom" htmlFor={`revision-check-${revision.revision}`}>{ revision.revision }</label>
           </td>
-          <td>{ revision.version }</td>
+          <td>
+            { revision.version }
+            {' '}
+            { this.isInDevmode(revision) &&
+              <span className="p-tooltip p-tooltip--btm-center" aria-describedby={`revision-devmode-${revision.revision}`}>
+                <i className="p-icon--warning"></i>
+                <span className="p-tooltip__message u-align--center" role="tooltip" id={`revision-devmode-${revision.revision}`}>
+                  Revisions with { revision.confinement === 'devmode' ? 'devmode confinement' : 'devel grade'} cannot<br/>
+                  be released to stable or beta channels.
+                </span>
+              </span>
+            }
+          </td>
           <td>{ revision.architectures.join(", ") }</td>
           <td>{ revision.channels.join(", ") }</td>
           <td className="u-align--right">

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -92,6 +92,12 @@ export default class RevisionsTable extends Component {
             { isChannelClosed &&
               <span> &rarr; <em>close channel</em></span>
             }
+            { thisPreviousRevision && isInDevmode(thisPreviousRevision) &&
+              <Fragment>
+                <br/>
+                { thisPreviousRevision.confinement === 'devmode' ? 'confinement: devmode' : 'grade: devel' }
+              </Fragment>
+            }
           </span>
         </span>
         { hasPendingRelease &&

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { RISKS_WITH_UNASSIGNED as RISKS, UNASSIGNED, STABLE } from './constants';
+import DevmodeIcon from './devmodeIcon';
 import PromoteButton from './promoteButton';
 
 export default class RevisionsTable extends Component {
@@ -36,6 +37,7 @@ export default class RevisionsTable extends Component {
     );
 
     const isChannelClosed = this.props.pendingCloses.includes(channel);
+    const isPending = hasPendingRelease || isChannelClosed;
 
     return (
       <td
@@ -45,16 +47,21 @@ export default class RevisionsTable extends Component {
       >
         <span className="p-tooltip p-tooltip--btm-center">
           <span className="p-release-version">
-            <span className={ (hasPendingRelease || isChannelClosed) ? 'p-previous-revision' : '' }>
+            <span className={ isPending ? 'p-previous-revision' : '' }>
               { thisPreviousRevision ?
-                <span className="p-revision-info">{thisPreviousRevision.version}
+                <span className="p-revision-info">
+                  {thisPreviousRevision.version}
+                  {' '}
+                  { !isPending &&
+                    <DevmodeIcon revision={thisPreviousRevision} showTooltip={false} />
+                  }
                   <span className="p-revision-info__revision">({thisPreviousRevision.revision})</span>
                 </span> :
                 '–'
               }
             </span>
-            { (hasPendingRelease || isChannelClosed) &&
-              <span>
+            { isPending &&
+              <Fragment>
                 {' '}
                 &rarr;
                 {' '}
@@ -64,7 +71,7 @@ export default class RevisionsTable extends Component {
                   </span> :
                   <em>close channel</em>
                 }
-              </span>
+              </Fragment>
             }
           </span>
 

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -1,9 +1,19 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import { RISKS_WITH_UNASSIGNED as RISKS, UNASSIGNED, STABLE } from './constants';
-import DevmodeIcon from './devmodeIcon';
+import {
+  RISKS_WITH_UNASSIGNED as RISKS,
+  UNASSIGNED,
+  STABLE,
+  BETA,
+  EDGE
+} from './constants';
+import DevmodeIcon, { isInDevmode } from './devmodeIcon';
 import PromoteButton from './promoteButton';
+
+function getChannelName(track, risk) {
+  return risk === UNASSIGNED ? risk : `${track}/${risk}`;
+}
 
 export default class RevisionsTable extends Component {
   getRevisionToDisplay(releasedChannels, nextReleases, channel, arch) {
@@ -26,8 +36,7 @@ export default class RevisionsTable extends Component {
   }
 
   renderRevisionCell(track, risk, arch, releasedChannels, nextChannelReleases) {
-    // TODO: extract or try not to duplicate?
-    const channel = risk === UNASSIGNED ? risk : `${track}/${risk}`;
+    const channel = getChannelName(track, risk);
 
     let thisRevision = this.getRevisionToDisplay(releasedChannels, nextChannelReleases, channel, arch);
     let thisPreviousRevision = releasedChannels[channel] && releasedChannels[channel][arch];
@@ -125,8 +134,7 @@ export default class RevisionsTable extends Component {
     const track = this.props.currentTrack;
 
     return RISKS.map(risk => {
-      // TODO: extract or try not to duplicate?
-      const channel = risk === UNASSIGNED ? risk : `${track}/${risk}`;
+      const channel = getChannelName(track, risk);
 
       // don't show unassigned revisions until some are selected from the table
       // TODO: always show (when we can click on it)
@@ -162,6 +170,17 @@ export default class RevisionsTable extends Component {
       if (canBePromoted) {
         // take all risks above current one
         targetRisks = RISKS.slice(0, RISKS.indexOf(risk));
+
+        // check for devmode revisions
+        if (risk === EDGE || risk === BETA || risk === UNASSIGNED) {
+          const hasDevmodeRevisions = Object.values(nextChannelReleases[channel]).some(isInDevmode);
+
+          // remove stable and beta channels as targets if any revision
+          // is in devmode
+          if (hasDevmodeRevisions) {
+            targetRisks = targetRisks.slice(2);
+          }
+        }
 
         // filter out risks that have the same revisions already released
         targetRisks = targetRisks.filter((targetRisk) => {

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -56,14 +56,16 @@ export default class RevisionsTable extends Component {
       >
         <span className="p-tooltip p-tooltip--btm-center">
           <span className="p-release-version">
+
+            <span className="p-revision-icon">
+              { thisPreviousRevision && !isPending &&
+                <DevmodeIcon revision={thisPreviousRevision} showTooltip={false} />
+              }
+            </span>
             <span className={ isPending ? 'p-previous-revision' : '' }>
               { thisPreviousRevision ?
                 <span className="p-revision-info">
                   {thisPreviousRevision.version}
-                  {' '}
-                  { !isPending &&
-                    <DevmodeIcon revision={thisPreviousRevision} showTooltip={false} />
-                  }
                   <span className="p-revision-info__revision">({thisPreviousRevision.revision})</span>
                 </span> :
                 '–'
@@ -319,7 +321,7 @@ export default class RevisionsTable extends Component {
             <tr>
               <th width="22%" scope="col"></th>
               {
-                archs.map(arch => <th width="13%" key={`${arch}`}>{ arch }</th>)
+                archs.map(arch => <th width="13%" className="p-release-table__arch" key={`${arch}`}>{ arch }</th>)
               }
             </tr>
           </thead>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -5,6 +5,10 @@
     }
   }
 
+  .p-release-table__arch {
+    padding-left: 20px;
+  }
+
   .p-release-table__cell {
     position: relative;
   }
@@ -45,6 +49,11 @@
     &.is-pending {
       font-weight: 400;
     }
+  }
+
+  .p-revision-icon {
+    display: inline-block;
+    width: 20px;
   }
 
   .p-revision-info__revision {


### PR DESCRIPTION
Fixes #1186 

Adds information about devmode revisions (if there are any in history or currently released) and prevents from releasing devmode snaps to stable and candidate.

### QA
- ./run or http://snapcraft.io-canonical-websites-pr-1195.run.demo.haus/
- go to Releases page of a snap you owned
- if there are any revisions in history that are devmode they should be marked with an icon
- icon should have a tooltip
- if any devmode/devel revision is released (in edge or beta) warning icon should appear next to it, tooltip should say why the icon is there and notification should appear with links to the docs.

<img width="1062" alt="screen shot 2018-10-12 at 16 35 02" src="https://user-images.githubusercontent.com/83575/46875838-137baf80-ce3d-11e8-863c-fed0df9579bf.png">
