### PR TITLE
Update styles of releases table

### DIFF
--- a/static/js/publisher/release/channelMenu.js
+++ b/static/js/publisher/release/channelMenu.js
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import ContextualMenu from "./contextualMenu";
+
+export default class ChannelMenu extends ContextualMenu {
+  closeChannelClick(channel, event) {
+    this.props.closeChannel(channel);
+    this.itemClickHandler(event);
+  }
+
+  renderItems() {
+    const { channel } = this.props;
+
+    return (
+      <span className="p-contextual-menu__group">
+        <a
+          className="p-contextual-menu__link"
+          href="#"
+          onClick={this.closeChannelClick.bind(this, channel)}
+        >
+          Close {channel}
+        </a>
+      </span>
+    );
+  }
+}
+
+ChannelMenu.propTypes = {
+  channel: PropTypes.string.isRequired,
+  closeChannel: PropTypes.func.isRequired
+};

--- a/static/js/publisher/release/contextualMenu.js
+++ b/static/js/publisher/release/contextualMenu.js
@@ -1,0 +1,76 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+export default class ContextualMenu extends Component {
+  constructor() {
+    super();
+    this.closeAllDropdowns = this.closeAllDropdowns.bind(this);
+  }
+
+  componentDidMount() {
+    // use window instead of document, as React catches all events in document
+    window.addEventListener("click", this.closeAllDropdowns);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("click", this.closeAllDropdowns);
+  }
+
+  itemClickHandler(event) {
+    this.closeAllDropdowns();
+    event.preventDefault(); // prevent link from changing URL
+    event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
+  }
+
+  dropdownButtonClick(event) {
+    this.closeAllDropdowns();
+    const dropdownEl = event.target
+      .closest(".p-promote-button")
+      .querySelector(".p-contextual-menu__dropdown");
+
+    if (dropdownEl) {
+      dropdownEl.setAttribute("aria-hidden", false);
+    }
+
+    event.stopPropagation();
+  }
+
+  closeAllDropdowns() {
+    [].slice
+      .call(document.querySelectorAll(".p-contextual-menu__dropdown"))
+      .forEach(dropdown => {
+        dropdown.setAttribute("aria-hidden", true);
+      });
+  }
+
+  renderIcon() {
+    return <i className="p-icon--contextual-menu" />;
+  }
+
+  renderItems() {
+    return null;
+  }
+
+  render() {
+    const { position } = this.props;
+    const menuClass = "p-contextual-menu" + (position ? `--${position}` : "");
+
+    return (
+      <span
+        className={`p-promote-button p-button--neutral p-icon-button ${menuClass}`}
+        onClick={this.dropdownButtonClick.bind(this)}
+      >
+        {this.renderIcon()}
+        <span className="p-contextual-menu__dropdown" aria-hidden="true">
+          {this.renderItems()}
+        </span>
+      </span>
+    );
+  }
+}
+
+ContextualMenu.propTypes = {
+  position: PropTypes.oneOf(["left", "center"]), // right is by default
+  channel: PropTypes.string.isRequired,
+  closeChannel: PropTypes.func.isRequired
+};

