### PR TITLE
Move from gevent to sync workers

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:create_app() --bind $1 --worker-class gevent --name talisker-`hostname` --access-logfile -"
+RUN_COMMAND="talisker.gunicorn webapp.app:create_app() --bind $1 --worker-class sync --workers 8 --name talisker-`hostname` --access-logfile -"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"


### PR DESCRIPTION
# Summary

Use sync workers instead of gevent.
We will deploy 8 workers per pod (5)

# QA

- `./run`
- make sure we have 8 workers running
- make sure blog.ubuntu.com still accessible 
- try to play with siege for example to check the number of requests we can handle (`siege http://localhost:8023 --concurrent 10 --reps 5`)