### PR TITLE
Update revisions list after the release

### DIFF
--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -3,104 +3,12 @@ import ReactDOM from "react-dom";
 
 import ReleasesController from "./release/releasesController";
 
-// getting list of tracks names from channel maps list
-function getTracksFromChannelMap(channelMapsList) {
-  const tracks = ["latest"];
-
-  channelMapsList.map(t => t.track).forEach(track => {
-    // if we haven't saved it yet
-    if (tracks.indexOf(track) === -1) {
-      tracks.push(track);
-    }
-  });
-
-  return tracks;
-}
-
-// transforming channel map list data into format used by this component
-function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
-  const releasedChannels = {};
-  const releasedArchs = {};
-
-  channelMapsList.forEach(mapInfo => {
-    const { track, architecture, map } = mapInfo;
-    map.forEach(channelInfo => {
-      if (channelInfo.info === "released") {
-        const channel =
-          track === "latest"
-            ? `${track}/${channelInfo.channel}`
-            : channelInfo.channel;
-
-        if (!releasedChannels[channel]) {
-          releasedChannels[channel] = {};
-        }
-
-        // XXX bartaz
-        // this may possibly lead to issues with revisions in multiple architectures
-        // if we have data about given revision in revision history we can store it
-        if (revisionsMap[channelInfo.revision]) {
-          releasedChannels[channel][architecture] =
-            revisionsMap[channelInfo.revision];
-          // but if for some reason we don't have full data about revision in channel map
-          // we need to ducktype it from channel info
-        } else {
-          releasedChannels[channel][architecture] = channelInfo;
-          releasedChannels[channel][architecture].architectures = [
-            architecture
-          ];
-        }
-
-        releasedArchs[architecture] = true;
-      }
-    });
-  });
-
-  return releasedChannels;
-}
-
 const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
