### PR TITLE
Fix missing attribute when no response from api

### DIFF
--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -1,0 +1,59 @@
+import responses
+from flask_testing import TestCase
+from webapp.app import create_app
+
+
+class GetDetailsPageTest(TestCase):
+    render_templates = False
+
+    def setUp(self):
+        self.snap_name = "toto"
+        self.api_url = "".join(
+            [
+                "https://api.snapcraft.io/v2/",
+                "snaps/info/",
+                self.snap_name,
+                "?fields=title,summary,description,license,contact,website,",
+                "publisher,prices,media,download,version,created-at,"
+                "confinement",
+            ]
+        )
+        self.endpoint_url = "/" + self.snap_name
+
+    def create_app(self):
+        app = create_app(testing=True)
+        app.secret_key = "secret_key"
+        app.config["WTF_CSRF_METHODS"] = []
+
+        return app
+
+    @responses.activate
+    def test_api_500(self):
+        payload = {"error-list": []}
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=500
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 1
+        called = responses.calls[0]
+        assert called.request.url == self.api_url
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_api_500_no_answer(self):
+        responses.add(
+            responses.Response(method="GET", url=self.api_url, status=500)
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 1
+        called = responses.calls[0]
+        assert called.request.url == self.api_url
+
+        assert response.status_code == 502

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -66,12 +66,15 @@ class StoreApi:
     headers = {"X-Ubuntu-Series": "16"}
     headers_v2 = {"Snap-Device-Series": "16"}
 
-    def __init__(self, store=None):
+    def __init__(self, store=None, testing=False):
         if store:
             self.headers.update({"X-Ubuntu-Store": store})
             self.headers_v2.update({"Snap-Device-Store": store})
 
-        self.session = api.requests.CachedSession()
+        if testing:
+            self.session = api.requests.Session()
+        else:
+            self.session = api.requests.CachedSession()
         self.session.headers.update(self.headers)
         self.session.headers.update(self.headers_v2)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -45,7 +45,7 @@ def create_app(testing=False):
     set_handlers(app)
 
     if app.config["WEBAPP"] == "snapcraft":
-        init_snapcraft(app)
+        init_snapcraft(app, testing)
     else:
         init_brandstore(app)
 
@@ -57,11 +57,11 @@ def init_brandstore(app):
     app.register_blueprint(store_blueprint(store))
 
 
-def init_snapcraft(app):
+def init_snapcraft(app, testing=False):
     app.register_blueprint(snapcraft_blueprint())
     app.register_blueprint(first_snap, url_prefix="/first-snap")
     app.register_blueprint(login)
-    app.register_blueprint(store_blueprint())
+    app.register_blueprint(store_blueprint(testing=testing))
     app.register_blueprint(account, url_prefix="/account")
     app.register_blueprint(publisher_snaps)
     app.register_blueprint(blog, url_prefix="/blog")

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -253,7 +253,7 @@ def store_blueprint(store_query=None, testing=False):
                         api_response_error_list.errors.key()
                     )
                 else:
-                    error_messages = ""
+                    error_messages = "An error occurred."
                 flask.abort(502, error_messages)
         except ApiResponseError as api_response_error:
             flask.abort(502, str(api_response_error))

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -18,8 +18,8 @@ from webapp.api.exceptions import (
 from urllib.parse import quote_plus
 
 
-def store_blueprint(store_query=None):
-    api = StoreApi(store_query)
+def store_blueprint(store_query=None, testing=False):
+    api = StoreApi(store=store_query, testing=testing)
 
     store = flask.Blueprint(
         "store",

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -248,9 +248,12 @@ def store_blueprint(store_query=None):
             if api_response_error_list.status_code == 404:
                 flask.abort(404, "No snap named {}".format(snap_name))
             else:
-                error_messages = ", ".join(
-                    api_response_error_list.errors.key()
-                )
+                if api_response_error_list.errors:
+                    error_messages = ", ".join(
+                        api_response_error_list.errors.key()
+                    )
+                else:
+                    error_messages = ""
                 flask.abort(502, error_messages)
         except ApiResponseError as api_response_error:
             flask.abort(502, str(api_response_error))


### PR DESCRIPTION
# Summary

Fixes #1260 
Fix error when API returns empty response on  500
Add tests to make sure it works well

# QA

- To reproduce behaviour:
- at line 80 of file `webapp/api/store.py` add this:
```python
                api_error_exception = ApiResponseErrorList(
                    "The api returned a list of errors",
                    response.status_code,
                    []
                )
                raise api_error_exception
```
- `./run`
- http://localhost:8004/toto
- Should return a `Bade Gateway` page