### PR TITLE
Make swiper slides adapt to screenshots widths

### DIFF
--- a/static/js/config/swiper.config.js
+++ b/static/js/config/swiper.config.js
@@ -1,15 +1,11 @@
 const SCREENSHOTS = {
+  freeMode: true,
   watchOverflow: true,
-  slidesPerView: 2.2,
-  spaceBetween: 8,
+  slidesPerView: 'auto',
+  spaceBetween: 16,
   navigation: {
     nextEl: `.swiper-button__next`,
     prevEl: `.swiper-button__prev`
-  },
-  breakpoints: {
-    460: {
-      slidesPerView: 1.2
-    }
   }
 };
 

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -18,8 +18,8 @@
 
       img {
         display: block;
-        max-width: 100%;
         max-height: 248px;
+        max-width: 100%;
       }
 
       &:hover {
@@ -158,7 +158,6 @@
     height: 100%;
     position: relative;
     transition-property: transform;
-    width: 100%;
   }
 
   .swiper-slide-invisible-blank {


### PR DESCRIPTION
Fixes #1200

Makes swiper work correctly with screenshots of different widths.

### QA

- ./run or demo
- go to snap details page of couple of snaps with screenshots (in different sizes)
- make sure spacing is fine regardless of screenshot width
- check it on different screen sizes

<img width="1049" alt="screen shot 2018-10-18 at 14 05 00" src="https://user-images.githubusercontent.com/83575/47153093-d4d37280-d2de-11e8-88c8-934fd1720b8f.png">
