### PR TITLE
Update macaroon package

### DIFF
--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -59,7 +59,16 @@ def request_macaroon():
     Returns the macaroon.
     """
     response = sso.post_macaroon(
-        {"permissions": ["package_access", "package_upload", "edit_account"]}
+        {
+            "permissions": [
+                "package_access",
+                "package_metrics",
+                "package_update",
+                "package_register",
+                "package_release",
+                "edit_account",
+            ]
+        }
     )
 
     return response["macaroon"]


### PR DESCRIPTION
# Summary

Replace package_upload with new package_* macaroon:

https://dashboard.snapcraft.io/docs/api/macaroon.html#request-a-macaroon

```
package_upload = package_metrics + package_update + package_register + package_release
```

# QA

- `./run`
- http://0.0.0.0:8004/
- Try modify snap, access your metrics update release and register a new snap name
- All those actions should still work on all accounts pages