### PR TITLE
Add missing link to golang first snap flow

### DIFF
--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -163,9 +163,17 @@ function initSnapScreenshotsEdit(
       document
         .querySelector(".js-delete-screenshot")
         .setAttribute("disabled", "disabled");
+
+      document
+        .querySelector(".js-fullscreen-screenshot")
+        .setAttribute("disabled", "disabled");
     } else {
       document
         .querySelector(".js-delete-screenshot")
+        .removeAttribute("disabled");
+
+      document
+        .querySelector(".js-fullscreen-screenshot")
         .removeAttribute("disabled");
     }
   };

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -47,4 +47,16 @@
        </ul>
      </div>
   </div>
+  <div class="row">
+    <div class="col-12">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+            <li class="p-inline-list__item">
+              <a class="p-link--soft" accesskey="8" href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-link--soft" accesskey="9" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>
+            </li>
+          </ul>
+    </div>
+  </div>
 </footer>

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -33,6 +33,6 @@
 
 <div class="p-flow-details__continue">
     In just a few steps, you’ll have an example Go app in the Snap Store.
-    <a class="p-button--positive is-inline" href="https://snapcraft.io/first-snap/golang">Continue</a>
+    <a class="p-button--positive is-inline" href="/first-snap/golang">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -33,6 +33,6 @@
 
 <div class="p-flow-details__continue">
     In just a few steps, you’ll have an example Go app in the Snap Store.
-    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/go">Continue</a>
+    <a class="p-button--positive is-inline" href="https://snapcraft.io/first-snap/golang">Continue</a>
   </div>
 </div>


### PR DESCRIPTION
Forgot to land the link to the golang "first snap" flow in #1301.