### PR TITLE
Get metrics 1 day and 3 hours previously

### DIFF
--- a/webapp/metrics/helper.py
+++ b/webapp/metrics/helper.py
@@ -15,8 +15,8 @@ def get_last_metrics_processed_date():
     # We want to give time to the store to proccess all the metrics,
     # since the metrics are processed during the night
     # https://github.com/canonical-websites/snapcraft.io/pull/616
-    twelve_hours = relativedelta.relativedelta(hours=12)
-    last_metrics_processed = datetime.datetime.utcnow() - twelve_hours
+    three_hours = relativedelta.relativedelta(hours=3)
+    last_metrics_processed = datetime.datetime.utcnow() - three_hours
 
     one_day = relativedelta.relativedelta(days=1)
     return last_metrics_processed.date() - one_day


### PR DESCRIPTION
Also addresses forum.snapcraft.io/t/store-metrics/8434/6 and forum.snapcraft.io/t/publisher-metrics-dont-add-up/8487/1

This PR changes the metrics 'grabbing' period from -1 day and 12 hours to -1 day and 3 hours. As mentioned by @nottrobin [here](https://github.com/canonical-websites/snapcraft.io/pull/616#issuecomment-385981115).

This should enable viewing the previous days metrics a lot sooner (before midday utc)

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/metrics
- You should be able to see the last available date (today - 1)