### PR TITLE
Cache badges images for a year

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -121,14 +121,20 @@ def set_handlers(app):
             if flask.session:
                 response.headers["Cache-Control"] = "private"
             else:
+                cache_control = {"public"}
+
+                if "/static/images/badges" in flask.request.url:
+                    cache_control.update({"max-age=31556952"})
+                else:
+                    cache_control.update(
+                        {
+                            "max-age=61",
+                            "stale-while-revalidate=300",
+                            "stale-if-error=86400",
+                        }
+                    )
+
                 # Only add caching headers to successful responses
-                response.headers["Cache-Control"] = ", ".join(
-                    {
-                        "public",
-                        "max-age=61",
-                        "stale-while-revalidate=300",
-                        "stale-if-error=86400",
-                    }
-                )
+                response.headers["Cache-Control"] = ", ".join(cache_control)
 
         return response


### PR DESCRIPTION
# Summary

Fixes #1302 
Cache images for a year

# QA

- `./run`
- http://127.0.0.1:8004/static/images/badges/en/snap-store-black.svg
- Make sure image is cached for a year in a private window:
  - Cache control header should have a field max-age set to 31556952 (1 year in seconds)