### PR TITLE
Release UI - visual updates

### DIFF
--- a/static/js/publisher/release/contextualMenu.js
+++ b/static/js/publisher/release/contextualMenu.js
@@ -54,10 +54,11 @@ export default class ContextualMenu extends Component {
   render() {
     const { position } = this.props;
     const menuClass = "p-contextual-menu" + (position ? `--${position}` : "");
+    const appearance = this.props.appearance || "neutral";
 
     return (
       <span
-        className={`p-promote-button p-button--neutral p-icon-button ${menuClass}`}
+        className={`p-promote-button p-button--${appearance} p-icon-button ${menuClass}`}
         onClick={this.dropdownButtonClick.bind(this)}
       >
         {this.renderIcon()}
@@ -71,6 +72,7 @@ export default class ContextualMenu extends Component {
 
 ContextualMenu.propTypes = {
   position: PropTypes.oneOf(["left", "center"]), // right is by default
+  appearance: PropTypes.oneOf(["base", "neutral"]),
   channel: PropTypes.string.isRequired,
   closeChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/contextualMenu.js
+++ b/static/js/publisher/release/contextualMenu.js
@@ -55,10 +55,11 @@ export default class ContextualMenu extends Component {
     const { position } = this.props;
     const menuClass = "p-contextual-menu" + (position ? `--${position}` : "");
     const appearance = this.props.appearance || "neutral";
+    const className = this.props.className || "";
 
     return (
       <span
-        className={`p-promote-button p-button--${appearance} p-icon-button ${menuClass}`}
+        className={`p-promote-button p-button--${appearance} p-icon-button ${menuClass} ${className}`}
         onClick={this.dropdownButtonClick.bind(this)}
       >
         {this.renderIcon()}
@@ -71,6 +72,7 @@ export default class ContextualMenu extends Component {
 }
 
 ContextualMenu.propTypes = {
+  className: PropTypes.string,
   position: PropTypes.oneOf(["left", "center"]), // right is by default
   appearance: PropTypes.oneOf(["base", "neutral"]),
   channel: PropTypes.string.isRequired,

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -108,7 +108,9 @@ export default class ReleasesTable extends Component {
                 <span className="p-release-data__icon">&rarr;</span>
                 {hasPendingRelease ? (
                   <span className="p-release-data__info is-pending">
-                    {thisRevision.version}
+                    <span className="p-release-data__version">
+                      {thisRevision.version}
+                    </span>
                     <span className="p-release-data__revision">
                       ({thisRevision.revision})
                     </span>
@@ -119,7 +121,9 @@ export default class ReleasesTable extends Component {
               </Fragment>
             ) : thisPreviousRevision ? (
               <span className="p-release-data__info">
-                {thisPreviousRevision.version}
+                <span className="p-release-data__version">
+                  {thisPreviousRevision.version}
+                </span>
                 <span className="p-release-data__revision">
                   ({thisPreviousRevision.revision})
                 </span>

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -281,7 +281,10 @@ export default class ReleasesTable extends Component {
         key={channel}
       >
         <div className="p-releases-channel">
-          <span className="p-releases-channel__promote">
+          <span className="p-releases-channel__name">
+            {risk === UNASSIGNED ? <em>Available revisions</em> : channel}
+          </span>
+          <span className="p-releases-table__row__menu">
             {canBePromoted && (
               <PromoteButton
                 position="left"
@@ -290,13 +293,9 @@ export default class ReleasesTable extends Component {
                 promoteToChannel={this.onPromoteToChannel.bind(this, channel)}
               />
             )}
-          </span>
-          <span className="p-releases-channel__name">
-            {risk === UNASSIGNED ? <em>Available revisions</em> : channel}
-          </span>
-          <span className="p-releases-table__row__menu">
             {canBeClosed && (
               <ChannelMenu
+                appearance="base"
                 position="left"
                 channel={channel}
                 closeChannel={this.onCloseChannel.bind(this, channel)}

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -288,9 +288,10 @@ export default class ReleasesTable extends Component {
           <span className="p-releases-channel__name">
             {risk === UNASSIGNED ? <em>Available revisions</em> : channel}
           </span>
-          <span className="p-releases-table__row__menu">
+          <span className="p-releases-table__menus">
             {canBePromoted && (
               <PromoteButton
+                className="p-releases-channel__promote"
                 position="left"
                 track={track}
                 targetRisks={targetRisks}

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -75,15 +75,14 @@ export default class ReleasesTable extends Component {
     const trackingChannel = this.props.getTrackingChannel(track, risk, arch);
 
     const isUnassigned = risk === UNASSIGNED;
-    const className = `p-releases-table__cell is-clickable ${
-      isUnassigned ? "is-unassigned" : ""
-    } ${
+    const isActive =
       this.props.revisionsFilters &&
       this.props.revisionsFilters.arch === arch &&
-      this.props.revisionsFilters.risk === risk
-        ? "is-active"
-        : ""
-    }`;
+      this.props.revisionsFilters.risk === risk;
+    const isHighlighted = isPending || (isUnassigned && thisRevision);
+    const className = `p-releases-table__cell is-clickable ${
+      isUnassigned ? "is-unassigned" : ""
+    } ${isActive ? "is-active" : ""} ${isHighlighted ? "is-highlighted" : ""}`;
 
     return (
       <div

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -178,10 +178,10 @@ export default class ReleasesTable extends Component {
         {hasPendingRelease && (
           <div className="p-release-buttons">
             <button
-              className="p-icon-button p-tooltip p-tooltip--btm-center"
+              className="p-action-button p-tooltip p-tooltip--btm-center"
               onClick={this.undoClick.bind(this, thisRevision, track, risk)}
             >
-              &#x2715;
+              <i className="p-icon--close" />
               <span className="p-tooltip__message">
                 Cancel promoting this revision
               </span>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -83,6 +83,12 @@
       cursor: pointer;
     }
 
+    &.is-active {
+      .p-release-data__version {
+        font-weight: bold;
+      }
+    }
+
     &.is-highlighted {
       background: $color-highlighted;
     }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -45,7 +45,7 @@
     align-items: center;
     display: flex;
     flex-shrink: 0;
-    margin-right: $sph-inter;
+    margin-right: $grid-gutter-width / 2;
     width: 22.53423%; // col-3
   }
 
@@ -69,7 +69,7 @@
     flex-basis: 100px;
     flex-grow: 1;
     margin-left: 1px;
-    max-width: 22.53423%; // col-3
+    max-width: 25.2%; // fill the whole space for 3 archs
     min-width: 100px;
     padding: ($spv-intra - .1rem) $sph-intra;
     position: relative;

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -1,4 +1,6 @@
 @mixin snapcraft-release {
+  $color-highlighted: #fff8ee;
+
   // RELEASES CONFIRM
 
   .p-releases-confirm {
@@ -86,6 +88,10 @@
       background-color: $color-x-light;
       border-color: $color-mid-dark;
       cursor: pointer;
+    }
+
+    &.is-highlighted {
+      background: $color-highlighted;
     }
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -176,6 +176,19 @@
     }
   }
 
+  .p-action-button {
+    background: none;
+    border: 0;
+    display: block;
+    line-height: 14px;
+    padding: 2px 4px;
+
+    .p-icon--close {
+      height: 14px;
+      width: 14px;
+    }
+  }
+
   .p-contextual-menu__item {
     @extend .p-contextual-menu__link; // sass-lint:disable-line placeholder-in-extend
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -51,13 +51,6 @@
     width: 22.53423%; // col-3
   }
 
-  .p-releases-channel__promote {
-    flex-grow: 0;
-    flex-shrink: 0;
-    margin-right: .5rem;
-    width: 2rem;
-  }
-
   .p-releases-channel__name {
     flex-grow: 1;
   }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -41,18 +41,31 @@
     margin-top: $spv-inter--regular;
   }
 
+  .p-releases-table__menus {
+    display: flex;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    margin-top: $sp-unit;
+    width: 78px; // to fit 2 icon buttons exactly
+  }
+
+  // align first (promote) button to left
+  .p-releases-channel__promote {
+    margin-right: auto;
+  }
   // channel cell
 
   .p-releases-channel {
-    align-items: center;
+    align-items: flex-start;
     display: flex;
     flex-shrink: 0;
     margin-right: $grid-gutter-width / 2;
-    width: 22.53423%; // col-3
+    width: 222px; // fixed width col-3
   }
 
   .p-releases-channel__name {
     flex-grow: 1;
+    padding-top: ($spv-intra - .1rem);
   }
 
   // release cell
@@ -179,6 +192,11 @@
 
     &:not(:last-of-type):not(:only-of-type) {
       margin-right: .25rem;
+    }
+
+    // don't grow these buttons to 100% width on mobile
+    @media (max-width: $breakpoint-small) {
+      width: auto;
     }
   }
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -123,8 +123,11 @@
 
   .p-release-data__info--empty {
     display: inline-block;
+    overflow: hidden;
     padding-bottom: .6em;
     padding-top: .6em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .p-release-data__revision {


### PR DESCRIPTION
Fixes #1308

Designs: https://github.com/canonicalltd/snapcraft-design/issues/552

Done:

- improved grid/spacing of releases table
- updated contextual menu buttons for channels
- smaller cancel release button [X]
- highlights pending releases in 'yellowish' colour
- makes sure it looks nice for 6 archs (no wrapping 'Add revision')

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1328.run.demo.haus/
- go to releases page of any snap
- check if everything looks nice
- go to releases page of snap with 6 architectures (surl)
- everything should look ok

<img width="1038" alt="screen shot 2018-11-19 at 08 33 42" src="https://user-images.githubusercontent.com/83575/48692389-1f922400-ebd6-11e8-9e53-def3f8730c37.png">
