### PR TITLE
Redirect blog.ubuntu.com URL forms to the blog

### DIFF
--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -308,3 +308,31 @@ class BlogPage(TestCase):
         response = self.client.get("/blog/feed")
 
         assert response.status_code == 502
+
+    def test_article_redirects(self):
+        """
+        Check that blog articles can be requested with
+        year, month and day parts in the URL, which will
+        result in a redirect to the canonical URL, with just the slug
+        """
+
+        year_redirect = self.client.get("/blog/2005/article_slug")
+        month_redirect = self.client.get("/blog/2005/10/article_slug")
+        day_redirect = self.client.get("/blog/2005/10/31/article_slug")
+
+        assert year_redirect.status_code == 302
+        assert month_redirect.status_code == 302
+        assert day_redirect.status_code == 302
+
+        assert (
+            year_redirect.headers.get("Location")
+            == "http://localhost/blog/article_slug"
+        )
+        assert (
+            month_redirect.headers.get("Location")
+            == "http://localhost/blog/article_slug"
+        )
+        assert (
+            day_redirect.headers.get("Location")
+            == "http://localhost/blog/article_slug"
+        )

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -117,6 +117,16 @@ def feed():
     return flask.Response(right_title, mimetype="text/xml")
 
 
+@blog.route(
+    '/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>/'
+    '<regex("[0-9]{2}"):day>/<slug>'
+)
+@blog.route('/<regex("[0-9]{4}"):year>/<regex("[0-9]{2}"):month>/<slug>')
+@blog.route('/<regex("[0-9]{4}"):year>/<slug>')
+def article_redirect(slug, year, month=None, day=None):
+    return flask.redirect(flask.url_for(".article", slug=slug))
+
+
 @blog.route("/<slug>")
 def article(slug):
     try:


### PR DESCRIPTION
This will redirect URLs of the following forms:

- `/blog/{year}/{slug}`
- `/blog/{year}/{month}/{slug}`
- `/blog/{year}/{month}/{day}/{slug}`

To the canonical form of `/blog/{slug}`.

This is to provide parity in URL support with blog.ubuntu.com, to help with #1222.

QA
--

`./run` and go to any of:

- http://0.0.0.0:8004/blog/2018/03/09/your-first-robot-the-driver-4-5
- http://0.0.0.0:8004/blog/2018/03/your-first-robot-the-driver-4-5
- http://0.0.0.0:8004/blog/2018/your-first-robot-the-driver-4-5

Check you're correctly redirected to http://0.0.0.0:8004/blog/your-first-robot-the-driver-4-5

Also, check `./run test` passes.