### PR TITLE
Enable 12m and 24m metrics

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevices.js
+++ b/static/js/publisher/metrics/graphs/activeDevices.js
@@ -210,7 +210,16 @@ function drawGraph(holderSelector, holder, activeDevices) {
 
   // Add the x axix
   let tickValues = [];
-  if (isMobile() && _data.length > 90) {
+  let tickFormat = "%b %e";
+
+  if (_data.length > 360) {
+    tickValues = _data
+      .filter((item, i) => {
+        return i % 14 === 0;
+      })
+      .map(item => item.date);
+    tickFormat = "%b %e %Y";
+  } else if (isMobile() && _data.length > 90) {
     // Get the first day of each month
     let monthCache = false;
     tickValues = _data
@@ -233,7 +242,7 @@ function drawGraph(holderSelector, holder, activeDevices) {
   g.append("g")
     .attr("class", "axis axis--x")
     .attr("transform", `translate(0, ${height})`)
-    .call(xAxis.tickFormat(utcFormat("%b %e")));
+    .call(xAxis.tickFormat(utcFormat(tickFormat)));
 
   cullXAxis();
 

--- a/static/js/publisher/metrics/graphs/activeDevices.js
+++ b/static/js/publisher/metrics/graphs/activeDevices.js
@@ -212,7 +212,9 @@ function drawGraph(holderSelector, holder, activeDevices) {
   let tickValues = [];
   let tickFormat = "%b %e";
 
+  // The ticks get cramped when there are too many data points
   if (_data.length > 360) {
+    // This restricts anything over 1 year
     tickValues = _data
       .filter((item, i) => {
         return i % 14 === 0;
@@ -220,6 +222,7 @@ function drawGraph(holderSelector, holder, activeDevices) {
       .map(item => item.date);
     tickFormat = "%b %e %Y";
   } else if (isMobile() && _data.length > 90) {
+    // This restricts anything over 3 months and if viewing on a mobile
     // Get the first day of each month
     let monthCache = false;
     tickValues = _data

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -38,6 +38,8 @@ Publisher metrics for {{ snap_title }}
               <option value="30d"{% if metric_period == '30d' %} selected="selected"{% endif %}>Past 30 days</option>
               <option value="3m"{% if metric_period == '3m' %} selected="selected"{% endif %}>Past 3 months</option>
               <option value="6m"{% if metric_period == '6m' %} selected="selected"{% endif %}>Past 6 months</option>
+              <option value="1y"{% if metric_period == '1y' %} selected="selected"{% endif %}>Past year</option>
+              <option value="2y"{% if metric_period == '2y' %} selected="selected"{% endif %}>Past 2 years</option>
             </select>
           </div>
           <div class="col-3">

--- a/tests/publisher/snaps/tests_get_metrics.py
+++ b/tests/publisher/snaps/tests_get_metrics.py
@@ -97,6 +97,56 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("nodata", True)
 
     @responses.activate
+    def test_data_version_1_year(self):
+        random_values = random.sample(range(1, 30), 29)
+        dates = [
+            datetime(2018, 3, day).strftime("%Y-%m-%d") for day in range(1, 30)
+        ]
+        coutries = [
+            {"values": [2], "name": "FR"},
+            {"values": [3], "name": "GB"},
+        ]
+        payload = {
+            "metrics": [
+                {
+                    "status": "OK",
+                    "series": [{"values": random_values, "name": "0.1"}],
+                    "buckets": dates,
+                    "metric_name": "weekly_installed_base_by_version",
+                },
+                {
+                    "status": "OK",
+                    "series": coutries,
+                    "buckets": ["2018-03-18"],
+                    "metric_name": "weekly_installed_base_by_country",
+                },
+            ]
+        }
+        responses.add(responses.POST, self.api_url, json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url + "?period=1y")
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.info_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+        called = responses.calls[1]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used("publisher/metrics.html")
+        self.assert_context("snap_name", self.snap_name)
+        self.assert_context("snap_title", "Test Snap")
+        self.assert_context("metric_period", "1y")
+        self.assert_context("active_device_metric", "version")
+        self.assert_context("nodata", False)
+
+    @responses.activate
     def test_data_version_1_month(self):
         random_values = random.sample(range(1, 30), 29)
         dates = [
@@ -299,6 +349,58 @@ class GetMetricsPostMetrics(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("snap_name", self.snap_name)
         self.assert_context("snap_title", "Test Snap")
         self.assert_context("metric_period", "7d")
+        self.assert_context("active_device_metric", "os")
+        self.assert_context("nodata", False)
+
+    @responses.activate
+    def test_data_os_1_year(self):
+        random_values = random.sample(range(1, 100), 59)
+        dates = [
+            datetime(2018, 3, day).strftime("%Y-%m-%d") for day in range(1, 30)
+        ]
+        coutries = [
+            {"values": [2], "name": "FR"},
+            {"values": [3], "name": "GB"},
+        ]
+        payload = {
+            "metrics": [
+                {
+                    "status": "OK",
+                    "series": [{"values": random_values, "name": "0.1"}],
+                    "buckets": dates,
+                    "metric_name": "weekly_installed_base_by_operating_system",
+                },
+                {
+                    "status": "OK",
+                    "series": coutries,
+                    "buckets": ["2018-03-18"],
+                    "metric_name": "weekly_installed_base_by_country",
+                },
+            ]
+        }
+        responses.add(responses.POST, self.api_url, json=payload, status=200)
+
+        response = self.client.get(
+            self.endpoint_url + "?period=1y&active-devices=os"
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.info_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+        called = responses.calls[1]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used("publisher/metrics.html")
+        self.assert_context("snap_name", self.snap_name)
+        self.assert_context("snap_title", "Test Snap")
+        self.assert_context("metric_period", "1y")
         self.assert_context("active_device_metric", "os")
         self.assert_context("nodata", False)
 

--- a/webapp/metrics/helper.py
+++ b/webapp/metrics/helper.py
@@ -42,6 +42,7 @@ def build_metrics_json(
     elif metric_bucket == "m":
         start = end + relativedelta.relativedelta(months=-metric_period)
     elif metric_bucket == "y":
+        # Go back an extra day to ensure the granularity increases
         start = end + relativedelta.relativedelta(
             years=-metric_period, days=-1
         )

--- a/webapp/metrics/helper.py
+++ b/webapp/metrics/helper.py
@@ -37,12 +37,14 @@ def build_metrics_json(
     """
     end = get_last_metrics_processed_date()
 
-    # -1 day counteracts an issue that the api call is inclusive of the dates
-    # specified, meaning you receive 1 extra data point then required
     if metric_bucket == "d":
-        start = end - relativedelta.relativedelta(days=metric_period)
+        start = end + relativedelta.relativedelta(days=-metric_period)
     elif metric_bucket == "m":
-        start = end - relativedelta.relativedelta(months=metric_period)
+        start = end + relativedelta.relativedelta(months=-metric_period)
+    elif metric_bucket == "y":
+        start = end + relativedelta.relativedelta(
+            years=-metric_period, days=-1
+        )
 
     return {
         "filters": [

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -75,12 +75,14 @@ def extract_metrics_period(metric_period):
 
     :returns A dictionnary with the differents values of the period
     """
+    allowed_periods = ["d", "m", "y"]
+
     if not metric_period[:-1].isdigit():
         metric_period = "30d"
 
     metric_period_int = int(metric_period[:-1])
     metric_bucket = metric_period[-1:]
-    if metric_bucket != "d" and metric_bucket != "m":
+    if metric_bucket not in allowed_periods:
         metric_bucket = "d"
 
     return {


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1359

Added "Past year" and "Past 2 years" options.

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/metrics
- Change the dropdown to Past year or Past 2 years