### PR TITLE
Extract actions to separate module, add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Run tests with coverage
           command: |
             coverage run  --source=. -m unittest discover tests
-            bash <(curl -s https://codecov.io/bash)
+            bash <(curl -s https://codecov.io/bash) -cF python
   js-lint:
     <<: *defaults
     steps:
@@ -54,7 +54,9 @@ jobs:
           command: yarn
       - run:
           name: Run tests with jest
-          command: yarn run test-js
+          command: |
+            yarn run test-js
+            bash <(curl -s https://codecov.io/bash) -cF javascript
   scss-lint:
     <<: *defaults
     steps:

--- a/static/js/publisher/release/actions/revisions.js
+++ b/static/js/publisher/release/actions/revisions.js
@@ -1,0 +1,8 @@
+export const UPDATE_REVISIONS = "UPDATE_REVISIONS";
+
+export function updateRevisions(revisions) {
+  return {
+    type: UPDATE_REVISIONS,
+    payload: { revisions }
+  };
+}

--- a/static/js/publisher/release/actions/revisions.test.js
+++ b/static/js/publisher/release/actions/revisions.test.js
@@ -1,0 +1,19 @@
+import { UPDATE_REVISIONS, updateRevisions } from "./revisions";
+
+describe("revisions actions", () => {
+  describe("updateRevisions", () => {
+    let revisions = {
+      1: { revision: 1 },
+      2: { revision: 2 },
+      3: { revision: 3, channels: ["stable"] }
+    };
+
+    it("should create an action to update revisions list", () => {
+      expect(updateRevisions(revisions).type).toBe(UPDATE_REVISIONS);
+    });
+
+    it("should supply a payload with revisions map", () => {
+      expect(updateRevisions(revisions).payload.revisions).toEqual(revisions);
+    });
+  });
+});

--- a/static/js/publisher/release/reducers/index.js
+++ b/static/js/publisher/release/reducers/index.js
@@ -1,16 +1,6 @@
 import { combineReducers } from "redux";
 
-const revisions = function(state = {}, action) {
-  switch (action.type) {
-    case "UPDATE_REVISIONS":
-      return {
-        ...state,
-        ...action.payload.revisions
-      };
-    default:
-      return state;
-  }
-};
+import revisions from "./revisions";
 
 const releases = combineReducers({
   revisions

--- a/static/js/publisher/release/reducers/revisions.js
+++ b/static/js/publisher/release/reducers/revisions.js
@@ -1,0 +1,13 @@
+import { UPDATE_REVISIONS } from "../actions/revisions";
+
+export default function revisions(state = {}, action) {
+  switch (action.type) {
+    case UPDATE_REVISIONS:
+      return {
+        ...state,
+        ...action.payload.revisions
+      };
+    default:
+      return state;
+  }
+}

--- a/static/js/publisher/release/reducers/revisions.test.js
+++ b/static/js/publisher/release/reducers/revisions.test.js
@@ -1,0 +1,38 @@
+import revisions from "./revisions";
+import { UPDATE_REVISIONS } from "../actions/revisions";
+
+describe("revisions", () => {
+  it("should return the initial state", () => {
+    expect(revisions(undefined, {})).toEqual({});
+  });
+
+  describe("on UPDATE_REVISIONS action", () => {
+    let updateRevisionsAction = {
+      type: UPDATE_REVISIONS,
+      payload: {
+        revisions: {
+          1: { revision: 1 },
+          2: { revision: 2 },
+          3: { revision: 3, channels: ["stable"] }
+        }
+      }
+    };
+
+    it("should add revisions to state", () => {
+      const result = revisions({}, updateRevisionsAction);
+
+      expect(result).toEqual(updateRevisionsAction.payload.revisions);
+    });
+
+    it("should update existing revisions in state", () => {
+      const initialState = {
+        1: { revision: 1 },
+        3: { revision: 3 }
+      };
+
+      const result = revisions(initialState, updateRevisionsAction);
+
+      expect(result).toEqual(updateRevisionsAction.payload.revisions);
+    });
+  });
+});

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -8,6 +8,8 @@ import Notification from "./notification";
 import { isInDevmode } from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
+import { updateRevisions } from "./actions/revisions";
+
 import {
   getNextReleasedChannels,
   getArchsFromRevisionsMap,
@@ -575,17 +577,10 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    // TODO: extract to outside actions module
-    updateRevisions: revisions => {
-      dispatch({
-        type: "UPDATE_REVISIONS",
-        payload: {
-          revisions
-        }
-      });
-    }
+    updateRevisions: revisions => dispatch(updateRevisions(revisions))
   };
 };
+
 export default connect(
   mapStateToProps,
   mapDispatchToProps


### PR DESCRIPTION
As part of release UI redux migration (#1384):
- extracts actions to separate module
- adds tests for actions and reducers

### QA
- ./run or demo
- go to Releases page, everything should work as before
- ./run exec yarn test-js
- tests should run for revisions reducers and actions, they should pass

Coverage report should now include JS.
Click on [Continue to review full report at Codecov](https://codecov.io/gh/canonical-websites/snapcraft.io/pull/1386?src=pr&el=continue) to see full report including separate python and js score:

<img width="617" alt="screen shot 2018-11-30 at 15 43 15" src="https://user-images.githubusercontent.com/83575/49295781-dcc62b00-f4b6-11e8-982b-247911bcb4bb.png">
