### PR TITLE
Fixes getting the name of tracked channel

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -141,6 +141,7 @@ export default class ReleasesController extends Component {
           releasedChannels[trackingChannel][arch]
         ) {
           tracking = trackingChannel;
+          break;
         }
       }
     }


### PR DESCRIPTION
Fixes #1274

Fixes getting the name of tracked channel (when more then one channel has revisions)

### QA

- ./run or  https://snapcraft-io-canonical-websites-pr-1275.run.demo.haus/
- go to releases page of [juju](https://snapcraft-io-canonical-websites-pr-1275.run.demo.haus/juju/releases) (or any snap that has revisions in stable and candidate but not beta)
- check tooltips when hovering over ↑ in tracking channel
- it should show a name of correct channel

<img width="582" alt="screen shot 2018-11-06 at 16 06 08" src="https://user-images.githubusercontent.com/83575/48072938-e6bd7c80-e1dd-11e8-8913-1f6297600a24.png">
