### PR TITLE
Fix PropTypes in release UI components

### DIFF
--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -101,7 +101,7 @@ export default class RevisionsList extends Component {
 }
 
 RevisionsList.propTypes = {
-  revisions: PropTypes.object.isRequired,
+  revisions: PropTypes.array.isRequired,
   selectedRevisions: PropTypes.array.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   selectRevision: PropTypes.func.isRequired

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -422,7 +422,7 @@ export default class RevisionsTable extends Component {
 RevisionsTable.propTypes = {
   releasedChannels: PropTypes.object.isRequired,
   pendingReleases: PropTypes.object.isRequired,
-  pendingCloses: PropTypes.object.isRequired,
+  pendingCloses: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,


### PR DESCRIPTION
Building React in `release.js` properly in development mode revealed some warning about incorrectly passed props.

This updates the PropTypes declarations to correct types.

### QA

- ./run locally in development mode
- go to Release page of any snap
- there should be no errors with React PropTypes warnings in the console