### PR TITLE
Rename release endpoint to releases

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -257,7 +257,7 @@ export default class ReleasesController extends Component {
   fetchRelease(revision, channels) {
     const { csrfToken } = this.props.options;
 
-    return fetch(`/${this.props.snapName}/release`, {
+    return fetch(`/${this.props.snapName}/releases`, {
       method: "POST",
       mode: "cors",
       cache: "no-cache",
@@ -275,7 +275,7 @@ export default class ReleasesController extends Component {
   fetchClose(channels) {
     const { csrfToken } = this.props.options;
 
-    return fetch(`/${this.props.snapName}/release/close-channel`, {
+    return fetch(`/${this.props.snapName}/releases/close-channel`, {
       method: "POST",
       mode: "cors",
       cache: "no-cache",

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -28,7 +28,7 @@
           </li>
           <li class="p-tabs__item" role="presentation">
             <a
-              href="/{{ snap_name }}/release"
+              href="/{{ snap_name }}/releases"
               class="p-tabs__link"
               tabindex="0"
               role="tab"

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -158,7 +158,7 @@ My published snaps — Linux software in the Snap Store
                 <td>Not released</td>
               {% endif %}
               <td>
-                <a href="/account/snaps/{{snap}}/release">
+                <a href="/{{snap}}/releases">
                   {{ snaps[snap].latest_revisions[0].version }}
                 </a>
               </td>

--- a/tests/publisher/snaps/tests_post_close_channel.py
+++ b/tests/publisher/snaps/tests_post_close_channel.py
@@ -5,7 +5,7 @@ from tests.publisher.endpoint_testing import BaseTestCases
 class PostCloseChannelPageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = "/{}/release/close-channel".format(snap_name)
+        endpoint_url = "/{}/releases/close-channel".format(snap_name)
 
         super().setUp(
             snap_name=snap_name,
@@ -17,7 +17,7 @@ class PostCloseChannelPageNotAuth(BaseTestCases.EndpointLoggedOut):
 class PostDataCloseChannelGetSnapIdPage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = "/{}/release/close-channel".format(snap_name)
+        endpoint_url = "/{}/releases/close-channel".format(snap_name)
         json = {"info": "json"}
 
         api_url = "https://dashboard.snapcraft.io/dev/api/snaps/info/{}"
@@ -59,7 +59,7 @@ class PostDataCloseChannelPage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
         snap_id = "test_id"
-        endpoint_url = "/{}/release/close-channel".format(snap_name)
+        endpoint_url = "/{}/releases/close-channel".format(snap_name)
         api_url = (
             "https://dashboard.snapcraft.io/dev/api/"
             "snaps/{}/close".format(snap_id)

--- a/tests/publisher/snaps/tests_post_release.py
+++ b/tests/publisher/snaps/tests_post_release.py
@@ -5,7 +5,7 @@ from tests.publisher.endpoint_testing import BaseTestCases
 class PostReleasePageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = "/{}/release".format(snap_name)
+        endpoint_url = "/{}/releases".format(snap_name)
 
         super().setUp(
             snap_name=snap_name,
@@ -17,7 +17,7 @@ class PostReleasePageNotAuth(BaseTestCases.EndpointLoggedOut):
 class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = "/{}/release".format(snap_name)
+        endpoint_url = "/{}/releases".format(snap_name)
         api_url = "https://dashboard.snapcraft.io/dev/api/snap-release/"
 
         super().setUp(

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -5,7 +5,7 @@ from tests.publisher.endpoint_testing import BaseTestCases
 class RevisionHistoryPageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):
         snap_name = "test-snap"
-        endpoint_url = "/{}/release".format(snap_name)
+        endpoint_url = "/{}/releases".format(snap_name)
 
         super().setUp(snap_name=snap_name, endpoint_url=endpoint_url)
 
@@ -19,7 +19,7 @@ class GetRevisionGetInfoPage(BaseTestCases.EndpointLoggedInErrorHandling):
             + "/releases?page=1&size=100"
         )
         api_url = api_url.format(snap_name)
-        endpoint_url = "/{}/release".format(snap_name)
+        endpoint_url = "/{}/releases".format(snap_name)
 
         super().setUp(
             snap_name=snap_name,
@@ -39,7 +39,7 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
             + "/releases?page=1&size=100"
         )
         api_url = api_url.format(snap_name)
-        endpoint_url = "/{}/release".format(snap_name)
+        endpoint_url = "/{}/releases".format(snap_name)
 
         super().setUp(
             snap_name=snap_name,

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -458,6 +458,7 @@ def post_listing_snap(snap_name):
 
 
 @publisher_snaps.route("/account/snaps/<snap_name>/release")
+@publisher_snaps.route("/<snap_name>/release")
 @login_required
 def redirect_get_release_history(snap_name):
     return flask.redirect(
@@ -465,7 +466,7 @@ def redirect_get_release_history(snap_name):
     )
 
 
-@publisher_snaps.route("/<snap_name>/release")
+@publisher_snaps.route("/<snap_name>/releases")
 @login_required
 def get_release_history(snap_name):
     try:
@@ -495,6 +496,7 @@ def get_release_history(snap_name):
 
 
 @publisher_snaps.route("/account/snaps/<snap_name>/release", methods=["POST"])
+@publisher_snaps.route("/<snap_name>/release", methods=["POST"])
 @login_required
 def redirect_post_release(snap_name):
     return flask.redirect(
@@ -502,7 +504,7 @@ def redirect_post_release(snap_name):
     )
 
 
-@publisher_snaps.route("/<snap_name>/release", methods=["POST"])
+@publisher_snaps.route("/<snap_name>/releases", methods=["POST"])
 @login_required
 def post_release(snap_name):
     data = flask.request.json
@@ -524,6 +526,14 @@ def post_release(snap_name):
 
 
 @publisher_snaps.route("/<snap_name>/release/close-channel", methods=["POST"])
+@login_required
+def redirect_post_close_channel(snap_name):
+    return flask.redirect(
+        flask.url_for(".post_close_channel", snap_name=snap_name), 307
+    )
+
+
+@publisher_snaps.route("/<snap_name>/releases/close-channel", methods=["POST"])
 @login_required
 def post_close_channel(snap_name):
     data = flask.request.json


### PR DESCRIPTION
# Summary

Rename release to releases

# QA

- `./run`
- http://localhost:8004/toto/release should redirect to http://localhost:8004/toto/releases
- http://localhost:8004/toto/release updates should still works