### PR TITLE
Set the 'theme-color' to match the global nav

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#262626">
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/1q9ia7iDuWQlCaJ7nfKVeQ5G-FPyJbP-H{% endblock %}">
 


### PR DESCRIPTION
Match the browser chrome and status bar to the global nav colour for seamlessness.

## QA

- Pull the branch
- `./run`
- Visit `{your-laptop-ip}:8004` on a mobile device (or visit the demo)
- See that the browser chrome and status backgrounds match the global nav


Before:
![photo_2018-11-13_10-18-14](https://user-images.githubusercontent.com/479384/48406927-98eccb00-e72d-11e8-82cb-467162e99ae9.jpg)


After:
![photo_2018-11-13_10-18-21](https://user-images.githubusercontent.com/479384/48406935-9c805200-e72d-11e8-8e23-e84a52d3e286.jpg)
