### PR TITLE
Refine the golang pitch

### DIFF
--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -1,12 +1,16 @@
 <div class="col-12 p-flow-details" style="display: none" data-flow-details="go">
   <div class='col-6'>
     <h4>Why are snaps good for Go projects?</h4>
-    <p>Go doesn't offer a method for delivering app updates to end users, and you're on your own when it comes to showcasing your project. Snaps offer a way to fill these gaps.</p>
     <ul>
-      <li>Snaps are easy to discover and install, with millions installing from the Snap Store every day.</li>
-      <li>They auto-update, ensuring users always have the latest stable version of your app.</li>
-      <li>They're reliable, rolling back on failure while preserving your app's versioned data.</li>
+      <li>Easy to discover and install by millions using the Snap Store or command-line every day</li>
+      <li>Automatically updated to the latest stable version of your app</li>
+      <li>Revert to the previous version if an update fails, preserving data</li>
     </ul>
+    <p>
+      Programming in Go makes it easy to create a zip of your app that runs across Linux, without dependencies.
+      However, end user discovery and update management remain a challenge.
+      Snaps fill this gap, letting you distribute a Go app in an app store experience for end users.
+    </p>
   </div>
 
   <div class='col-6'>


### PR DESCRIPTION
Following #1366, this moves Golang pitch closer to what we wrote for Python. Unlike Python, app isolation is not a problem in Go. Also less relevant is dealing with native libraries (from my limited experience, someone please correct me). So I've focused the Go pitch on discovery and updates.