### PR TITLE
Fix restricted channels in devmode icon tooltip

### DIFF
--- a/static/js/publisher/release/devmodeIcon.js
+++ b/static/js/publisher/release/devmodeIcon.js
@@ -26,7 +26,7 @@ export default function DevmodeIcon({ revision, showTooltip }) {
               : "devel grade"}{" "}
             cannot
             <br />
-            be released to stable or beta channels.
+            be released to stable or candidate channels.
           </span>
         )}
       </span>


### PR DESCRIPTION
Fixes wrong channel name in devmode icon tooltip.

### QA

- ./run or http://snapcraft.io-canonical-websites-pr-1238.run.demo.haus/
- go to Releases page of any snap with devmode revisions
- hover over devmode icon on revision in the revisions list
- it should mention stable and candidate (not beta) channels

<img width="702" alt="screen shot 2018-10-24 at 09 46 25" src="https://user-images.githubusercontent.com/83575/47414631-b43d6980-d771-11e8-85c3-ed7ec87058ac.png">
