### PR TITLE
Fix Privacy Notice URL when signing up for developer account.

### DIFF
--- a/templates/publisher/developer_programme_agreement.html
+++ b/templates/publisher/developer_programme_agreement.html
@@ -18,7 +18,7 @@
         <a class="p-link--external" href="https://www.ubuntu.com/legal/terms-and-policies/developer-terms-and-conditions" target="_blank">Developer Terms and Conditions</a>
       </p>
       <p class="p-card__content">
-        <a class="p-link--external" href="https://www.ubuntu.com/legal/dataprivacy/snap-store" target="_blank">Privacy Notice</a>
+        <a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/snap-store" target="_blank">Privacy Notice</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
I was just signing up for a developer account and happen to be one of those users who takes a peep at the privacy policy, but the link went to 404. Looks like a typo - this appears to be the correct URL.