### PR TITLE
Use cloudinary for blog post images

### DIFF
--- a/tests/blog/tests_index.py
+++ b/tests/blog/tests_index.py
@@ -212,7 +212,14 @@ class BlogPage(TestCase):
             "posts?slug=test-page&tags=2065"
         )
 
-        payload = [{"author": 321, "tags": [10], "id": 20}]
+        payload = [
+            {
+                "author": 321,
+                "tags": [10],
+                "id": 20,
+                "content": {"rendered": "test"},
+            }
+        ]
 
         responses.add(responses.GET, url, json=payload, status=200)
 
@@ -221,7 +228,14 @@ class BlogPage(TestCase):
         assert response.status_code == 200
         self.assert_template_used("blog/article.html")
         self.assert_context(
-            "article", {"author": None, "image": None, "id": 20, "tags": [10]}
+            "article",
+            {
+                "author": None,
+                "image": None,
+                "id": 20,
+                "tags": [10],
+                "content": {"rendered": "test"},
+            },
         )
 
     @responses.activate

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -27,9 +27,9 @@ def replace_images_with_cloudinary(content):
     cloudinary = "https://res.cloudinary.com/"
 
     urls = [
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_540/\g<url>",
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1080/\g<url>",
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1620/\g<url>",
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_650/\g<url>",
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1300/\g<url>",
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1950/\g<url>",
     ]
 
     image_match = (
@@ -39,8 +39,8 @@ def replace_images_with_cloudinary(content):
         "<img\g<prefix>"
         f' decoding="async"'
         f' src="{urls[0]}"'
-        f' srcset="{urls[0]} 540w, {urls[1]} 1080w 2x, {urls[2]} 1620w 3x"'
-        f' sizes="540px"'
+        f' srcset="{urls[0]} 650w, {urls[1]} 1300w 2x, {urls[2]} 1950w 3x"'
+        f' sizes="650px"'
         "\g<suffix>>"
     )
 

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -27,6 +27,7 @@ def replace_images_with_cloudinary(content):
     cloudinary = "https://res.cloudinary.com/"
 
     urls = [
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_350/\g<url>",
         cloudinary + "canonical/image/fetch/q_auto,f_auto,w_650/\g<url>",
         cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1300/\g<url>",
         cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1950/\g<url>",
@@ -38,9 +39,9 @@ def replace_images_with_cloudinary(content):
     replacement = (
         "<img\g<prefix>"
         f' decoding="async"'
-        f' src="{urls[0]}"'
-        f' srcset="{urls[0]} 650w, {urls[1]} 1300w, {urls[2]} 1950w"'
-        f' sizes="650px"'
+        f' src="{urls[1]}"'
+        f' srcset="{urls[0]} 350w, {urls[1]} 650w, {urls[2]} 1300w, {urls[3]} 1950w"'
+        f' sizes="(max-width: 400px) 350w, 650px"'
         "\g<suffix>>"
     )
 

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -39,7 +39,7 @@ def replace_images_with_cloudinary(content):
         "<img\g<prefix>"
         f' decoding="async"'
         f' src="{urls[0]}"'
-        f' srcset="{urls[0]} 650w, {urls[1]} 1300w 2x, {urls[2]} 1950w 3x"'
+        f' srcset="{urls[0]} 650w, {urls[1]} 1300w, {urls[2]} 1950w"'
         f' sizes="650px"'
         "\g<suffix>>"
     )

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -24,36 +24,27 @@ def replace_images_with_cloudinary(content):
 
     :returns: Update HTML string with converted images
     """
-    cloudinary = (
-        "https://res.cloudinary.com/" "canonical/image/fetch/q_auto,f_auto,"
-    )
-    cloudinary = 'https://res.cloudinary.com/'
+    cloudinary = "https://res.cloudinary.com/"
 
     urls = [
-        cloudinary + 'canonical/image/fetch/q_auto,f_auto,w_750/\g<url>',
-        cloudinary + 'canonical/image/fetch/q_auto,f_auto,w_960/\g<url>',
-        cloudinary + 'canonical/image/fetch/q_auto,f_auto,w_1120/\g<url>',
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_540/\g<url>",
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1080/\g<url>",
+        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1620/\g<url>",
     ]
-    
-    image_match = r'<img(?P<prefix>[^>]*) src="(?P<url>[^"]+)"(?P<suffix>[^>]*)>'
+
+    image_match = (
+        r'<img(?P<prefix>[^>]*) src="(?P<url>[^"]+)"(?P<suffix>[^>]*)>'
+    )
     replacement = (
-        '<img\g<prefix>'
-        f' src="{urls[2]}"'
-        f' srcset="{urls[0]} 750w, {urls[1]} 960w, {urls[2]} 1120w"'
-        ' sizes="(max-width: 375px) 560px, (max-width: 480px) 880px, 1120px"'
-        '\g<suffix>>'
+        "<img\g<prefix>"
+        f' decoding="async"'
+        f' src="{urls[0]}"'
+        f' srcset="{urls[0]} 540w, {urls[1]} 1080w 2x, {urls[2]} 1620w 3x"'
+        f' sizes="540px"'
+        "\g<suffix>>"
     )
 
     return re.sub(image_match, replacement, content)
-        r"img(.*)src=\"(.[^\"]*)\"",
-        r'img\1 src="{url}w_1120/\2"'
-        r'srcset="{url}w_750/\2 750w,'
-        r'{url}w_960/\2 960w, {url}w_1120/\2 1120w"'
-        r'sizes="(max-width: 375px) 560px,'
-        r"(max-width: 480px) 880px,"
-        r'1120px"'.format(url=cloudinary),
-        content,
-    )
 
 
 def transform_article(

--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -27,7 +27,24 @@ def replace_images_with_cloudinary(content):
     cloudinary = (
         "https://res.cloudinary.com/" "canonical/image/fetch/q_auto,f_auto,"
     )
-    return re.sub(
+    cloudinary = 'https://res.cloudinary.com/'
+
+    urls = [
+        cloudinary + 'canonical/image/fetch/q_auto,f_auto,w_750/\g<url>',
+        cloudinary + 'canonical/image/fetch/q_auto,f_auto,w_960/\g<url>',
+        cloudinary + 'canonical/image/fetch/q_auto,f_auto,w_1120/\g<url>',
+    ]
+    
+    image_match = r'<img(?P<prefix>[^>]*) src="(?P<url>[^"]+)"(?P<suffix>[^>]*)>'
+    replacement = (
+        '<img\g<prefix>'
+        f' src="{urls[2]}"'
+        f' srcset="{urls[0]} 750w, {urls[1]} 960w, {urls[2]} 1120w"'
+        ' sizes="(max-width: 375px) 560px, (max-width: 480px) 880px, 1120px"'
+        '\g<suffix>>'
+    )
+
+    return re.sub(image_match, replacement, content)
         r"img(.*)src=\"(.[^\"]*)\"",
         r'img\1 src="{url}w_1120/\2"'
         r'srcset="{url}w_750/\2 750w,'

--- a/webapp/blog/views.py
+++ b/webapp/blog/views.py
@@ -146,7 +146,9 @@ def article(slug):
     except ApiError:
         author = None
 
-    transformed_article = logic.transform_article(article, author=author)
+    transformed_article = logic.transform_article(
+        article, author=author, optimise_images=True
+    )
 
     tags = article["tags"]
     tag_names = []


### PR DESCRIPTION
@pmahnke helpfully [added a snippet](https://github.com/canonical-websites/blog.ubuntu.com/pull/416/files#diff-e8b4e4b3fe31ecb310658b8a0d0f0c8eR106) to the Ubuntu blog. Here I've copied/ pasted and modified it slightly.

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/blog
- Click on an article
- Open the network inspector and see how small the inline images are
- Compare to the same post and network inspector on snapcraft.io/blog