-  // init channel data in revisions list
-  const revisionsMap = {};
-  releasesData.revisions.forEach(rev => {
-    rev.channels = [];
-    revisionsMap[rev.revision] = rev;
-  });
-
-  // go through releases from older to newest
-  releasesData.releases
-    .slice()
-    .reverse()
-    .forEach(release => {
-      if (release.revision && !release.branch) {
-        const rev = revisionsMap[release.revision];
-
-        if (rev) {
-          const channel =
-            release.track === "latest"
-              ? release.risk
-              : `${release.track}/${release.risk}`;
-
-          if (rev.channels.indexOf(channel) === -1) {
-            rev.channels.push(channel);
-          }
-        }
-      }
-    });
-
-  const releasedChannels = getReleaseDataFromChannelMap(
-    channelMapsList,
-    revisionsMap
-  );
-  const tracks = getTracksFromChannelMap(channelMapsList);
-
   ReactDOM.render(
     <ReleasesController
       snapName={snapName}
-      releasedChannels={releasedChannels}
-      revisions={releasesData.revisions}
-      releases={releasesData.releases}
-      revisionsMap={revisionsMap}
-      tracks={tracks}
+      channelMapsList={channelMapsList}
+      releasesData={releasesData}
       options={options}
     />,
     document.querySelector(id)

--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -9,6 +9,7 @@ export default class HistoryPanel extends Component {
       <div className="p-history-panel">
         <div className="p-strip is-shallow">
           <RevisionsList
+            releases={this.props.releases}
             revisionsMap={this.props.revisionsMap}
             revisionsFilters={this.props.revisionsFilters}
             releasedChannels={this.props.releasedChannels}
@@ -17,7 +18,6 @@ export default class HistoryPanel extends Component {
             showChannels={true}
             showArchitectures={this.props.showArchitectures}
             closeHistoryPanel={this.props.closeHistoryPanel}
-            getReleaseHistory={this.props.getReleaseHistory}
           />
         </div>
       </div>
@@ -27,6 +27,7 @@ export default class HistoryPanel extends Component {
 
 HistoryPanel.propTypes = {
   // state
+  releases: PropTypes.array.isRequired,
   revisionsMap: PropTypes.object.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
@@ -34,6 +35,5 @@ HistoryPanel.propTypes = {
   showArchitectures: PropTypes.bool,
   // actions
   selectRevision: PropTypes.func.isRequired,
-  closeHistoryPanel: PropTypes.func.isRequired,
-  getReleaseHistory: PropTypes.func.isRequired
+  closeHistoryPanel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -9,7 +9,7 @@ export default class HistoryPanel extends Component {
       <div className="p-history-panel">
         <div className="p-strip is-shallow">
           <RevisionsList
-            revisions={this.props.revisions}
+            revisionsMap={this.props.revisionsMap}
             revisionsFilters={this.props.revisionsFilters}
             releasedChannels={this.props.releasedChannels}
             selectedRevisions={this.props.selectedRevisions}
@@ -27,7 +27,7 @@ export default class HistoryPanel extends Component {
 
 HistoryPanel.propTypes = {
   // state
-  revisions: PropTypes.array.isRequired,
+  revisionsMap: PropTypes.object.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
   selectedRevisions: PropTypes.array.isRequired,

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -5,98 +5,15 @@ import "whatwg-fetch";
 import ReleasesTable from "./releasesTable";
 import Notification from "./notification";
 import { isInDevmode } from "./devmodeIcon";
-import { RISKS, UNASSIGNED } from "./constants";
+import { UNASSIGNED } from "./constants";
 
-// getting list of tracks names from channel maps list
-function getTracksFromChannelMap(channelMapsList) {
-  const tracks = ["latest"];
-
-  channelMapsList.map(t => t.track).forEach(track => {
-    // if we haven't saved it yet
-    if (tracks.indexOf(track) === -1) {
-      tracks.push(track);
-    }
-  });
-
-  return tracks;
-}
-
-function getRevisionsMap(revisions) {
-  const revisionsMap = {};
-  revisions.forEach(rev => {
-    rev.channels = [];
-    revisionsMap[rev.revision] = rev;
-  });
-
-  return revisionsMap;
-}
-
-// init channels data in revision history
-function initReleasesData(revisionsMap, releases) {
-  // go through releases from older to newest
-  releases
-    .slice()
-    .reverse()
-    .forEach(release => {
-      if (release.revision && !release.branch) {
-        const rev = revisionsMap[release.revision];
-
-        if (rev) {
-          const channel =
-            release.track === "latest"
-              ? release.risk
-              : `${release.track}/${release.risk}`;
-
-          if (rev.channels.indexOf(channel) === -1) {
-            rev.channels.push(channel);
-          }
-        }
-      }
-    });
-
-  return releases;
-}
-
-// transforming channel map list data into format used by this component
-function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
-  const releasedChannels = {};
-  const releasedArchs = {};
-
-  channelMapsList.forEach(mapInfo => {
-    const { track, architecture, map } = mapInfo;
-    map.forEach(channelInfo => {
-      if (channelInfo.info === "released") {
-        const channel =
-          track === "latest"
-            ? `${track}/${channelInfo.channel}`
-            : channelInfo.channel;
-
-        if (!releasedChannels[channel]) {
-          releasedChannels[channel] = {};
-        }
-
-        // XXX bartaz
-        // this may possibly lead to issues with revisions in multiple architectures
-        // if we have data about given revision in revision history we can store it
-        if (revisionsMap[channelInfo.revision]) {
-          releasedChannels[channel][architecture] =
-            revisionsMap[channelInfo.revision];
-          // but if for some reason we don't have full data about revision in channel map
-          // we need to ducktype it from channel info
-        } else {
-          releasedChannels[channel][architecture] = channelInfo;
-          releasedChannels[channel][architecture].architectures = [
-            architecture
-          ];
-        }
-
-        releasedArchs[architecture] = true;
-      }
-    });
-  });
-
-  return releasedChannels;
-}
+import {
+  getArchsFromReleasedChannels,
+  getTracksFromChannelMap,
+  getRevisionsMap,
+  initReleasesData,
+  getReleaseDataFromChannelMap
+} from "./releasesState";
 
 export default class ReleasesController extends Component {
   constructor(props) {
@@ -128,7 +45,7 @@ export default class ReleasesController extends Component {
       // list of all available tracks
       tracks: tracks,
       // list of architectures released to (or selected to be released to)
-      archs: this.getArchsFromReleasedChannels(releasedChannels),
+      archs: getArchsFromReleasedChannels(releasedChannels),
       // revisions to be released:
       // key is the id of revision to release
       // value is object containing release object and channels to release to
@@ -162,21 +79,6 @@ export default class ReleasesController extends Component {
     });
   }
 
-  // update list of architectures based on revisions released (or selected)
-  getArchsFromReleasedChannels(releasedChannels) {
-    let archs = [];
-    Object.keys(releasedChannels).forEach(channel => {
-      Object.keys(releasedChannels[channel]).forEach(arch => {
-        archs.push(arch);
-      });
-    });
-
-    // make archs unique and sorted
-    archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
-
-    return archs.sort();
-  }
-
   selectRevision(revision) {
     this.setState(state => {
       const releasedChannels = state.releasedChannels;
@@ -200,7 +102,7 @@ export default class ReleasesController extends Component {
       const selectedRevisions = Object.keys(releasedChannels[UNASSIGNED]).map(
         arch => releasedChannels[UNASSIGNED][arch].revision
       );
-      const archs = this.getArchsFromReleasedChannels(releasedChannels);
+      const archs = getArchsFromReleasedChannels(releasedChannels);
 
       return {
         selectedRevisions,
@@ -237,34 +139,6 @@ export default class ReleasesController extends Component {
     });
 
     return nextReleaseData;
-  }
-
-  getTrackingChannel(track, risk, arch) {
-    const { releasedChannels } = this.state;
-
-    let tracking = null;
-    // if there is no revision for this arch in given channel (track/risk)
-    if (
-      !(
-        releasedChannels[`${track}/${risk}`] &&
-        releasedChannels[`${track}/${risk}`][arch]
-      )
-    ) {
-      // find the next channel that has any revision
-      for (let i = RISKS.indexOf(risk); i >= 0; i--) {
-        const trackingChannel = `${track}/${RISKS[i]}`;
-
-        if (
-          releasedChannels[trackingChannel] &&
-          releasedChannels[trackingChannel][arch]
-        ) {
-          tracking = trackingChannel;
-          break;
-        }
-      }
-    }
-
-    return tracking;
   }
 
   promoteChannel(channel, targetChannel) {
@@ -432,6 +306,7 @@ export default class ReleasesController extends Component {
     }).then(response => response.json());
   }
 
+  // TODO: move inside of this function out
   handleReleaseResponse(json, release) {
     if (json.success) {
       this.setState(state => {
@@ -478,7 +353,7 @@ export default class ReleasesController extends Component {
           }
         });
 
-        const archs = this.getArchsFromReleasedChannels(releasedChannels);
+        const archs = getArchsFromReleasedChannels(releasedChannels);
 
         return {
           releasedChannels,
@@ -633,44 +508,6 @@ export default class ReleasesController extends Component {
     });
   }
 
-  getReleaseHistory(filters) {
-    return (
-      this.state.releases
-        // only releases of revisions (ignore closing channels)
-        .filter(release => release.revision)
-        // only releases in given architecture
-        .filter(release => {
-          return filters && filters.arch
-            ? release.architecture === filters.arch
-            : true;
-        })
-        // only releases in given track
-        .filter(release => {
-          return filters && filters.track
-            ? release.track === filters.track
-            : true;
-        })
-        // only releases in given risk
-        .filter(release => {
-          return filters && filters.risk ? release.risk === filters.risk : true;
-        })
-        // before we have branches support we ignore any releases to branches
-        .filter(release => !release.branch)
-        // only one latest release of every revision
-        .filter((release, index, all) => {
-          return all.findIndex(r => r.revision === release.revision) === index;
-        })
-        // map release history to revisions
-        .map(release => {
-          const revision = JSON.parse(
-            JSON.stringify(this.state.revisionsMap[release.revision])
-          );
-          revision.release = release;
-          return revision;
-        })
-    );
-  }
-
   render() {
     const hasDevmodeRevisions = Object.values(this.state.releasedChannels).some(
       archReleases => {
@@ -716,11 +553,9 @@ export default class ReleasesController extends Component {
           undoRelease={this.undoRelease.bind(this)}
           clearPendingReleases={this.clearPendingReleases.bind(this)}
           closeChannel={this.closeChannel.bind(this)}
-          getTrackingChannel={this.getTrackingChannel.bind(this)}
           toggleHistoryPanel={this.toggleHistoryPanel.bind(this)}
           selectRevision={this.selectRevision.bind(this)}
           closeHistoryPanel={this.closeHistoryPanel.bind(this)}
-          getReleaseHistory={this.getReleaseHistory.bind(this)}
         />
       </Fragment>
     );

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -1,0 +1,182 @@
+import { RISKS } from "./constants";
+
+// getting list of tracks names from channel maps list
+function getTracksFromChannelMap(channelMapsList) {
+  const tracks = ["latest"];
+
+  channelMapsList.map(t => t.track).forEach(track => {
+    // if we haven't saved it yet
+    if (tracks.indexOf(track) === -1) {
+      tracks.push(track);
+    }
+  });
+
+  return tracks;
+}
+
+function getRevisionsMap(revisions) {
+  const revisionsMap = {};
+  revisions.forEach(rev => {
+    rev.channels = [];
+    revisionsMap[rev.revision] = rev;
+  });
+
+  return revisionsMap;
+}
+
+// init channels data in revision history
+function initReleasesData(revisionsMap, releases) {
+  // go through releases from older to newest
+  releases
+    .slice()
+    .reverse()
+    .forEach(release => {
+      if (release.revision && !release.branch) {
+        const rev = revisionsMap[release.revision];
+
+        if (rev) {
+          const channel =
+            release.track === "latest"
+              ? release.risk
+              : `${release.track}/${release.risk}`;
+
+          if (rev.channels.indexOf(channel) === -1) {
+            rev.channels.push(channel);
+          }
+        }
+      }
+    });
+
+  return releases;
+}
+
+// transforming channel map list data into format used by this component
+function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
+  const releasedChannels = {};
+  const releasedArchs = {};
+
+  channelMapsList.forEach(mapInfo => {
+    const { track, architecture, map } = mapInfo;
+    map.forEach(channelInfo => {
+      if (channelInfo.info === "released") {
+        const channel =
+          track === "latest"
+            ? `${track}/${channelInfo.channel}`
+            : channelInfo.channel;
+
+        if (!releasedChannels[channel]) {
+          releasedChannels[channel] = {};
+        }
+
+        // XXX bartaz
+        // this may possibly lead to issues with revisions in multiple architectures
+        // if we have data about given revision in revision history we can store it
+        if (revisionsMap[channelInfo.revision]) {
+          releasedChannels[channel][architecture] =
+            revisionsMap[channelInfo.revision];
+          // but if for some reason we don't have full data about revision in channel map
+          // we need to ducktype it from channel info
+        } else {
+          releasedChannels[channel][architecture] = channelInfo;
+          releasedChannels[channel][architecture].architectures = [
+            architecture
+          ];
+        }
+
+        releasedArchs[architecture] = true;
+      }
+    });
+  });
+
+  return releasedChannels;
+}
+
+// update list of architectures based on revisions released (or selected)
+function getArchsFromReleasedChannels(releasedChannels) {
+  let archs = [];
+  Object.keys(releasedChannels).forEach(channel => {
+    Object.keys(releasedChannels[channel]).forEach(arch => {
+      archs.push(arch);
+    });
+  });
+
+  // make archs unique and sorted
+  archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
+
+  return archs.sort();
+}
+
+function getFilteredReleaseHistory(releases, revisionsMap, filters) {
+  return (
+    releases
+      // only releases of revisions (ignore closing channels)
+      .filter(release => release.revision)
+      // only releases in given architecture
+      .filter(release => {
+        return filters && filters.arch
+          ? release.architecture === filters.arch
+          : true;
+      })
+      // only releases in given track
+      .filter(release => {
+        return filters && filters.track
+          ? release.track === filters.track
+          : true;
+      })
+      // only releases in given risk
+      .filter(release => {
+        return filters && filters.risk ? release.risk === filters.risk : true;
+      })
+      // before we have branches support we ignore any releases to branches
+      .filter(release => !release.branch)
+      // only one latest release of every revision
+      .filter((release, index, all) => {
+        return all.findIndex(r => r.revision === release.revision) === index;
+      })
+      // map release history to revisions
+      .map(release => {
+        const revision = JSON.parse(
+          JSON.stringify(revisionsMap[release.revision])
+        );
+        revision.release = release;
+        return revision;
+      })
+  );
+}
+
+// for channel without release get next (less risk) channel with a release
+function getTrackingChannel(releasedChannels, track, risk, arch) {
+  let tracking = null;
+  // if there is no revision for this arch in given channel (track/risk)
+  if (
+    !(
+      releasedChannels[`${track}/${risk}`] &&
+      releasedChannels[`${track}/${risk}`][arch]
+    )
+  ) {
+    // find the next channel that has any revision
+    for (let i = RISKS.indexOf(risk); i >= 0; i--) {
+      const trackingChannel = `${track}/${RISKS[i]}`;
+
+      if (
+        releasedChannels[trackingChannel] &&
+        releasedChannels[trackingChannel][arch]
+      ) {
+        tracking = trackingChannel;
+        break;
+      }
+    }
+  }
+
+  return tracking;
+}
+
+export {
+  getArchsFromReleasedChannels,
+  getFilteredReleaseHistory,
+  getTracksFromChannelMap,
+  getTrackingChannel,
+  getRevisionsMap,
+  initReleasesData,
+  getReleaseDataFromChannelMap
+};

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -13,6 +13,8 @@ import ChannelMenu from "./channelMenu";
 import PromoteButton from "./promoteButton";
 import HistoryPanel from "./historyPanel";
 
+import { getTrackingChannel } from "./releasesState";
+
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
 }
@@ -72,7 +74,12 @@ export default class ReleasesTable extends Component {
 
     const isChannelClosed = this.props.pendingCloses.includes(channel);
     const isPending = hasPendingRelease || isChannelClosed;
-    const trackingChannel = this.props.getTrackingChannel(track, risk, arch);
+    const trackingChannel = getTrackingChannel(
+      releasedChannels,
+      track,
+      risk,
+      arch
+    );
 
     const isUnassigned = risk === UNASSIGNED;
     const isActive =
@@ -325,6 +332,7 @@ export default class ReleasesTable extends Component {
     return (
       <HistoryPanel
         key="history-panel"
+        releases={this.props.releases}
         revisionsMap={this.props.revisionsMap}
         revisionsFilters={this.props.revisionsFilters}
         releasedChannels={this.props.releasedChannels}
@@ -332,7 +340,6 @@ export default class ReleasesTable extends Component {
         selectRevision={this.props.selectRevision}
         showArchitectures={!!showArchitectures}
         closeHistoryPanel={this.props.closeHistoryPanel}
-        getReleaseHistory={this.props.getReleaseHistory}
       />
     );
   }
@@ -512,6 +519,7 @@ export default class ReleasesTable extends Component {
 
 ReleasesTable.propTypes = {
   // state
+  releases: PropTypes.array.isRequired,
   revisionsMap: PropTypes.object.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
@@ -533,9 +541,7 @@ ReleasesTable.propTypes = {
   undoRelease: PropTypes.func.isRequired,
   clearPendingReleases: PropTypes.func.isRequired,
   closeChannel: PropTypes.func.isRequired,
-  getTrackingChannel: PropTypes.func.isRequired,
   toggleHistoryPanel: PropTypes.func.isRequired,
   selectRevision: PropTypes.func.isRequired,
-  closeHistoryPanel: PropTypes.func.isRequired,
-  getReleaseHistory: PropTypes.func.isRequired
+  closeHistoryPanel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -325,7 +325,7 @@ export default class ReleasesTable extends Component {
     return (
       <HistoryPanel
         key="history-panel"
-        revisions={this.props.revisions}
+        revisionsMap={this.props.revisionsMap}
         revisionsFilters={this.props.revisionsFilters}
         releasedChannels={this.props.releasedChannels}
         selectedRevisions={this.props.selectedRevisions}
@@ -471,6 +471,7 @@ export default class ReleasesTable extends Component {
 
   render() {
     const { archs, tracks } = this.props;
+    const revisionsCount = Object.keys(this.props.revisionsMap).length;
 
     return (
       <Fragment>
@@ -496,8 +497,8 @@ export default class ReleasesTable extends Component {
           </div>
           <div className="p-release-actions">
             <a href="#" onClick={this.handleShowRevisionsClick.bind(this)}>
-              Show {this.props.revisions.length} latest revision
-              {this.props.revisions.length > 1 ? "s" : ""}
+              Show {revisionsCount} latest revision
+              {revisionsCount > 1 ? "s" : ""}
             </a>
           </div>
           {this.props.isHistoryOpen &&
@@ -511,7 +512,7 @@ export default class ReleasesTable extends Component {
 
 ReleasesTable.propTypes = {
   // state
-  revisions: PropTypes.array,
+  revisionsMap: PropTypes.object.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired,

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -95,7 +95,7 @@ export default class RevisionsList extends Component {
   }
 
   render() {
-    let filteredRevisions = this.props.revisions;
+    let filteredRevisions = Object.values(this.props.revisionsMap).reverse();
     let title = "Latest revisions";
     let filters = this.props.revisionsFilters;
     let isReleaseHistory = false;
@@ -170,7 +170,7 @@ export default class RevisionsList extends Component {
 
 RevisionsList.propTypes = {
   // state
-  revisions: PropTypes.array.isRequired,
+  revisionsMap: PropTypes.object.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
   selectedRevisions: PropTypes.array.isRequired,

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -6,6 +6,8 @@ import format from "date-fns/format";
 import DevmodeIcon from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
+import { getFilteredReleaseHistory } from "./releasesState";
+
 export default class RevisionsList extends Component {
   revisionSelectChange(revision) {
     this.props.selectRevision(revision);
@@ -113,7 +115,11 @@ export default class RevisionsList extends Component {
           filters.risk
         }`;
 
-        filteredRevisions = this.props.getReleaseHistory(filters);
+        filteredRevisions = getFilteredReleaseHistory(
+          this.props.releases,
+          this.props.revisionsMap,
+          filters
+        );
       }
     }
 
@@ -170,6 +176,7 @@ export default class RevisionsList extends Component {
 
 RevisionsList.propTypes = {
   // state
+  releases: PropTypes.array.isRequired,
   revisionsMap: PropTypes.object.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
@@ -178,6 +185,5 @@ RevisionsList.propTypes = {
   showArchitectures: PropTypes.bool,
   // actions
   selectRevision: PropTypes.func.isRequired,
-  closeHistoryPanel: PropTypes.func.isRequired,
-  getReleaseHistory: PropTypes.func.isRequired
+  closeHistoryPanel: PropTypes.func.isRequired
 };


### PR DESCRIPTION
Fixes #1261 

Update revisions list after release to properly show channels where given revision was released.

Done:
- after a release is posted via API fresh release history is fetched to update local state
- data manipulation functions moved out from components

### QA

- ./run or demo
- go to Releases page of any snap
- find a revision that was not released to some channel yet (for example beta)
- release it to this channel
- after release is completed and releases table updated look at 'all revisions' list to see if this revision was updated (has new channel on the list)