### PR TITLE
Fix missing links and icons iot page

### DIFF
--- a/templates/store/categories/iot.html
+++ b/templates/store/categories/iot.html
@@ -141,7 +141,7 @@
       </div>
       <div class="col-2">
         <a class="p-media-object--snap" href="/ammp-edge">
-          <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-media-object--snap__img" alt="">
+          <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/08/AMMP_Logo_-_solid_in_circle_256.png" class="p-media-object--snap__img" alt="">
           <div class="p-media-object--snap__content">
             <h4 class="p-media-object--snap__title">
               ammp-edge
@@ -393,8 +393,8 @@
         </a>
       </div>
       <div class="col-2">
-        <span class="p-media-object--snap">
-          <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-media-object--snap__img" alt="">
+        <a class="p-media-object--snap" href="/pc">
+          <img src="https://dashboard.snapcraft.io/site_media/appmedia/2016/07/icon_30.png" class="p-media-object--snap__img" alt="">
           <div class="p-media-object--snap__content">
             <h4 class="p-media-object--snap__title">
               PC
@@ -405,7 +405,7 @@
               </p>
             </div>
           </div>
-        </span>
+        </a>
       </div>
     </div>
 


### PR DESCRIPTION
# Summary

Fix missing links on iot page: PC link and missing icon for ammp edge

# QA

- `./run`
- Make sure all the icon for ammp edge show up on the snap card
- Make sure snap PC is linked to snapcraft.io/pc