### PR TITLE
Fix truncating version number in releases table

### DIFF
--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -84,7 +84,7 @@ export default class RevisionsTable extends Component {
           isUnassigned ? this.handleReleaseCellClick.bind(this, arch) : null
         }
       >
-        <span className="p-tooltip p-tooltip--btm-center">
+        <div className="p-tooltip p-tooltip--btm-center">
           <span className="p-release-version">
             {thisPreviousRevision &&
               isInDevmode(thisPreviousRevision) &&
@@ -96,32 +96,10 @@ export default class RevisionsTable extends Component {
                   />
                 </span>
               )}
-            <span className={isPending ? "p-previous-revision" : ""}>
-              {thisPreviousRevision ? (
-                <span className="p-revision-info">
-                  {thisPreviousRevision.version}
-                  <span className="p-revision-info__revision">
-                    ({thisPreviousRevision.revision})
-                  </span>
-                </span>
-              ) : (
-                <span className={!isPending ? "p-revision-info--empty" : ""}>
-                  {trackingChannel ? (
-                    "↑"
-                  ) : isUnassigned ? (
-                    <span>
-                      <i className="p-icon--plus" /> Add revision
-                    </span>
-                  ) : (
-                    "–"
-                  )}
-                </span>
-              )}
-            </span>
-            {isPending && (
+
+            {isPending ? (
               <Fragment>
-                {" "}
-                &rarr;{" "}
+                <span className="p-revision-icon">&rarr;</span>
                 {hasPendingRelease ? (
                   <span className="p-revision-info is-pending">
                     {thisRevision.version}
@@ -133,6 +111,25 @@ export default class RevisionsTable extends Component {
                   <em>close channel</em>
                 )}
               </Fragment>
+            ) : thisPreviousRevision ? (
+              <span className="p-revision-info">
+                {thisPreviousRevision.version}
+                <span className="p-revision-info__revision">
+                  ({thisPreviousRevision.revision})
+                </span>
+              </span>
+            ) : (
+              <span className="p-revision-info--empty">
+                {trackingChannel ? (
+                  "↑"
+                ) : isUnassigned ? (
+                  <Fragment>
+                    <i className="p-icon--plus" /> Add revision
+                  </Fragment>
+                ) : (
+                  "–"
+                )}
+              </span>
             )}
           </span>
 
@@ -171,7 +168,7 @@ export default class RevisionsTable extends Component {
                 )}
             </span>
           )}
-        </span>
+        </div>
         {hasPendingRelease && (
           <div className="p-release-buttons">
             <button

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -56,11 +56,9 @@
   }
 
   .p-release-version {
-    display: inline-block;
+    display: flex;
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+
   }
 
   .p-release-buttons {
@@ -70,13 +68,13 @@
   }
 
   .p-revision-info {
-    display: inline-block;
-    min-width: 30px;
-    padding-bottom: 1em;
-    position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &.is-pending {
       font-weight: 400;
+      padding-right: $sph-inter;
     }
   }
 
@@ -87,16 +85,14 @@
   }
 
   .p-revision-icon {
-    display: inline-block;
-    width: 20px;
+    margin-right: 4px;
   }
 
   .p-revision-info__revision {
     color: $color-mid-dark;
+    display: block;
     font-size: .8em;
-    left: 0;
-    position: absolute;
-    top: 1.6em;
+    margin-top: -.3rem;
   }
 
   .p-release-confirm {


### PR DESCRIPTION
Fixes #1265 

Fixes styles of release table to avoid unnecessary truncating version numbers.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1273.run.demo.haus/
- go to releases page of any snap (with long version numbers)
- check if they are truncated properly
- go to release page of a snap where release version is shorter then revision id ([juju](https://snapcraft-io-canonical-websites-pr-1273.run.demo.haus/juju/releases))
- check if versions are displayed properly
- select some revisions to release or promote a channel - see if in different states versions are displayed properly

<img width="1061" alt="screen shot 2018-11-06 at 15 40 55" src="https://user-images.githubusercontent.com/83575/48071345-66494c80-e1da-11e8-8cf8-f2bd7a948488.png">
