### PR TITLE
transpile node_module dependencies

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,7 +82,6 @@ export default [
         jsnext: true
       }),
       babel({
-        exclude: 'node_modules/**',
         plugins: ['external-helpers']
       }),
       commonjs({


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1197

## QA

- Pull the branch
- `./run build-js`
- Open `static/js/dist/public.js`
- Search for all instances of `class ` (include the space, otherwise there will be way too many)
- Check there isn't a class decleration