### PR TITLE
All blogs API cache for an hour

### DIFF
--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -22,7 +22,6 @@ class BlogPage(TestCase):
 
     def setUp(self):
         api.blog.api_session = api.requests.Session()
-        api.blog.api_short_session = api.requests.Session()
         self.api_url = "https://admin.insights.ubuntu.com/wp-json/wp/v2"
 
     @responses.activate

--- a/webapp/api/blog.py
+++ b/webapp/api/blog.py
@@ -6,7 +6,6 @@ TAGS = [2996]  # 'snapcraft.io'
 
 
 api_session = api.requests.CachedSession(expire_after=3600)
-api_short_session = api.requests.CachedSession(expire_after=300)
 
 
 def process_response(response):
@@ -43,7 +42,7 @@ def get_articles(tags=TAGS, per_page=12, page=1, exclude=None, category=None):
 
     url = "".join(url_parts)
 
-    response = api_short_session.get(url)
+    response = api_session.get(url)
     total_pages = response.headers.get("X-WP-TotalPages")
 
     return process_response(response), total_pages


### PR DESCRIPTION
# Summary
 
Cache all blog api calls for an hour

# QA

- `./run`
- http://0.0.0.0:8004/blog
- make sure blog still works