### PR TITLE
Return last cached api call on error

### DIFF
--- a/webapp/api/requests.py
+++ b/webapp/api/requests.py
@@ -103,6 +103,7 @@ class CachedSession(BaseSession, requests_cache.CachedSession):
             "expire_after": 5,
             # Include headers in cache key
             "include_get_headers": True,
+            "old_data_on_error": True,
         }
 
         options.update(kwargs)


### PR DESCRIPTION
# Summary

Fixes #1233 
On error return last cached api call

# QA

- `./run`
- http://localhost:8004/toto
- Disconnect from internet
- http://localhost:8004/toto
- Page should still show (without any images)
- After 5 minutes (time for cache to expire) http://localhost:8004/toto
- Page should still be accessible