### PR TITLE
Ensure the last point on the graph is accessible

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevices.js
+++ b/static/js/publisher/metrics/graphs/activeDevices.js
@@ -253,7 +253,7 @@ function drawGraph(holderSelector, holder, activeDevices) {
 
     const x0 = xScale.invert(mousePosition[0]);
     const _date = new Date(x0);
-    _date.setHours(0);
+    _date.setHours(_date.getHours() - 12);
     _date.setMinutes(0);
     _date.setSeconds(0);
     _date.setMilliseconds(0);


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1309

This PR offsets the hover date by -12 hours so the middle of a day is aligned with the tick.

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/metrics
- Hover over the graph around the last tick
- You should be able to see the last available date (today - 1)