### PR TITLE
Refactoring release UI components

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -19,6 +19,10 @@ export default class ReleasesController extends Component {
       // released channels contains channel map for each channel in current track
       // also includes 'unassigned' fake channel to show selected unassigned revision
       releasedChannels: this.props.releasedChannels,
+      // list of revisions returned by API (from releases interval)
+      revisions: this.props.revisions,
+      // list of all available tracks
+      tracks: this.props.tracks,
       // list of architectures released to (or selected to be released to)
       archs: this.getArchsFromReleasedChannels(this.props.releasedChannels),
       // revisions to be released:
@@ -481,28 +485,11 @@ export default class ReleasesController extends Component {
   }
 
   render() {
-    const { tracks } = this.props;
-    const { archs, releasedChannels } = this.state;
-
-    const hasDevmodeRevisions = Object.values(releasedChannels).some(
+    const hasDevmodeRevisions = Object.values(this.state.releasedChannels).some(
       archReleases => {
         return Object.values(archReleases).some(isInDevmode);
       }
     );
-
-    let filteredRevisions = this.props.revisions;
-    let title = null;
-    let filters = this.state.revisionsFilters;
-
-    if (filters && filters.arch) {
-      title = "Latest revisions";
-
-      filteredRevisions = filteredRevisions.filter(revision => {
-        return revision.architectures.includes(filters.arch);
-      });
-
-      title = `${title} in ${filters.arch}`;
-    }
 
     return (
       <Fragment>
@@ -527,14 +514,11 @@ export default class ReleasesController extends Component {
             .
           </Notification>
         )}
+
         <RevisionsTable
-          releasedChannels={releasedChannels}
-          currentTrack={this.state.currentTrack}
-          tracks={tracks}
-          archs={archs}
-          isLoading={this.state.isLoading}
-          pendingReleases={this.state.pendingReleases}
-          pendingCloses={this.state.pendingCloses}
+          // map all the state into props
+          {...this.state}
+          // actions
           getNextReleasedChannels={this.getNextReleasedChannels.bind(this)}
           setCurrentTrack={this.setCurrentTrack.bind(this)}
           releaseRevisions={this.releaseRevisions.bind(this)}
@@ -545,15 +529,9 @@ export default class ReleasesController extends Component {
           closeChannel={this.closeChannel.bind(this)}
           getTrackingChannel={this.getTrackingChannel.bind(this)}
           openRevisionsList={this.openRevisionsList.bind(this)}
-          filters={this.state.revisionsFilters}
-          revisions={this.props.revisions}
-          filteredRevisions={filteredRevisions}
-          title={title}
-          selectedRevisions={this.state.selectedRevisions}
           selectRevision={this.selectRevision.bind(this)}
           closeRevisionsList={this.closeRevisionsList.bind(this)}
           toggleRevisionsList={this.toggleRevisionsList.bind(this)}
-          isRevisionsListOpen={this.state.isRevisionsListOpen}
         />
       </Fragment>
     );

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import "whatwg-fetch";
 
 import RevisionsTable from "./revisionsTable";
-import RevisionsList from "./revisionsList";
 import Notification from "./notification";
 import { isInDevmode } from "./devmodeIcon";
 import { RISKS, UNASSIGNED } from "./constants";
@@ -547,25 +546,15 @@ export default class ReleasesController extends Component {
           getTrackingChannel={this.getTrackingChannel.bind(this)}
           openRevisionsList={this.openRevisionsList.bind(this)}
           filters={this.state.revisionsFilters}
+          revisions={this.props.revisions}
+          filteredRevisions={filteredRevisions}
+          title={title}
+          selectedRevisions={this.state.selectedRevisions}
+          selectRevision={this.selectRevision.bind(this)}
+          closeRevisionsList={this.closeRevisionsList.bind(this)}
+          toggleRevisionsList={this.toggleRevisionsList.bind(this)}
+          isRevisionsListOpen={this.state.isRevisionsListOpen}
         />
-        <div className="p-release-actions">
-          <a href="#" onClick={this.toggleRevisionsList.bind(this)}>
-            Show available revisions ({this.props.revisions.length})
-          </a>
-        </div>
-        {this.state.isRevisionsListOpen && (
-          <RevisionsList
-            title={title}
-            idPrefix="main"
-            revisions={filteredRevisions}
-            releasedChannels={releasedChannels}
-            selectedRevisions={this.state.selectedRevisions}
-            selectRevision={this.selectRevision.bind(this)}
-            showChannels={true}
-            showArchitectures={true}
-            closeRevisionsList={this.closeRevisionsList.bind(this)}
-          />
-        )}
       </Fragment>
     );
   }

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -31,14 +31,12 @@ export default class RevisionsList extends Component {
             <input
               type="checkbox"
               checked={isSelected}
-              id={`${this.props.idPrefix}-revision-check-${revision.revision}`}
+              id={`revision-check-${revision.revision}`}
               onChange={this.revisionSelectChange.bind(this, revision)}
             />
             <label
               className="u-no-margin--bottom"
-              htmlFor={`${this.props.idPrefix}-revision-check-${
-                revision.revision
-              }`}
+              htmlFor={`revision-check-${revision.revision}`}
             >
               {revision.revision}
             </label>
@@ -77,12 +75,24 @@ export default class RevisionsList extends Component {
   }
 
   render() {
+    let filteredRevisions = this.props.revisions;
+    let title = "Revisions available";
+    let filters = this.props.revisionsFilters;
+
+    if (filters && filters.arch) {
+      title = "Latest revisions";
+
+      filteredRevisions = filteredRevisions.filter(revision => {
+        return revision.architectures.includes(filters.arch);
+      });
+
+      title = `${title} in ${filters.arch}`;
+    }
+
     return (
       <Fragment>
         <div>
-          <h4 className="u-float--left">
-            {this.props.title ? this.props.title : "Revisions available"}
-          </h4>
+          <h4 className="u-float--left">{title}</h4>
           <a
             style={{ marginTop: "0.5rem" }}
             href="#"
@@ -107,7 +117,7 @@ export default class RevisionsList extends Component {
               </th>
             </tr>
           </thead>
-          <tbody>{this.renderRows(this.props.revisions)}</tbody>
+          <tbody>{this.renderRows(filteredRevisions)}</tbody>
         </table>
       </Fragment>
     );
@@ -115,13 +125,14 @@ export default class RevisionsList extends Component {
 }
 
 RevisionsList.propTypes = {
-  idPrefix: PropTypes.string,
+  // state
   revisions: PropTypes.array.isRequired,
-  selectedRevisions: PropTypes.array.isRequired,
   releasedChannels: PropTypes.object.isRequired,
-  selectRevision: PropTypes.func.isRequired,
+  revisionsFilters: PropTypes.object,
+  selectedRevisions: PropTypes.array.isRequired,
   showChannels: PropTypes.bool,
   showArchitectures: PropTypes.bool,
-  title: PropTypes.string,
+  // actions
+  selectRevision: PropTypes.func.isRequired,
   closeRevisionsList: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -11,6 +11,7 @@ import {
 import DevmodeIcon, { isInDevmode } from "./devmodeIcon";
 import ChannelMenu from "./channelMenu";
 import PromoteButton from "./promoteButton";
+import RevisionsList from "./revisionsList";
 
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
@@ -437,6 +438,24 @@ export default class RevisionsTable extends Component {
           </div>
           {this.renderRows(releasedChannels, archs)}
         </div>
+        <div className="p-release-actions">
+          <a href="#" onClick={this.props.toggleRevisionsList}>
+            Show available revisions ({this.props.revisions.length})
+          </a>
+        </div>
+        {this.props.isRevisionsListOpen && (
+          <RevisionsList
+            title={this.props.title}
+            idPrefix="main"
+            revisions={this.props.filteredRevisions}
+            releasedChannels={releasedChannels}
+            selectedRevisions={this.props.selectedRevisions}
+            selectRevision={this.props.selectRevision}
+            showChannels={true}
+            showArchitectures={true}
+            closeRevisionsList={this.props.closeRevisionsList}
+          />
+        )}
       </Fragment>
     );
   }
@@ -460,5 +479,13 @@ RevisionsTable.propTypes = {
   closeChannel: PropTypes.func.isRequired,
   getTrackingChannel: PropTypes.func.isRequired,
   openRevisionsList: PropTypes.func.isRequired,
-  filters: PropTypes.object
+  filters: PropTypes.object,
+  filteredRevisions: PropTypes.array,
+  title: PropTypes.string,
+  selectedRevisions: PropTypes.array,
+  selectRevision: PropTypes.func,
+  closeRevisionsList: PropTypes.func,
+  revisions: PropTypes.array,
+  toggleRevisionsList: PropTypes.func,
+  isRevisionsListOpen: PropTypes.bool
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -67,11 +67,12 @@ export default class RevisionsTable extends Component {
     const trackingChannel = this.props.getTrackingChannel(track, risk, arch);
 
     const isUnassigned = risk === UNASSIGNED;
-
     const className = `p-release-table__cell ${
       isUnassigned ? "is-clickable" : ""
     } ${
-      isUnassigned && this.props.filters && this.props.filters.arch === arch
+      isUnassigned &&
+      this.props.revisionsFilters &&
+      this.props.revisionsFilters.arch === arch
         ? "is-active"
         : ""
     }`;
@@ -445,9 +446,8 @@ export default class RevisionsTable extends Component {
         </div>
         {this.props.isRevisionsListOpen && (
           <RevisionsList
-            title={this.props.title}
-            idPrefix="main"
-            revisions={this.props.filteredRevisions}
+            revisions={this.props.revisions}
+            revisionsFilters={this.props.revisionsFilters}
             releasedChannels={releasedChannels}
             selectedRevisions={this.props.selectedRevisions}
             selectRevision={this.props.selectRevision}
@@ -462,16 +462,23 @@ export default class RevisionsTable extends Component {
 }
 
 RevisionsTable.propTypes = {
+  // state
+  revisions: PropTypes.array,
+  archs: PropTypes.array.isRequired,
+  tracks: PropTypes.array.isRequired,
+  currentTrack: PropTypes.string.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   pendingReleases: PropTypes.object.isRequired,
   pendingCloses: PropTypes.array.isRequired,
-  currentTrack: PropTypes.string.isRequired,
-  archs: PropTypes.array.isRequired,
-  tracks: PropTypes.array.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  revisionsFilters: PropTypes.object,
+  selectedRevisions: PropTypes.array,
+  isRevisionsListOpen: PropTypes.bool,
+
+  // actions
   getNextReleasedChannels: PropTypes.func.isRequired,
-  setCurrentTrack: PropTypes.func.isRequired,
   releaseRevisions: PropTypes.func.isRequired,
+  setCurrentTrack: PropTypes.func.isRequired,
   promoteRevision: PropTypes.func.isRequired,
   promoteChannel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
@@ -479,13 +486,7 @@ RevisionsTable.propTypes = {
   closeChannel: PropTypes.func.isRequired,
   getTrackingChannel: PropTypes.func.isRequired,
   openRevisionsList: PropTypes.func.isRequired,
-  filters: PropTypes.object,
-  filteredRevisions: PropTypes.array,
-  title: PropTypes.string,
-  selectedRevisions: PropTypes.array,
-  selectRevision: PropTypes.func,
-  closeRevisionsList: PropTypes.func,
-  revisions: PropTypes.array,
-  toggleRevisionsList: PropTypes.func,
-  isRevisionsListOpen: PropTypes.bool
+  selectRevision: PropTypes.func.isRequired,
+  closeRevisionsList: PropTypes.func.isRequired,
+  toggleRevisionsList: PropTypes.func.isRequired
 };


### PR DESCRIPTION
Part of #1266 

As preparation to show channel history in Release UI this PR moves revisions list component rendering into release table (so later it can be rendered in between the table rows).
Also cleans up a bit of how the state data of release UI is passed into components.

### QA

- ./run or demo
- to go releases page of any snap
- everything should work as before