### PR TITLE
Use bases in the first snap flow

### DIFF
--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -81,6 +81,27 @@
           <li class="p-list-step__item">
             <h4 class="p-list-step__title">
               <span class="p-list-step__bullet">5</span>
+              Base
+            </h4>
+            <div class="p-list-step__content">
+              {% for item in steps.explain.base %}
+                {% if item.text %}
+                  <p>{{ item.text|safe }}</p>
+                {% elif item.code %}
+                  <pre><code>{{ item.code }}</code></pre>
+                {% elif item.warning %}
+                  <div class="p-notification--caution">
+                    <p class="p-notification__response">
+                      {{ item.warning|safe }}
+                    </p>
+                  </div>
+                {% endif %}
+              {% endfor %}
+            </div>
+          </li>
+          <li class="p-list-step__item">
+            <h4 class="p-list-step__title">
+              <span class="p-list-step__bullet">6</span>
               Parts
             </h4>
             <div class="p-list-step__content">
@@ -101,7 +122,7 @@
           </li>
           <li class="p-list-step__item">
             <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">6</span>
+              <span class="p-list-step__bullet">7</span>
               Apps
             </h4>
             <div class="p-list-step__content">

--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -21,6 +21,7 @@
   don't support it.
 
 <b>confinement</b>: devmode
+<b>base</b>: core18
 
 <b>parts</b>:
   <b>dosbox</b>:

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -18,6 +18,7 @@
   HTTPLab let you inspect HTTP requests and forge responses.
 
 <b>confinement</b>: devmode
+<b>base</b>: core18
 
 <b>parts</b>:
   <b>httplab</b>:

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -24,6 +24,7 @@
     $ wethr --imperial
 
 <b>confinement</b>: devmode
+<b>base</b>: core18
 
 <b>parts</b>:
   <b>wethr</b>:

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -22,6 +22,7 @@
   questions that Geekbench can answer.
 
 <b>confinement</b>: devmode
+<b>base</b>: core18
 
 <b>parts</b>:
   <b>geekbench4</b>:

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -20,6 +20,7 @@
   Maildirs. OfflineIMAP will synchronize both sides via IMAP.
 
 <b>confinement</b>: devmode
+<b>base</b>: core18
 
 <b>parts</b>:
   <b>offlineimap</b>:

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -18,6 +18,7 @@
   Style checker/lint tool for markdown files
 
 <b>confinement</b>: devmode
+<b>base</b>: core18
 
 <b>parts</b>:
   <b>mdl</b>:

--- a/webapp/first_snap/content/golang/package.yaml
+++ b/webapp/first_snap/content/golang/package.yaml
@@ -29,6 +29,11 @@ explain:
     - text: Snaps are containerised to ensure more predictable application behaviour and greater security.
     - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
     - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
+  base:
+    - text: Snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. The <code>base</code> keyword specifies a special kind of snap that will be mounted as the root filesystem for your application.
+    - code: |
+        base: core18
+    - text: The <code>core18</code> base is recommended.
   parts:
     - text: |
         Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets.

--- a/webapp/first_snap/content/golang/package.yaml
+++ b/webapp/first_snap/content/golang/package.yaml
@@ -30,7 +30,8 @@ explain:
     - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
     - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
   base:
-    - text: Snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. The <code>base</code> keyword specifies a special kind of snap that will be mounted as the root filesystem for your application.
+    - text: In general, snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. However, applications still need some location to act as the root filesystem. They would also benefit from common libraries (e.g. libc) being in this root filesystem rather than bundled into each application.
+    - text: The base keyword specifies a special kind of snap that provides a minimal set of libraries common to most applications. It will be mounted as the root filesystem for your application.
     - code: |
         base: core18
     - text: The <code>core18</code> base is recommended.

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -32,7 +32,8 @@ explain:
     - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
     - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
   base:
-    - text: Snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. The <code>base</code> keyword specifies a special kind of snap that will be mounted as the root filesystem for your application.
+    - text: In general, snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. However, applications still need some location to act as the root filesystem. They would also benefit from common libraries (e.g. libc) being in this root filesystem rather than bundled into each application.
+    - text: The base keyword specifies a special kind of snap that provides a minimal set of libraries common to most applications. It will be mounted as the root filesystem for your application.
     - code: |
         base: core18
     - text: The <code>core18</code> base is recommended.

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -31,6 +31,11 @@ explain:
     - text: Snaps are containerised to ensure more predictable application behaviour and greater security.
     - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
     - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
+  base:
+    - text: Snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. The <code>base</code> keyword specifies a special kind of snap that will be mounted as the root filesystem for your application.
+    - code: |
+        base: core18
+    - text: The <code>core18</code> base is recommended.
   parts:
     - text: |
         Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets.


### PR DESCRIPTION
Use the `base` keyword in the snapcraft.yaml files in the first snap flow. The use of bases makes snapcraft use a tightly controlled build environment inside multipass to create the snap, _much_ more reliable than relying on whatever is in the developer's host system.

/cc @sergiusens