### PR TITLE
Add 50X error template

### DIFF
--- a/templates/50X.html
+++ b/templates/50X.html
@@ -1,0 +1,17 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block meta_title %}{{ error.name }}{% endblock %}
+
+{% block content %}
+<div class="p-strip">
+  <div class="row">
+    <div class="col-10">
+      <h1>{{ error.name }}</h1>
+      <h2>Please try again later</h2>
+      <p>{{ error.description }}</p>
+      <p>You can check the service status at <a href="https://status.snapcraft.io">https://status.snapcraft.io</a>.</p>
+      <p>If the problem persists please check the Snapcraft <a href="https://forum.snapcraft.io">forum</a> or <a href="https://github.com/canonical-websites/snapcraft.io/issues/new">report an issue</a>.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -52,9 +52,17 @@ def set_handlers(app):
 
         return flask.render_template("404.html", error=error.description), 404
 
+    @app.errorhandler(500)
+    def internal_error(error):
+        return flask.render_template("50X.html", error=error), 500
+
     @app.errorhandler(503)
     def service_unavailable(error):
         return flask.render_template("503.html"), 503
+
+    @app.errorhandler(504)
+    def gateway_timeout(error):
+        return flask.render_template("50X.html", error=error), 504
 
     # Global tasks for all requests
     # ===


### PR DESCRIPTION
Fixes #1181

Adds a template to 500 and 504 errors.

### QA

- ./run or demo
- try to get Gateway timeout or internal server error (may require forcing some error locally)
- styled error should appear instead of plain HTML one

<img width="1037" alt="screen shot 2018-10-18 at 15 29 41" src="https://user-images.githubusercontent.com/83575/47158228-7eb8fc00-d2eb-11e8-837a-5116632d60c9.png">
