### PR TITLE
Use political neutral title for TW store badge

### DIFF
--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -888,7 +888,7 @@ def get_publicise(snap_name):
         },
         "jp": {"title": "日本語", "text": "Snap Store から入手ください"},
         "ru": {"title": "русский язык", "text": "Загрузите из Snap Store"},
-        "tw": {"title": "中華民國國語", "text": "安裝軟體敬請移駕 Snap Store"},
+        "tw": {"title": "中文（台灣）", "text": "安裝軟體敬請移駕 Snap Store"},
     }
 
     context = {


### PR DESCRIPTION
The current TW store badge's title, "中華民國國語" is actually "Mandarin
Chinese of Republic of China" which is a political minefield for both
people in PRC and Taiwan, for the following reasons:

* Most PRC people believe ROC is illegal due to one-china blablabla...
* Most Taiwanese people believe ROC is, also illegal, as it is a Chinese
government that only governs Taiwan due to historical reason with no
legal standings

To avoid the Snap Store being boycotted by both users some day in the
future (like the airline companies[1]), this patch changes the title to
the politically neutral "Chinese(Taiwan)".

Refer-to:
[1] China-Taiwan controversy for airlines is coming to a close
<https://money.cnn.com/2018/07/25/news/companies/taiwan-china-airlines/index.html>

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>