### PR TITLE
Shows release history when channel/arch cell is clicked in release UI

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -98,6 +98,7 @@ const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
       snapName={snapName}
       releasedChannels={releasedChannels}
       revisions={releasesData.revisions}
+      releases={releasesData.releases}
       revisionsMap={revisionsMap}
       tracks={tracks}
       options={options}

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -11,7 +11,7 @@ export default class RevisionsList extends Component {
     this.props.selectRevision(revision);
   }
 
-  renderRows(revisions, showCheckboxes) {
+  renderRows(revisions, isHistory) {
     return revisions.map(revision => {
       const revisionDate = revision.release
         ? new Date(revision.release.when)
@@ -23,7 +23,7 @@ export default class RevisionsList extends Component {
       // disable revisions from the same architecture that already selected
       // but only if checkboxes are visible (not in channel history)
       const isDisabled =
-        showCheckboxes &&
+        isHistory &&
         !isSelected &&
         revision.architectures.some(
           arch =>
@@ -32,11 +32,20 @@ export default class RevisionsList extends Component {
         );
 
       const id = `revision-check-${revision.revision}`;
+      const className = `${isDisabled ? "is-disabled" : ""} ${
+        isHistory ? "is-clickable" : ""
+      }`;
 
       return (
-        <tr key={id} className={isDisabled ? "is-disabled" : ""}>
+        <tr
+          key={id}
+          className={className}
+          onClick={
+            isHistory ? this.revisionSelectChange.bind(this, revision) : null
+          }
+        >
           <td>
-            {showCheckboxes ? (
+            {isHistory ? (
               <Fragment>
                 <input
                   type="checkbox"

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -19,7 +19,11 @@ export default class RevisionsList extends Component {
       const isSelected = this.props.selectedRevisions.includes(
         revision.revision
       );
+
+      // disable revisions from the same architecture that already selected
+      // but only if checkboxes are visible (not in channel history)
       const isDisabled =
+        showCheckboxes &&
         !isSelected &&
         revision.architectures.some(
           arch =>

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -34,7 +34,8 @@ export default class RevisionsTable extends Component {
     }
   }
 
-  undoClick(revision, track, risk) {
+  undoClick(revision, track, risk, event) {
+    event.stopPropagation();
     this.props.undoRelease(revision, `${track}/${risk}`);
   }
 

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -38,8 +38,8 @@ export default class RevisionsTable extends Component {
     this.props.undoRelease(revision, `${track}/${risk}`);
   }
 
-  handleReleaseCellClick(arch, event) {
-    this.props.openRevisionsList({ arch });
+  handleReleaseCellClick(arch, risk, track, event) {
+    this.props.openRevisionsList({ arch, risk, track });
 
     event.preventDefault();
     event.stopPropagation();
@@ -70,9 +70,9 @@ export default class RevisionsTable extends Component {
     const className = `p-release-table__cell ${
       isUnassigned ? "is-clickable" : ""
     } ${
-      isUnassigned &&
       this.props.revisionsFilters &&
-      this.props.revisionsFilters.arch === arch
+      this.props.revisionsFilters.arch === arch &&
+      this.props.revisionsFilters.risk === risk
         ? "is-active"
         : ""
     }`;
@@ -82,9 +82,7 @@ export default class RevisionsTable extends Component {
         className={className}
         style={{ position: "relative" }}
         key={`${channel}/${arch}`}
-        onClick={
-          isUnassigned ? this.handleReleaseCellClick.bind(this, arch) : null
-        }
+        onClick={this.handleReleaseCellClick.bind(this, arch, risk, track)}
       >
         <div className="p-tooltip p-tooltip--btm-center">
           <span className="p-release-version">
@@ -454,6 +452,7 @@ export default class RevisionsTable extends Component {
             showChannels={true}
             showArchitectures={true}
             closeRevisionsList={this.props.closeRevisionsList}
+            getReleaseHistory={this.props.getReleaseHistory}
           />
         )}
       </Fragment>
@@ -488,5 +487,6 @@ RevisionsTable.propTypes = {
   openRevisionsList: PropTypes.func.isRequired,
   selectRevision: PropTypes.func.isRequired,
   closeRevisionsList: PropTypes.func.isRequired,
-  toggleRevisionsList: PropTypes.func.isRequired
+  toggleRevisionsList: PropTypes.func.isRequired,
+  getReleaseHistory: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -67,8 +67,8 @@ export default class RevisionsTable extends Component {
     const trackingChannel = this.props.getTrackingChannel(track, risk, arch);
 
     const isUnassigned = risk === UNASSIGNED;
-    const className = `p-release-table__cell ${
-      isUnassigned ? "is-clickable" : ""
+    const className = `p-release-table__cell is-clickable ${
+      isUnassigned ? "is-unassigned" : ""
     } ${
       this.props.revisionsFilters &&
       this.props.revisionsFilters.arch === arch &&

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -154,6 +154,10 @@
 
     .is-disabled {
       opacity: .5;
+
+      .p-tooltip__message {
+        display: none;
+      }
     }
 
     .is-clickable {
@@ -190,9 +194,5 @@
     padding: 1rem;
     position: absolute;
     z-index: 100;
-  }
-
-  .p-release-table__cell .p-tooltip__message {
-    z-index: 101;
   }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -90,8 +90,8 @@
 
   .p-revision-info--empty {
     display: inline-block;
-    padding-bottom: .5em;
-    padding-top: .5em;
+    padding-bottom: .6em;
+    padding-top: .6em;
   }
 
   .p-revision-icon {
@@ -154,6 +154,15 @@
 
     .is-disabled {
       opacity: .5;
+    }
+
+    .is-clickable {
+      cursor: pointer;
+
+      &:hover {
+        background-color: $color-light;
+
+      }
     }
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -10,6 +10,7 @@
   }
 
   .p-release-table__cell {
+    @include vf-animation (#{background-color, border-color}, fast, in);
     background: $color-light;
     border: 1px solid transparent;
     flex-basis: 100px;
@@ -20,8 +21,7 @@
     padding: $spv-intra $sph-intra;
     position: relative;
 
-    &.is-clickable {
-      @include vf-animation (#{background-color, border-color}, fast, in);
+    &.is-unassigned {
       background-color: $color-x-light;
       border-color: $color-mid-light;
       border-radius: 2px;
@@ -32,8 +32,18 @@
       }
     }
 
+
+    &.is-clickable {
+      cursor: pointer;
+
+      &:hover {
+        border-color: $color-mid-light;
+      }
+    }
+
     &.is-active {
       background-color: $color-selected;
+      border-color: $color-mid-light;
       box-shadow: 0 1px 5px 1px transparentize($color-x-dark, .8);
     }
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -138,7 +138,7 @@
   }
 
   .p-revisions-list {
-    .col-has-checkbox {
+    .col-checkbox-spacer {
       padding-left: 2rem;
     }
 

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -15,8 +15,7 @@ class GetRevisionGetInfoPage(BaseTestCases.EndpointLoggedInErrorHandling):
         snap_name = "test-snap"
 
         api_url = (
-            "https://dashboard.snapcraft.io/api/v2/snaps/{}"
-            + "/releases?page=1&size=100"
+            "https://dashboard.snapcraft.io/api/v2/snaps/{}" + "/releases"
         )
         api_url = api_url.format(snap_name)
         endpoint_url = "/{}/releases".format(snap_name)
@@ -35,8 +34,7 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
         snap_name = "test-snap"
 
         api_url = (
-            "https://dashboard.snapcraft.io/api/v2/snaps/{}"
-            + "/releases?page=1&size=100"
+            "https://dashboard.snapcraft.io/api/v2/snaps/{}" + "/releases"
         )
         api_url = api_url.format(snap_name)
         endpoint_url = "/{}/releases".format(snap_name)

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -54,7 +54,7 @@ REGISTER_NAME_URL = "".join([DASHBOARD_API, "register-name/"])
 REVISION_HISTORY_URL = "".join([DASHBOARD_API, "snaps/{snap_id}/history"])
 
 SNAP_RELEASE_HISTORY_URL = "".join(
-    [DASHBOARD_API_V2, "snaps/{snap_name}/releases?page=1&size=100"]
+    [DASHBOARD_API_V2, "snaps/{snap_name}/releases"]
 )
 
 


### PR DESCRIPTION
Fixes #1266 

Shows release history when channel/arch cell is clicked in release UI

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1286.run.demo.haus/
- go to Releases page of any snap
- click on any channel/arch cell
- history of releases for this channel in this architecture should show in table below

<img width="1032" alt="screen shot 2018-11-08 at 15 43 13" src="https://user-images.githubusercontent.com/83575/48205809-29618f00-e36d-11e8-93c8-accb0994c2c9.png">
