### PR TITLE
Fix promoting channel over already pending release

### DIFF
--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -201,7 +201,47 @@ function getPendingRelease(pendingReleases, arch, channel) {
   return pendingRelease;
 }
 
+// get channel map data updated with any pending releases
+function getNextReleasedChannels(releasedChannels, pendingReleases) {
+  const nextReleaseData = JSON.parse(JSON.stringify(releasedChannels));
+
+  // for each release
+  Object.keys(pendingReleases).forEach(releasedRevision => {
+    pendingReleases[releasedRevision].channels.forEach(channel => {
+      const revision = pendingReleases[releasedRevision].revision;
+
+      if (!nextReleaseData[channel]) {
+        nextReleaseData[channel] = {};
+      }
+
+      revision.architectures.forEach(arch => {
+        nextReleaseData[channel][arch] = revision;
+      });
+    });
+  });
+
+  return nextReleaseData;
+}
+
+// remove pending revisions from given channel
+function removePendingRelease(pendingReleases, revision, channel) {
+  if (pendingReleases[revision.revision]) {
+    const channels = pendingReleases[revision.revision].channels;
+
+    if (channels.includes(channel)) {
+      channels.splice(channels.indexOf(channel), 1);
+    }
+
+    if (channels.length === 0) {
+      delete pendingReleases[revision.revision];
+    }
+  }
+
+  return pendingReleases;
+}
+
 export {
+  getNextReleasedChannels,
   getPendingRelease,
   getUnassignedRevisions,
   getArchsFromRevisionsMap,
@@ -209,6 +249,7 @@ export {
   getTracksFromChannelMap,
   getTrackingChannel,
   getRevisionsMap,
+  removePendingRelease,
   initReleasesData,
   getReleaseDataFromChannelMap
 };


### PR DESCRIPTION
Fixes #1357 

Correctly handles promoting revisions into channel with already pending releases.

### QA
- ./run or  https://snapcraft-io-canonical-websites-pr-1369.run.demo.haus/
- go to Releases page of a snap (with more then 1 architecture)
- select a revision `+ Add revision` in one architecture and promote it to one channel
- select revisions in all other architectures as well
- promote 'Unreleased' revisions again to the same channel as before (overriding previously promoted revision)
- all revisions should be correctly marked for release
- there should be no errors on the console
- try selecting/promoting/canceling in different configurations

<img width="1008" alt="screen shot 2018-11-28 at 13 42 07" src="https://user-images.githubusercontent.com/83575/49152537-6ccb6f80-f313-11e8-9070-5c202d3d31ae.png">
