### PR TITLE
Latest talisker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Flask-Testing==0.6.2
 Flask-WTF==0.14.2
 gunicorn[gevent]
 humanize==0.5.1
-prometheus_client==0.3.1
 prometheus-flask-exporter==0.2.0
 pybreaker==0.4.4
 pycountry==17.9.23
@@ -17,5 +16,6 @@ requests-cache==0.4.13
 responses==0.9.0
 gunicorn[gevent]
 statsd<3.3.0
-talisker==0.9.14
+prometheus_client==0.3.1
+talisker==0.9.16
 black==18.6b4


### PR DESCRIPTION
The latest version of talisker has important fixes for prometheus.

QA
--

`./run`, check the site still works.

``` bash
docker build --tag snapcraft.io --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -ti -p 8998:80 snapcraft.io
```

Go to http://127.0.0.1:8998, check the site works this way too.