### PR TITLE
Update channel map to incorporate default track + safest risk level + version

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -69,6 +69,13 @@
       </div>
       {% if not webapp_config['STORE_QUERY'] %}
         <div class="col-5 p-snap-install-buttons">
+          <button
+            class="p-button--neutral p-snap-install-buttons__versions"
+            data-js="open-channel-map"
+            data-controls="channel-map-versions"
+            aria-controls="channel-map-versions">
+            {{ default_track }}/{{ lowest_risk_available }} {{ version }}&nbsp;&nbsp;<i class="p-icon--chevron"></i>
+          </button>
           {% if has_stable %}
             <button
               class="p-button--positive p-snap-install-buttons__install"
@@ -78,13 +85,6 @@
                 Install
             </button>
           {% endif %}
-          <button
-            class="p-button--neutral p-snap-install-buttons__versions"
-            data-js="open-channel-map"
-            data-controls="channel-map-versions"
-            aria-controls="channel-map-versions">
-              All versions&nbsp;&nbsp;<i class="p-icon--chevron"></i>
-          </button>
         </div>
       {% else %}
         <div class="col-5 p-snap-install-buttons">

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -192,6 +192,21 @@ class StoreLogicTest(unittest.TestCase):
             },
         )
 
+    def test_get_version(self):
+        channel_map = {
+            "arch": {
+                "track": [
+                    {"risk": "edge", "version": "12"},
+                    {"risk": "stable", "version": "10"},
+                ]
+            }
+        }
+        edge_version = logic.get_confinement(channel_map, "track", "edge")
+        self.assertEqual(classic_result, "12")
+
+        stable_version = logic.get_confinement(channel_map, "track", "stable")
+        self.assertEqual(strict_result, "10")
+
     def test_get_confinement(self):
         channel_map = {
             "arch": {

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -202,10 +202,10 @@ class StoreLogicTest(unittest.TestCase):
             }
         }
         edge_version = logic.get_version(channel_map, "track", "edge")
-        self.assertEqual(classic_result, "12")
+        self.assertEqual(edge_version, "12")
 
         stable_version = logic.get_version(channel_map, "track", "stable")
-        self.assertEqual(strict_result, "10")
+        self.assertEqual(stable_version, "10")
 
     def test_get_confinement(self):
         channel_map = {

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -201,10 +201,10 @@ class StoreLogicTest(unittest.TestCase):
                 ]
             }
         }
-        edge_version = logic.get_confinement(channel_map, "track", "edge")
+        edge_version = logic.get_version(channel_map, "track", "edge")
         self.assertEqual(classic_result, "12")
 
-        stable_version = logic.get_confinement(channel_map, "track", "stable")
+        stable_version = logic.get_version(channel_map, "track", "stable")
         self.assertEqual(strict_result, "10")
 
     def test_get_confinement(self):

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -207,6 +207,13 @@ class StoreLogicTest(unittest.TestCase):
         stable_version = logic.get_version(channel_map, "track", "stable")
         self.assertEqual(stable_version, "10")
 
+    def test_get_no_version(self):
+        channel_map = {
+            "arch": {"track": [{"risk": "stable", "version": "10"}]}
+        }
+        no_version = logic.get_version(channel_map, "track", "edge")
+        self.assertEqual(no_version, None)
+
     def test_get_confinement(self):
         channel_map = {
             "arch": {
@@ -221,3 +228,10 @@ class StoreLogicTest(unittest.TestCase):
 
         strict_result = logic.get_confinement(channel_map, "track", "stable")
         self.assertEqual(strict_result, "strict")
+
+    def test_get_no_confinement(self):
+        channel_map = {
+            "arch": {"track": [{"risk": "stable", "confinement": "strict"}]}
+        }
+        no_version = logic.get_confinement(channel_map, "track", "edge")
+        self.assertEqual(no_version, None)

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -294,7 +294,7 @@ def get_version(channel_map, track, risk):
     :param track: The track of the channel
     :param risk: The risk of the channel
 
-    :returns: The confinement
+    :returns: The version
     """
     for arch in channel_map:
         if arch in channel_map and track in channel_map[arch]:

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -278,7 +278,7 @@ def get_confinement(channel_map, track, risk):
     :returns: The confinement
     """
     for arch in channel_map:
-        if arch in channel_map and track in channel_map[arch]:
+        if track in channel_map[arch]:
             releases = channel_map[arch][track]
             for release in releases:
                 if release["risk"] == risk:
@@ -297,7 +297,7 @@ def get_version(channel_map, track, risk):
     :returns: The version
     """
     for arch in channel_map:
-        if arch in channel_map and track in channel_map[arch]:
+        if track in channel_map[arch]:
             releases = channel_map[arch][track]
             for release in releases:
                 if release["risk"] == risk:

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -285,3 +285,22 @@ def get_confinement(channel_map, track, risk):
                     return release["confinement"]
 
     return None
+
+
+def get_version(channel_map, track, risk):
+    """Get the version for a channel
+
+    :param channel_map: Channel map list
+    :param track: The track of the channel
+    :param risk: The risk of the channel
+
+    :returns: The confinement
+    """
+    for arch in channel_map:
+        if arch in channel_map and track in channel_map[arch]:
+            releases = channel_map[arch][track]
+            for release in releases:
+                if release["risk"] == risk:
+                    return release["version"]
+
+    return None

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -365,6 +365,10 @@ def store_blueprint(store_query=None, testing=False):
             channel_maps_list, default_track, lowest_risk_available
         )
 
+        last_version = logic.get_version(
+            channel_maps_list, default_track, lowest_risk_available
+        )
+
         context = {
             # Data direct from details API
             "snap_title": details["snap"]["title"],


### PR DESCRIPTION
1. Pull the branch or run the demo server
2. Open any snap detail page
3. Channel map actions should be `[ default_track/safest_risk_level  version_number ] [ Install ]` on every snap page

**NOTE:** Some snaps to test with `[node](https://snapcraft.io/node)` , `[skype](https://snapcraft.io/skype)`, `[blender](https://snapcraft.io/blender)`

🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 