### PR TITLE
Show all uploaded architectures in releases table

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -8,7 +8,7 @@ import { isInDevmode } from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
 import {
-  getArchsFromReleasedChannels,
+  getArchsFromRevisionsMap,
   getTracksFromChannelMap,
   getRevisionsMap,
   initReleasesData,
@@ -45,7 +45,7 @@ export default class ReleasesController extends Component {
       // list of all available tracks
       tracks: tracks,
       // list of architectures released to (or selected to be released to)
-      archs: getArchsFromReleasedChannels(releasedChannels),
+      archs: getArchsFromRevisionsMap(revisionsMap),
       // revisions to be released:
       // key is the id of revision to release
       // value is object containing release object and channels to release to
@@ -102,12 +102,10 @@ export default class ReleasesController extends Component {
       const selectedRevisions = Object.keys(releasedChannels[UNASSIGNED]).map(
         arch => releasedChannels[UNASSIGNED][arch].revision
       );
-      const archs = getArchsFromReleasedChannels(releasedChannels);
 
       return {
         selectedRevisions,
-        releasedChannels,
-        archs
+        releasedChannels
       };
     });
   }
@@ -365,11 +363,8 @@ export default class ReleasesController extends Component {
           }
         });
 
-        const archs = getArchsFromReleasedChannels(releasedChannels);
-
         return {
-          releasedChannels,
-          archs
+          releasedChannels
         };
       });
     } else {

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -91,13 +91,11 @@ function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
   return releasedChannels;
 }
 
-// update list of architectures based on revisions released (or selected)
-function getArchsFromReleasedChannels(releasedChannels) {
+// update list of architectures based on revisions uploaded
+function getArchsFromRevisionsMap(revisionsMap) {
   let archs = [];
-  Object.keys(releasedChannels).forEach(channel => {
-    Object.keys(releasedChannels[channel]).forEach(arch => {
-      archs.push(arch);
-    });
+  Object.values(revisionsMap).forEach(revision => {
+    archs = archs.concat(revision.architectures);
   });
 
   // make archs unique and sorted
@@ -206,7 +204,7 @@ function getPendingRelease(pendingReleases, arch, channel) {
 export {
   getPendingRelease,
   getUnassignedRevisions,
-  getArchsFromReleasedChannels,
+  getArchsFromRevisionsMap,
   getFilteredReleaseHistory,
   getTracksFromChannelMap,
   getTrackingChannel,


### PR DESCRIPTION
Fixes #1323 

Instead of showing just released architectures we include all uploaded architectures in releases table, so it's easier to find and release revisions in architectures not yet released.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1363.run.demo.haus/
- have a snap with no released revisions ([test-snap-toto](https://snapcraft-io-canonical-websites-pr-1363.run.demo.haus/test-snap-toto/releases))
- go to Releases page
- releases table should include architectures of not released revisions, you should be able to click on 'Add revision' and select one
- go to Releases page of a snap that has some releases, but also architectures not yet released (but uploaded) ([android-studio](https://snapcraft-io-canonical-websites-pr-1363.run.demo.haus/android-studio/releases))
- all architectures should be visible in the table

<img width="1026" alt="screen shot 2018-11-27 at 16 46 17" src="https://user-images.githubusercontent.com/83575/49093611-bc9f2d80-f264-11e8-93f5-9e49973c06b7.png">
<img width="1028" alt="screen shot 2018-11-27 at 16 45 53" src="https://user-images.githubusercontent.com/83575/49093612-bc9f2d80-f264-11e8-88e9-3d6df620e098.png">
