### PR TITLE
Included links to legal information and data privacy in the footer

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -47,4 +47,16 @@
        </ul>
      </div>
   </div>
+  <div class="row">
+    <div class="col-12">
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+            <li class="p-inline-list__item">
+              <a class="p-link--soft" accesskey="8" href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-link--soft" accesskey="9" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>
+            </li>
+          </ul>
+    </div>
+  </div>
 </footer>


### PR DESCRIPTION
Fixes #1312 

1. Pull the branch / Visit the demo URL
2. Check the footer includes links to Legal information and Data privacy from ubuntu
3. Make sure it happens in every page of the site