--- a/static/js/publisher/release/promoteButton.js
+++ b/static/js/publisher/release/promoteButton.js
@@ -1,112 +1,46 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 
-export default class PromoteButton extends Component {
-  constructor() {
-    super();
-    this.closeAllDropdowns = this.closeAllDropdowns.bind(this);
-  }
+import ContextualMenu from "./contextualMenu";
 
-  componentDidMount() {
-    // use window instead of document, as React catches all events in document
-    window.addEventListener("click", this.closeAllDropdowns);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("click", this.closeAllDropdowns);
-  }
-
+export default class PromoteButton extends ContextualMenu {
   promoteToChannelClick(targetChannel, event) {
     this.props.promoteToChannel(targetChannel);
-    this.closeAllDropdowns();
-    event.preventDefault(); // prevent link from changing URL
-    event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
+    this.itemClickHandler(event);
   }
 
-  closeChannelClick(channel, event) {
-    this.props.closeChannel(channel);
-    this.closeAllDropdowns();
-    event.preventDefault(); // prevent link from changing URL
-    event.stopPropagation(); // prevent event from propagating to parent button and opening dropdown again
+  renderIcon() {
+    return "⤴";
   }
 
-  dropdownButtonClick(event) {
-    this.closeAllDropdowns();
-    const dropdownEl = event.target
-      .closest(".p-promote-button")
-      .querySelector(".p-contextual-menu__dropdown");
-
-    if (dropdownEl) {
-      dropdownEl.setAttribute("aria-hidden", false);
-    }
-
-    event.stopPropagation();
-  }
-
-  closeAllDropdowns() {
-    [].slice
-      .call(document.querySelectorAll(".p-contextual-menu__dropdown"))
-      .forEach(dropdown => {
-        dropdown.setAttribute("aria-hidden", true);
-      });
-  }
-
-  render() {
-    const { position, track } = this.props;
-    const menuClass = "p-contextual-menu" + (position ? `--${position}` : "");
+  renderItems() {
+    const { track } = this.props;
 
     return (
-      <span
-        className={`p-promote-button p-button--neutral p-icon-button ${menuClass}`}
-        onClick={this.dropdownButtonClick.bind(this)}
-      >
-        <i className="p-icon--contextual-menu" />
-        <span className="p-contextual-menu__dropdown" aria-hidden="true">
-          {this.props.targetRisks.length > 0 && (
-            <span className="p-contextual-menu__group">
-              <span className="p-contextual-menu__item">Promote to:</span>
-              {this.props.targetRisks.map(targetRisk => {
-                return (
-                  <a
-                    className="p-contextual-menu__link is-indented"
-                    href="#"
-                    key={`promote-to-${track}/${targetRisk}`}
-                    onClick={this.promoteToChannelClick.bind(
-                      this,
-                      `${track}/${targetRisk}`
-                    )}
-                  >
-                    {`${track}/${targetRisk}`}
-                  </a>
-                );
-              })}
-            </span>
-          )}
-          {this.props.closeRisk && (
-            <span className="p-contextual-menu__group">
-              <a
-                className="p-contextual-menu__link"
-                href="#"
-                onClick={this.closeChannelClick.bind(
-                  this,
-                  `${track}/${this.props.closeRisk}`
-                )}
-              >
-                Close {`${track}/${this.props.closeRisk}`}
-              </a>
-            </span>
-          )}
-        </span>
+      <span className="p-contextual-menu__group">
+        <span className="p-contextual-menu__item">Promote to:</span>
+        {this.props.targetRisks.map(targetRisk => {
+          return (
+            <a
+              className="p-contextual-menu__link is-indented"
+              href="#"
+              key={`promote-to-${track}/${targetRisk}`}
+              onClick={this.promoteToChannelClick.bind(
+                this,
+                `${track}/${targetRisk}`
+              )}
+            >
+              {`${track}/${targetRisk}`}
+            </a>
+          );
+        })}
       </span>
     );
   }
 }
 
 PromoteButton.propTypes = {
-  position: PropTypes.oneOf(["left", "center"]), // right is by default
   track: PropTypes.string.isRequired,
   targetRisks: PropTypes.array.isRequired,
-  closeRisk: PropTypes.string,
-  promoteToChannel: PropTypes.func.isRequired,
-  closeChannel: PropTypes.func
+  promoteToChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -6,7 +6,7 @@ import RevisionsTable from "./revisionsTable";
 import RevisionsList from "./revisionsList";
 import Notification from "./notification";
 import { isInDevmode } from "./devmodeIcon";
-import { UNASSIGNED } from "./constants";
+import { RISKS, UNASSIGNED } from "./constants";
 
 export default class ReleasesController extends Component {
   constructor(props) {
@@ -113,6 +113,33 @@ export default class ReleasesController extends Component {
     });
 
     return nextReleaseData;
+  }
+
+  getTrackingChannel(track, risk, arch) {
+    const { releasedChannels } = this.state;
+
+    let tracking = null;
+    // if there is no revision for this arch in given channel (track/risk)
+    if (
+      !(
+        releasedChannels[`${track}/${risk}`] &&
+        releasedChannels[`${track}/${risk}`][arch]
+      )
+    ) {
+      // find the next channel that has any revision
+      for (let i = RISKS.indexOf(risk); i >= 0; i--) {
+        const trackingChannel = `${track}/${RISKS[i]}`;
+
+        if (
+          releasedChannels[trackingChannel] &&
+          releasedChannels[trackingChannel][arch]
+        ) {
+          tracking = trackingChannel;
+        }
+      }
+    }
+
+    return tracking;
   }
 
   promoteChannel(channel, targetChannel) {
@@ -473,6 +500,7 @@ export default class ReleasesController extends Component {
           undoRelease={this.undoRelease.bind(this)}
           clearPendingReleases={this.clearPendingReleases.bind(this)}
           closeChannel={this.closeChannel.bind(this)}
+          getTrackingChannel={this.getTrackingChannel.bind(this)}
         />
         <RevisionsList
           revisions={this.props.revisions}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -5,12 +5,20 @@
     }
   }
 
-  .p-release-table__arch {
-    padding-left: 20px;
+  .p-release-table__cell {
+    background: $color-light;
+    flex-basis: 100px;
+    flex-grow: 1;
+    margin-left: $sph-inter;
+    max-width: 22.53423%; // col-3
+    min-width: 100px;
+    padding: $spv-intra $sph-intra;
+    position: relative;
   }
 
-  .p-release-table__cell {
-    position: relative;
+  .p-release-table__arch {
+    background: none;
+    padding: 0 1em;
   }
 
   .p-icon-button {
@@ -23,7 +31,7 @@
   }
 
   .p-previous-revision {
-    opacity: .5;
+    display: none;
   }
 
   .p-release-version {
@@ -36,19 +44,25 @@
 
   .p-release-buttons {
     position: absolute;
-    right: 1rem; // match table padding
+    right: .5rem;
     top: .5rem;
   }
 
   .p-revision-info {
     display: inline-block;
     min-width: 30px;
-    padding-bottom: 1.2em;
+    padding-bottom: 1em;
     position: relative;
 
     &.is-pending {
       font-weight: 400;
     }
+  }
+
+  .p-revision-info--empty {
+    display: inline-block;
+    padding-bottom: .5em;
+    padding-top: .5em;
   }
 
   .p-revision-icon {
@@ -77,10 +91,15 @@
     top: 10px;
   }
 
-  .p-channel-buttons {
-    display: inline-block;
+  .p-release-channel-row__promote {
+    flex-grow: 0;
+    flex-shrink: 0;
     margin-right: .5rem;
     width: 2rem;
+  }
+
+  .p-release-channel-row__name {
+    flex-grow: 1;
   }
 
   .p-contextual-menu__item {
@@ -104,5 +123,17 @@
     .is-disabled {
       opacity: .5;
     }
+  }
+
+  .p-release-channel-row {
+    display: flex;
+    margin-bottom: $spv-inter--regular;
+  }
+
+  .p-release-channel-row__channel {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+    width: 22.53423%; // col-3
   }
 }

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -157,7 +157,11 @@ My published snaps — Linux software in the Snap Store
               {% else %}
                 <td>Not released</td>
               {% endif %}
-              <td>{{ snaps[snap].latest_revisions[0].version }}</td>
+              <td>
+                <a href="/account/snaps/{{snap}}/release">
+                  {{ snaps[snap].latest_revisions[0].version }}
+                </a>
+              </td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
Fixes #1187 

Updates visual style of releases table on Release page.
Design doc: https://docs.google.com/document/d/1DdWKGN22mppdse3jNmQe1p02ebimFO1ww94BXHD9Byg/edit?ts=5bab92e3#

### QA
- ./run or http://snapcraft.io-canonical-websites-pr-1206.run.demo.haus/
- go to Releases page of any snap
- look at the release table (it should have new look)
- select some revisions to release
- promote some channels
- close some channels
- check some snap with devmode revisions
- all should work as before with new look


<img width="1037" alt="screen shot 2018-10-17 at 15 46 20" src="https://user-images.githubusercontent.com/83575/47094215-0ee33c80-d22b-11e8-9e35-4a0f020c83b4.png">

