### PR TITLE
Workaround LP: #1802899

### DIFF
--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -40,6 +40,7 @@ explain:
             plugin: python
             python-version: python2
             source: .
+            source-type: git
             stage-packages:
               - python-six
     - text: The <code>python</code> plugin builds upon the work you’ve already done to describe your Python dependencies in <code>setup.py</code> and <code>requirements.txt</code>. You can include the latter by setting the <code>requirements</code> keyword to the path of your <code>requirements.txt</code>.

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -51,7 +51,7 @@ explain:
     - code: |
         apps:
           test-offlineimap-{name}:
-            command: bin/test-offlineimap-{name}
+            command: bin/offlineimap
     - warning: |
         <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official offlineimap snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.


### PR DESCRIPTION
We don't automatically install git in the build VM unless you set `source-type: git`, but if you use `version: git` we try to call it regardless. This works around that problem until we install git when using `version: git`. I've also updated the snapcraft-docs/offlineimap repo to match and confirmed a snap build does the right thing.

Also opportunistically fix a typo that would've prevented offlineimap from running (the path is always bin/offlineimap, regardless of whether you change the snap name and command name).