### PR TITLE
Extend search to wide architectures

### DIFF
--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -29,7 +29,7 @@ SNAP_SEARCH_URL = "".join(
     [
         SNAPCRAFT_IO_API,
         "snaps/search",
-        "?q={snap_name}&page={page}&size={size}&scope=wide",
+        "?q={snap_name}&page={page}&size={size}&scope=wide&arch=wide",
         "&confinement=strict,classic",
         "&fields=package_name,title,summary,icon_url,publisher,",
         "developer_validation,origin",


### PR DESCRIPTION
# Summary

Extend search for wide architectures

# QA 

- `./run`
- Search for “rigado-factory-dnsmasq” or “rigado”.
- Search for “pi2-kernel”, or “pi2, or “kernel”.
- Some snaps should show up