### PR TITLE
Disabled full screen button on listing page when there are no screenshot

### DIFF
--- a/static/js/publisher/market/screenshots.js
+++ b/static/js/publisher/market/screenshots.js
@@ -163,9 +163,17 @@ function initSnapScreenshotsEdit(
       document
         .querySelector(".js-delete-screenshot")
         .setAttribute("disabled", "disabled");
+
+      document
+        .querySelector(".js-fullscreen-screenshot")
+        .setAttribute("disabled", "disabled");
     } else {
       document
         .querySelector(".js-delete-screenshot")
+        .removeAttribute("disabled");
+
+      document
+        .querySelector(".js-fullscreen-screenshot")
         .removeAttribute("disabled");
     }
   };


### PR DESCRIPTION
Fixes #668

1. Pull the branch or run the demo URL
2. Open a snap from your published snaps
3. Make sure you have no screenshots on that snap
4. `Open full screen` and `delete` screenshots buttons should be disabled