### PR TITLE
Use pipes instead of chevrons for the fsf descriptions

### DIFF
--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -14,7 +14,7 @@
     <code class="p-code-yaml"><pre><b>name</b>: httplab
 <b>version</b>: git
 <b>summary</b>: An interactive web server.
-<b>description</b>: >
+<b>description</b>: |
   HTTPLab let you inspect HTTP requests and forge responses.
 
 <b>confinement</b>: devmode

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -15,7 +15,7 @@
     <code class="p-code-yaml"><pre><b>name</b>: wethr
 <b>version</b>: git
 <b>summary</b>: Command line weather tool.
-<b>description</b>: >
+<b>description</b>: |
   Get current weather:-
     $ wethr
   Get current weather in metric units

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -15,7 +15,7 @@
     <code class="p-code-yaml"><pre><b>name</b>: geekbench4
 <b>version</b>: 4.2.0
 <b>summary</b>: Cross-Platform Benchmark
-<b>description</b>: >
+<b>description</b>: |
   Geekbench 4 measures your system's power and tells you whether your
   computer is ready to roar. How strong is your mobile device or desktop
   computer? How will it perform when push comes to crunch? These are the

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -15,7 +15,7 @@
     <code class="p-code-yaml"><pre><b>name</b>: offlineimap
 <b>version</b>: git
 <b>summary</b>: OfflineIMAP
-<b>description</b>: >
+<b>description</b>: |
   OfflineIMAP is software that downloads your email mailbox(es) as local
   Maildirs. OfflineIMAP will synchronize both sides via IMAP.
 

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -14,7 +14,7 @@
     <code class="p-code-yaml"><pre><b>name</b>: mdl
 <b>version</b>: "0.5.0"
 <b>summary</b>: Markdown lint tool
-<b>description</b>: >
+<b>description</b>: |
   Style checker/lint tool for markdown files
 
 <b>confinement</b>: devmode

--- a/webapp/first_snap/content/golang/package.yaml
+++ b/webapp/first_snap/content/golang/package.yaml
@@ -7,7 +7,7 @@ metadata: |
   name: httplab
   version: git
   summary: An interactive web server.
-  description: >
+  description: |
     HTTPLab let you inspect HTTP requests and forge responses.
 explain:
   metadata:
@@ -19,9 +19,9 @@ explain:
     - text: By specifying git for the version, the current git tag or commit will be used as the version string. Versions carry no semantic meaning in snaps.
     - code: |
         version: git
-    - text: The summary can not exceed 79 characters. You can use a chevron ‘>’ in the description key to declare a multi-line description.
+    - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
     - code: |
-        description: >
+        description: |
   security:
     - text: The next section describes the level of confinement applied to your app.
     - code: |

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -7,7 +7,7 @@ metadata: |
   name: offlineimap
   version: git
   summary: OfflineIMAP
-  description: >
+  description: |
     OfflineIMAP is software that downloads your email mailbox(es)
     as local Maildirs. OfflineIMAP will synchronize both sides via
     IMAP.
@@ -21,9 +21,9 @@ explain:
     - text: By specifying git for the version, the current git tag or commit will be used as the version string. Versions carry no semantic meaning in snaps.
     - code: |
         version: git
-    - text: The summary can not exceed 79 characters. You can use a chevron ‘>’ in the description key to declare a multi-line description.
+    - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
     - code: |
-        description: >
+        description: |
   security:
     - text: The next section describes the level of confinement applied to your app.
     - code: |


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1364#event-1991908187

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/first-snap/golang/linux/package and http://0.0.0.0:8004/first-snap/python/linux/package
- Ensure any mention of the description uses '|'s instead of '>'s