### PR TITLE
“license” > “licence”

### DIFF
--- a/templates/publisher/publicise.html
+++ b/templates/publisher/publicise.html
@@ -119,7 +119,7 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
       <div class="col-8">
         <a href="https://github.com/snapcore/snap-store-badges/archive/{{ download_version }}.zip" class="p-button">zip</a>
         <a href="https://github.com/snapcore/snap-store-badges/archive/{{ download_version }}.tar.gz" class="p-button">tar.gz</a>
-        <a href="https://raw.githubusercontent.com/snapcore/snap-store-badges/master/LICENSE.md" target="_blank" class="p-link--external">View licence</a>
+        <a href="https://raw.githubusercontent.com/snapcore/snap-store-badges/master/LICENSE.md" target="_blank" class="p-link--external">View image licence</a>
       </div>
     </div>
   </div>

--- a/templates/publisher/publicise.html
+++ b/templates/publisher/publicise.html
@@ -119,7 +119,7 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
       <div class="col-8">
         <a href="https://github.com/snapcore/snap-store-badges/archive/{{ download_version }}.zip" class="p-button">zip</a>
         <a href="https://github.com/snapcore/snap-store-badges/archive/{{ download_version }}.tar.gz" class="p-button">tar.gz</a>
-        <a href="https://raw.githubusercontent.com/snapcore/snap-store-badges/master/LICENSE.md" target="_blank" class="p-link--external">View license</a>
+        <a href="https://raw.githubusercontent.com/snapcore/snap-store-badges/master/LICENSE.md" target="_blank" class="p-link--external">View licence</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Done

On snapcraft.io we use British English spelling. (I don’t think this is a good idea, but it’s what we do.)

Fixes #1321.

# QA

1. Go to [your snaps page](https://snapcraft-io-canonical-websites-pr-1390.run.demo.haus/snaps).
2. Choose a snap.
3. Choose “Publicise”.
4. Scroll to the bottom of the page.
5. See that “license” is now spelled the British way.