### PR TITLE
Update release UI layout

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -531,27 +531,29 @@ export default class ReleasesController extends Component {
 
     return (
       <Fragment>
-        {this.state.error && (
-          <Notification status="error" appearance="negative">
-            {this.state.error}
-          </Notification>
-        )}
-        {hasDevmodeRevisions && (
-          <Notification appearance="caution">
-            Revisions in development mode cannot be released to stable or
-            candidate channels.
-            <br />
-            You can read more about{" "}
-            <a href="https://docs.snapcraft.io/t/snap-confinement/6233">
-              <code>devmode</code> confinement
-            </a>{" "}
-            and{" "}
-            <a href="https://docs.snapcraft.io/t/snapcraft-yaml-reference/4276">
-              <code>devel</code> grade
-            </a>
-            .
-          </Notification>
-        )}
+        <div className="row">
+          {this.state.error && (
+            <Notification status="error" appearance="negative">
+              {this.state.error}
+            </Notification>
+          )}
+          {hasDevmodeRevisions && (
+            <Notification appearance="caution">
+              Revisions in development mode cannot be released to stable or
+              candidate channels.
+              <br />
+              You can read more about{" "}
+              <a href="https://docs.snapcraft.io/t/snap-confinement/6233">
+                <code>devmode</code> confinement
+              </a>{" "}
+              and{" "}
+              <a href="https://docs.snapcraft.io/t/snapcraft-yaml-reference/4276">
+                <code>devel</code> grade
+              </a>
+              .
+            </Notification>
+          )}
+        </div>
 
         <RevisionsTable
           // map all the state into props

--- a/static/js/publisher/release/releasesOverlay.js
+++ b/static/js/publisher/release/releasesOverlay.js
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import RevisionsList from "./revisionsList";
+
+export default class ReleasesOverlay extends Component {
+  render() {
+    return (
+      <div className="p-strip is-shallow">
+        <div className="row">
+          <RevisionsList
+            revisions={this.props.revisions}
+            revisionsFilters={this.props.revisionsFilters}
+            releasedChannels={this.props.releasedChannels}
+            selectedRevisions={this.props.selectedRevisions}
+            selectRevision={this.props.selectRevision}
+            showChannels={true}
+            showArchitectures={true}
+            closeRevisionsList={this.props.closeRevisionsList}
+            getReleaseHistory={this.props.getReleaseHistory}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+ReleasesOverlay.propTypes = {
+  // state
+  revisions: PropTypes.array.isRequired,
+  releasedChannels: PropTypes.object.isRequired,
+  revisionsFilters: PropTypes.object,
+  selectedRevisions: PropTypes.array.isRequired,
+  showChannels: PropTypes.bool,
+  showArchitectures: PropTypes.bool,
+  // actions
+  selectRevision: PropTypes.func.isRequired,
+  closeRevisionsList: PropTypes.func.isRequired,
+  getReleaseHistory: PropTypes.func.isRequired
+};

--- a/static/js/publisher/release/revisionsTable.js
+++ b/static/js/publisher/release/revisionsTable.js
@@ -11,7 +11,7 @@ import {
 import DevmodeIcon, { isInDevmode } from "./devmodeIcon";
 import ChannelMenu from "./channelMenu";
 import PromoteButton from "./promoteButton";
-import RevisionsList from "./revisionsList";
+import ReleasesOverlay from "./releasesOverlay";
 
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
@@ -419,32 +419,34 @@ export default class RevisionsTable extends Component {
 
     return (
       <Fragment>
-        <div className="u-clearfix">
-          <h4 className="u-float--left">Releases available for install</h4>
-          {tracks.length > 1 && this.renderTrackDropdown(tracks)}
-        </div>
-        {this.renderReleasesConfirm()}
-        <div className="p-release-table">
-          <div className="p-release-channel-row">
-            <div className="p-release-channel-row__channel" />
-            {archs.map(arch => (
-              <div
-                className="p-release-table__cell p-release-table__arch"
-                key={`${arch}`}
-              >
-                {arch}
-              </div>
-            ))}
+        <div className="row">
+          <div className="u-clearfix">
+            <h4 className="u-float--left">Releases available for install</h4>
+            {tracks.length > 1 && this.renderTrackDropdown(tracks)}
           </div>
-          {this.renderRows(releasedChannels, archs)}
-        </div>
-        <div className="p-release-actions">
-          <a href="#" onClick={this.props.toggleRevisionsList}>
-            Show available revisions ({this.props.revisions.length})
-          </a>
+          {this.renderReleasesConfirm()}
+          <div className="p-release-table">
+            <div className="p-release-channel-row">
+              <div className="p-release-channel-row__channel" />
+              {archs.map(arch => (
+                <div
+                  className="p-release-table__cell p-release-table__arch"
+                  key={`${arch}`}
+                >
+                  {arch}
+                </div>
+              ))}
+            </div>
+            {this.renderRows(releasedChannels, archs)}
+          </div>
+          <div className="p-release-actions">
+            <a href="#" onClick={this.props.toggleRevisionsList}>
+              Show available revisions ({this.props.revisions.length})
+            </a>
+          </div>
         </div>
         {this.props.isRevisionsListOpen && (
-          <RevisionsList
+          <ReleasesOverlay
             revisions={this.props.revisions}
             revisionsFilters={this.props.revisionsFilters}
             releasedChannels={releasedChannels}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -143,7 +143,6 @@
   }
 
   .p-release-actions {
-    margin-bottom: $spv-inter--regular;
     text-align: right;
   }
 

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -10,9 +10,7 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
   {% include "publisher/_header.html" %}
 
   <section class="p-strip is-shallow">
-    <div class="row">
-      <div id="release-history"></div>
-    </div>
+    <div id="release-history"></div>
   </section>
 </div>
 


### PR DESCRIPTION
Part of #1267 

Moves some of the layout elements (Vanilla rows) into React components as preparation for moving release history into a full width overlay 'dropdown'.

### QA

- ./run or demo
- go to Release page of any snap
- click around
- everything should work and look as before