### PR TITLE
Correct capitalisation on front page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
       </div>
     {% endif %}
     <div class="col-12">
-      <h2>A Universal App Store for Linux</h2>
+      <h2>A universal app store for Linux</h2>
       <p>Deliver and update your app on any Linux distribution &mdash;<br class="u-hide--small" /> for desktop, cloud,  and Internet of Things.</p>
       <a href="https://docs.snapcraft.io/build-snaps/languages" class="p-button--positive">Publish your app</a>
     </div>


### PR DESCRIPTION
Canonical style is to use sentence case for headings.