### PR TITLE
Shows pending releases in history

### DIFF
--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -14,9 +14,10 @@ export default class HistoryPanel extends Component {
             revisionsFilters={this.props.revisionsFilters}
             releasedChannels={this.props.releasedChannels}
             selectedRevisions={this.props.selectedRevisions}
-            selectRevision={this.props.selectRevision}
+            pendingReleases={this.props.pendingReleases}
             showChannels={this.props.showChannels}
             showArchitectures={this.props.showArchitectures}
+            selectRevision={this.props.selectRevision}
             closeHistoryPanel={this.props.closeHistoryPanel}
           />
         </div>
@@ -32,6 +33,7 @@ HistoryPanel.propTypes = {
   releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
   selectedRevisions: PropTypes.array.isRequired,
+  pendingReleases: PropTypes.object.isRequired,
   showChannels: PropTypes.bool,
   showArchitectures: PropTypes.bool,
   // actions

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -184,7 +184,27 @@ function getUnassignedRevisions(revisionsMap, arch) {
   return filteredRevisions;
 }
 
+function getPendingRelease(pendingReleases, arch, channel) {
+  let pendingRelease = null;
+  // for each release
+  Object.keys(pendingReleases).forEach(releasedRevision => {
+    const isSameChannel = pendingReleases[releasedRevision].channels.includes(
+      channel
+    );
+    const isSameArch = pendingReleases[
+      releasedRevision
+    ].revision.architectures.includes(arch);
+
+    if (isSameArch && isSameChannel) {
+      pendingRelease = releasedRevision;
+    }
+  });
+
+  return pendingRelease;
+}
+
 export {
+  getPendingRelease,
   getUnassignedRevisions,
   getArchsFromReleasedChannels,
   getFilteredReleaseHistory,

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -344,6 +344,7 @@ export default class ReleasesTable extends Component {
         revisionsFilters={this.props.revisionsFilters}
         releasedChannels={this.props.releasedChannels}
         selectedRevisions={this.props.selectedRevisions}
+        pendingReleases={this.props.pendingReleases}
         selectRevision={this.props.selectRevision}
         showArchitectures={!!showAllColumns}
         showChannels={!!showAllColumns}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -183,6 +183,10 @@
 
       }
     }
+
+    .is-pending {
+      background: $color-highlighted;
+    }
   }
 
   // HELPERS


### PR DESCRIPTION
Fixes #1326 

If there is any pending release it will show as a first highlighted row in a history panel.


### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1361.run.demo.haus/
- go to Releases page of any snap
- promote a channel or `Add revision` and promote it to some channel
- click on a cell with pending revision
- pending revision should be listed in the history as a first item

<img width="1016" alt="screen shot 2018-11-27 at 13 04 31" src="https://user-images.githubusercontent.com/83575/49080844-3b846e00-f245-11e8-9eef-090e35866da4.png">
