### PR TITLE
Shows only unreleased revisions when 'Add revision' is clicked

### DIFF
--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -15,7 +15,7 @@ export default class HistoryPanel extends Component {
             releasedChannels={this.props.releasedChannels}
             selectedRevisions={this.props.selectedRevisions}
             selectRevision={this.props.selectRevision}
-            showChannels={true}
+            showChannels={this.props.showChannels}
             showArchitectures={this.props.showArchitectures}
             closeHistoryPanel={this.props.closeHistoryPanel}
           />
@@ -32,6 +32,7 @@ HistoryPanel.propTypes = {
   releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
   selectedRevisions: PropTypes.array.isRequired,
+  showChannels: PropTypes.bool,
   showArchitectures: PropTypes.bool,
   // actions
   selectRevision: PropTypes.func.isRequired,

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -171,7 +171,21 @@ function getTrackingChannel(releasedChannels, track, risk, arch) {
   return tracking;
 }
 
+function getUnassignedRevisions(revisionsMap, arch) {
+  let filteredRevisions = Object.values(revisionsMap).reverse();
+  if (arch) {
+    filteredRevisions = filteredRevisions.filter(revision => {
+      return (
+        revision.architectures.includes(arch) &&
+        (!revision.channels || revision.channels.length === 0)
+      );
+    });
+  }
+  return filteredRevisions;
+}
+
 export {
+  getUnassignedRevisions,
   getArchsFromReleasedChannels,
   getFilteredReleaseHistory,
   getTracksFromChannelMap,

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -298,7 +298,7 @@ export default class ReleasesTable extends Component {
       >
         <div className="p-releases-channel">
           <span className="p-releases-channel__name">
-            {risk === UNASSIGNED ? <em>Unassigned revisions</em> : channel}
+            {risk === UNASSIGNED ? <em>Unreleased revisions</em> : channel}
           </span>
           <span className="p-releases-table__menus">
             {canBePromoted && (
@@ -505,8 +505,7 @@ export default class ReleasesTable extends Component {
           </div>
           <div className="p-release-actions">
             <a href="#" onClick={this.handleShowRevisionsClick.bind(this)}>
-              Show {revisionsCount} latest revision
-              {revisionsCount > 1 ? "s" : ""}
+              Show all latest revisions ({revisionsCount})
             </a>
           </div>
           {this.props.isHistoryOpen &&

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -13,7 +13,7 @@ import ChannelMenu from "./channelMenu";
 import PromoteButton from "./promoteButton";
 import HistoryPanel from "./historyPanel";
 
-import { getTrackingChannel } from "./releasesState";
+import { getTrackingChannel, getUnassignedRevisions } from "./releasesState";
 
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
@@ -90,7 +90,10 @@ export default class ReleasesTable extends Component {
     const className = `p-releases-table__cell is-clickable ${
       isUnassigned ? "is-unassigned" : ""
     } ${isActive ? "is-active" : ""} ${isHighlighted ? "is-highlighted" : ""}`;
-
+    const unassignedCount = getUnassignedRevisions(
+      this.props.revisionsMap,
+      arch
+    ).length;
     return (
       <div
         className={className}
@@ -135,17 +138,21 @@ export default class ReleasesTable extends Component {
                   ({thisPreviousRevision.revision})
                 </span>
               </span>
+            ) : isUnassigned ? (
+              <Fragment>
+                <span className="p-release-data__icon">
+                  <i className="p-icon--plus" />
+                </span>
+                <span className="p-release-data__info">
+                  <span className="p-release-data__version">Add revision</span>
+                  <span className="p-release-data__revision">
+                    {unassignedCount} available
+                  </span>
+                </span>
+              </Fragment>
             ) : (
               <span className="p-release-data__info--empty">
-                {trackingChannel ? (
-                  "↑"
-                ) : isUnassigned ? (
-                  <Fragment>
-                    <i className="p-icon--plus" /> Add revision
-                  </Fragment>
-                ) : (
-                  "–"
-                )}
+                {trackingChannel ? "↑" : "–"}
               </span>
             )}
           </span>

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -298,7 +298,7 @@ export default class ReleasesTable extends Component {
       >
         <div className="p-releases-channel">
           <span className="p-releases-channel__name">
-            {risk === UNASSIGNED ? <em>Available revisions</em> : channel}
+            {risk === UNASSIGNED ? <em>Unassigned revisions</em> : channel}
           </span>
           <span className="p-releases-table__menus">
             {canBePromoted && (
@@ -484,7 +484,7 @@ export default class ReleasesTable extends Component {
       <Fragment>
         <div className="row">
           <div className="u-clearfix">
-            <h4 className="u-float--left">Releases available for install</h4>
+            <h4 className="u-float--left">Releases available to install</h4>
             {tracks.length > 1 && this.renderTrackDropdown(tracks)}
           </div>
           {this.renderReleasesConfirm()}

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -328,7 +328,7 @@ export default class ReleasesTable extends Component {
     );
   }
 
-  renderHistoryPanel(showArchitectures) {
+  renderHistoryPanel(showAllColumns) {
     return (
       <HistoryPanel
         key="history-panel"
@@ -338,7 +338,8 @@ export default class ReleasesTable extends Component {
         releasedChannels={this.props.releasedChannels}
         selectedRevisions={this.props.selectedRevisions}
         selectRevision={this.props.selectRevision}
-        showArchitectures={!!showArchitectures}
+        showArchitectures={!!showAllColumns}
+        showChannels={!!showAllColumns}
         closeHistoryPanel={this.props.closeHistoryPanel}
       />
     );

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -131,7 +131,6 @@ export default class RevisionsList extends Component {
       }
     }
 
-    const isNarrow = !showChannels && !showArchitectures;
     return (
       <Fragment>
         <div>
@@ -143,12 +142,12 @@ export default class RevisionsList extends Component {
             className="p-icon--close u-float--right"
           />
         </div>
-        <table className={`p-revisions-list ${isNarrow ? "is-narrow" : ""}`}>
+        <table className="p-revisions-list">
           <thead>
             <tr>
               <th
                 className={!isReleaseHistory ? "col-checkbox-spacer" : ""}
-                width="100px"
+                width="150px"
                 scope="col"
               >
                 Revision
@@ -175,7 +174,7 @@ export default class RevisionsList extends Component {
               )
             ) : (
               <tr>
-                <td colSpan="5">
+                <td colSpan="4">
                   <em>No releases</em>
                 </td>
               </tr>

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -6,7 +6,10 @@ import format from "date-fns/format";
 import DevmodeIcon from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
-import { getFilteredReleaseHistory } from "./releasesState";
+import {
+  getFilteredReleaseHistory,
+  getUnassignedRevisions
+} from "./releasesState";
 
 export default class RevisionsList extends Component {
   revisionSelectChange(revision) {
@@ -104,18 +107,15 @@ export default class RevisionsList extends Component {
     let isReleaseHistory = false;
 
     if (filters && filters.arch) {
-      title = `Unreleased revisions: ${filters.arch}`;
-
-      filteredRevisions = filteredRevisions.filter(revision => {
-        return revision.architectures.includes(filters.arch);
-      });
-
       if (filters.risk === UNASSIGNED) {
+        title = `Unreleased revisions: ${filters.arch}`;
         // when listing 'unassigned' revisions show revisions with no channels
         showChannels = false;
-        filteredRevisions = filteredRevisions.filter(revision => {
-          return !revision.channels || revision.channels.length === 0;
-        });
+
+        filteredRevisions = getUnassignedRevisions(
+          this.props.revisionsMap,
+          filters.arch
+        );
       } else {
         // when listing any other (real) channel, show filtered release history
         isReleaseHistory = true;

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -104,7 +104,7 @@ export default class RevisionsList extends Component {
     let isReleaseHistory = false;
 
     if (filters && filters.arch) {
-      title = `${title}: ${filters.arch}`;
+      title = `Unreleased revisions: ${filters.arch}`;
 
       filteredRevisions = filteredRevisions.filter(revision => {
         return revision.architectures.includes(filters.arch);

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -163,6 +163,10 @@
   // REVISIONS LIST
 
   .p-revisions-list {
+    &.is-narrow {
+      max-width: 500px;
+    }
+
     .col-checkbox-spacer {
       padding-left: 2rem;
     }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -163,10 +163,6 @@
   // REVISIONS LIST
 
   .p-revisions-list {
-    &.is-narrow {
-      max-width: 500px;
-    }
-
     .col-checkbox-spacer {
       padding-left: 2rem;
     }


### PR DESCRIPTION
Fixes #1327 

When clicking on 'Add revision' only revisions not released previously to any channel are visible. All revisions are still accessible under 'Show latest revisions' link.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1351.run.demo.haus/
- go to Releases page of any snap
- click 'Add revision' link on any architecture
- only unreleased revisions of given architecture should be shown on the list

<img width="1036" alt="screen shot 2018-11-26 at 16 14 59" src="https://user-images.githubusercontent.com/83575/49023081-aa56be00-f196-11e8-9ea6-81cabdc88e52.png">
