### PR TITLE
Update channel map button to display 'All versions'

### DIFF
--- a/static/sass/_patterns_logo-links.scss
+++ b/static/sass/_patterns_logo-links.scss
@@ -18,52 +18,52 @@
     &:visited {
       color: inherit;
     }
+
+    // first snap flow details link styles
+    &.is-open {
+      border-bottom: 1px solid $color-mid-light;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      overflow: visible;
+      position: relative;
+    }
+
+    // bordered arrow
+    &.is-open::after,
+    &.is-open::before {
+      border-style: solid;
+      content: '';
+      display: block;
+      height: 0;
+      left: 100%;
+      position: absolute;
+      width: 0;
+    }
+
+    &.is-open::after {
+      border-color: transparent transparent $color-x-light transparent;
+      border-width: 12px;
+      bottom: -1px;
+      left: 50%;
+      margin-left: -12px;
+    }
+
+    &.is-open::before {
+      border-color: transparent transparent $color-mid-light transparent;
+      border-width: 12px;
+      bottom: 0;
+      left: 50%;
+      margin-left: -12px;
+    }
+
+    // disable focus outline on open link to make border more visible
+    &.is-open:focus {
+      outline: none;
+    }
   }
 
   .p-logo-image {
     align-items: center;
     display: flex;
-  }
-
-  // first snap flow details link styles
-  .is-open {
-    border-bottom: 1px solid $color-mid-light;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    overflow: visible;
-    position: relative;
-  }
-
-  // bordered arrow
-  .is-open::after,
-  .is-open::before {
-    border-style: solid;
-    content: '';
-    display: block;
-    height: 0;
-    left: 100%;
-    position: absolute;
-    width: 0;
-  }
-
-  .is-open::after {
-    border-color: transparent transparent $color-x-light transparent;
-    border-width: 12px;
-    bottom: -1px;
-    left: 50%;
-    margin-left: -12px;
-  }
-
-  .is-open::before {
-    border-color: transparent transparent $color-mid-light transparent;
-    border-width: 12px;
-    bottom: 0;
-    left: 50%;
-    margin-left: -12px;
-  }
-
-  // disable focus outline on open link to make border more visible
-  .is-open:focus {
-    outline: none;
   }
 }

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -86,7 +86,7 @@
     position: absolute;
     right: 0;
     top: 0;
-    z-index: 10;
+    z-index: 11;
 
     @media screen and (max-width: $breakpoint-medium) {
       border: {

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -83,7 +83,7 @@
             data-js="open-channel-map"
             data-controls="channel-map-versions"
             aria-controls="channel-map-versions">
-              Other versions&nbsp;&nbsp;<i class="p-icon--chevron"></i>
+              All versions&nbsp;&nbsp;<i class="p-icon--chevron"></i>
           </button>
         </div>
       {% else %}

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -112,7 +112,7 @@
 </div>
 <script type="text/template" id="install-window-template" data-js="install-window">
   <div class="row">
-    <a href="#" data-js="slide-all-versions">&lsaquo; Other versions</a>
+    <a href="#" data-js="slide-all-versions">&lsaquo; All versions</a>
   </div>
   <div class="row">
     <p class="p-heading--four">Install ${channel} of {{ snap_title }}</p>


### PR DESCRIPTION
## Done
As per conversations on the mailing list it seems that 'Other versions' doesn't have context when the 'Install' button isn't present. This PR changes the wording to read 'All versions' which works with the 'Install' button and without it.

### Drive-bys
- Scoped the styling of `is-open` of the new language selectors on the homepage
  (It was affecting the channel map `is-open` as it was global scoped)
- Increased the z-index of the channel map
  (The new swiper prev/ next buttons were at the same z-index and later in the page)
