### PR TITLE
Adds releases history JSON endpoint

### DIFF
--- a/tests/publisher/snaps/test_release_history_json.py
+++ b/tests/publisher/snaps/test_release_history_json.py
@@ -1,0 +1,60 @@
+import responses
+from tests.publisher.endpoint_testing import BaseTestCases
+
+
+class GetReleaseHistoryJsonNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = "/{}/releases/json".format(snap_name)
+
+        super().setUp(snap_name=snap_name, endpoint_url=endpoint_url)
+
+
+class GetReleasesHistoryJson(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
+        snap_name = "test-snap"
+
+        api_url = (
+            "https://dashboard.snapcraft.io/api/v2/snaps/{}"
+            + "/releases?page=1"
+        )
+        api_url = api_url.format(snap_name)
+        endpoint_url = "/{}/releases/json".format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url,
+            api_url=api_url,
+            method_endpoint="GET",
+            method_api="GET",
+        )
+
+    @responses.activate
+    def test_get_releases(self):
+        responses.add(responses.GET, self.api_url, json={}, status=200)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+        self.assertEqual(response.status_code, 200)
+        assert response.json == {}
+
+    @responses.activate
+    def test_404(self):
+        payload = {"error_list": []}
+        responses.add(responses.GET, self.api_url, json=payload, status=404)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+        self.assertEqual(response.status_code, 404)
+
+    @responses.activate
+    def test_5XX(self):
+        payload = {"error_list": []}
+        responses.add(responses.GET, self.api_url, json=payload, status=500)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+        self.assertEqual(response.status_code, 400)

--- a/tests/publisher/snaps/tests_revision.py
+++ b/tests/publisher/snaps/tests_revision.py
@@ -15,7 +15,8 @@ class GetRevisionGetInfoPage(BaseTestCases.EndpointLoggedInErrorHandling):
         snap_name = "test-snap"
 
         api_url = (
-            "https://dashboard.snapcraft.io/api/v2/snaps/{}" + "/releases"
+            "https://dashboard.snapcraft.io/api/v2/snaps/{}"
+            + "/releases?page=1"
         )
         api_url = api_url.format(snap_name)
         endpoint_url = "/{}/releases".format(snap_name)
@@ -34,7 +35,8 @@ class GetRevisionHistory(BaseTestCases.EndpointLoggedInErrorHandling):
         snap_name = "test-snap"
 
         api_url = (
-            "https://dashboard.snapcraft.io/api/v2/snaps/{}" + "/releases"
+            "https://dashboard.snapcraft.io/api/v2/snaps/{}"
+            + "/releases?page=1"
         )
         api_url = api_url.format(snap_name)
         endpoint_url = "/{}/releases".format(snap_name)

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -54,7 +54,7 @@ REGISTER_NAME_URL = "".join([DASHBOARD_API, "register-name/"])
 REVISION_HISTORY_URL = "".join([DASHBOARD_API, "snaps/{snap_id}/history"])
 
 SNAP_RELEASE_HISTORY_URL = "".join(
-    [DASHBOARD_API_V2, "snaps/{snap_name}/releases"]
+    [DASHBOARD_API_V2, "snaps/{snap_name}/releases?page={page}"]
 )
 
 
@@ -277,9 +277,9 @@ def snap_revision_history(session, snap_id):
     return process_response(response)
 
 
-def snap_release_history(session, snap_name):
+def snap_release_history(session, snap_name, page=1):
     response = api_session.get(
-        url=SNAP_RELEASE_HISTORY_URL.format(snap_name=snap_name),
+        url=SNAP_RELEASE_HISTORY_URL.format(snap_name=snap_name, page=page),
         headers=get_authorization_header(session),
     )
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -515,10 +515,7 @@ def redirect_post_release(snap_name):
 @publisher_snaps.route("/<snap_name>/releases/json")
 @login_required
 def get_release_history_json(snap_name):
-    page = 1
-
-    if flask.request.args.get("page"):
-        page = flask.request.args.get("page")
+    page = flask.request.args.get("page", default=1, type=int)
 
     try:
         release_history = api.snap_release_history(

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -512,6 +512,29 @@ def redirect_post_release(snap_name):
     )
 
 
+@publisher_snaps.route("/<snap_name>/releases/json")
+@login_required
+def get_release_history_json(snap_name):
+    page = 1
+
+    if flask.request.args.get("page"):
+        page = flask.request.args.get("page")
+
+    try:
+        release_history = api.snap_release_history(
+            flask.session, snap_name, page
+        )
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return flask.jsonify(api_response_error_list.errors), 400
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    return flask.jsonify(release_history)
+
+
 @publisher_snaps.route("/<snap_name>/releases", methods=["POST"])
 @login_required
 def post_release(snap_name):


### PR DESCRIPTION
Adds releases history JSON endpoint


### QA

- ./run or demo
- log in to your publisher accound
- go to releases page of any snap
- add /json to URL to get JSON response with releases history (/toto/releases/json)
- if snap has longer history it can be requested with ?page= param (/nextcloud/releases/json?page=2)