### PR TITLE
Release UI redux:  history

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "react-dom": "^16.4.1",
     "react-redux": "^5.1.1",
     "redux": "^4.0.1",
+    "redux-mock-store": "^1.5.3",
+    "redux-thunk": "^2.3.0",
     "sass-lint": "^1.10.2",
     "swiper": "^4.4.1",
     "topojson-client": "^3.0.0",

--- a/static/js/publisher/release.js
+++ b/static/js/publisher/release.js
@@ -1,15 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { createStore } from "redux";
+import { createStore, applyMiddleware, compose } from "redux";
+import thunk from "redux-thunk";
 import { Provider } from "react-redux";
 import ReleasesController from "./release/releasesController";
 
 import releases from "./release/reducers";
 
-const store = createStore(
-  releases,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-);
+// setup redux store with thunk middleware and devtools extension:
+// https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(releases, composeEnhancers(applyMiddleware(thunk)));
 
 const initReleases = (id, snapName, releasesData, channelMapsList, options) => {
   ReactDOM.render(

--- a/static/js/publisher/release/actions/history.js
+++ b/static/js/publisher/release/actions/history.js
@@ -1,0 +1,15 @@
+export const OPEN_HISTORY = "OPEN_HISTORY";
+export const CLOSE_HISTORY = "CLOSE_HISTORY";
+
+export function openHistory(filters) {
+  return {
+    type: OPEN_HISTORY,
+    payload: { filters }
+  };
+}
+
+export function closeHistory() {
+  return {
+    type: CLOSE_HISTORY
+  };
+}

--- a/static/js/publisher/release/actions/history.js
+++ b/static/js/publisher/release/actions/history.js
@@ -13,3 +13,21 @@ export function closeHistory() {
     type: CLOSE_HISTORY
   };
 }
+
+export function toggleHistory(filters) {
+  return (dispatch, getState) => {
+    const { history } = getState();
+
+    if (
+      history.isOpen &&
+      history.filters &&
+      filters.track === history.filters.track &&
+      filters.arch === history.filters.arch &&
+      filters.risk === history.filters.risk
+    ) {
+      dispatch(closeHistory());
+    } else {
+      dispatch(openHistory(filters));
+    }
+  };
+}

--- a/static/js/publisher/release/actions/history.test.js
+++ b/static/js/publisher/release/actions/history.test.js
@@ -1,23 +1,30 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+export const mockStore = configureMockStore([thunk]);
+
 import {
   OPEN_HISTORY,
   CLOSE_HISTORY,
   openHistory,
-  closeHistory
+  closeHistory,
+  toggleHistory
 } from "./history";
 
 describe("history actions", () => {
-  describe("openHistory", () => {
-    let filters = {
-      track: "latest",
-      arch: "abc42"
-    };
+  const dummyFilters = {
+    arch: "abc42",
+    track: "latest",
+    risk: "stable"
+  };
 
+  describe("openHistory", () => {
     it("should create an action to open history panel", () => {
-      expect(openHistory(filters).type).toBe(OPEN_HISTORY);
+      expect(openHistory(dummyFilters).type).toBe(OPEN_HISTORY);
     });
 
     it("should supply a payload with filters", () => {
-      expect(openHistory(filters).payload.filters).toEqual(filters);
+      expect(openHistory(dummyFilters).payload.filters).toEqual(dummyFilters);
     });
   });
 
@@ -28,6 +35,66 @@ describe("history actions", () => {
 
     it("should not supply any payload", () => {
       expect(closeHistory().payload).toBeUndefined();
+    });
+  });
+
+  describe("toggleHistory", () => {
+    describe("when history with same filters is open", () => {
+      it("should dispatch action to close history panel", () => {
+        const store = mockStore({
+          history: {
+            isOpen: true,
+            filters: {
+              ...dummyFilters
+            }
+          }
+        });
+
+        store.dispatch(toggleHistory(dummyFilters));
+
+        const actions = store.getActions();
+        const expectedAction = closeHistory();
+        expect(actions).toEqual([expectedAction]);
+      });
+    });
+
+    describe("when history with different filters is open", () => {
+      it("should dispatch action to open history panel with new filters", () => {
+        const store = mockStore({
+          history: {
+            isOpen: true,
+            filters: {
+              ...dummyFilters
+            }
+          }
+        });
+        const testFilters = {
+          ...dummyFilters,
+          arch: "test321"
+        };
+        store.dispatch(toggleHistory(testFilters));
+
+        const actions = store.getActions();
+        const expectedAction = openHistory(testFilters);
+        expect(actions).toEqual([expectedAction]);
+      });
+    });
+
+    describe("when history is closed", () => {
+      it("should dispatch action to open history panel", () => {
+        const store = mockStore({
+          history: {
+            isOpen: false,
+            filters: null
+          }
+        });
+
+        store.dispatch(toggleHistory(dummyFilters));
+
+        const actions = store.getActions();
+        const expectedAction = openHistory(dummyFilters);
+        expect(actions).toEqual([expectedAction]);
+      });
     });
   });
 });

--- a/static/js/publisher/release/actions/history.test.js
+++ b/static/js/publisher/release/actions/history.test.js
@@ -1,0 +1,33 @@
+import {
+  OPEN_HISTORY,
+  CLOSE_HISTORY,
+  openHistory,
+  closeHistory
+} from "./history";
+
+describe("history actions", () => {
+  describe("openHistory", () => {
+    let filters = {
+      track: "latest",
+      arch: "abc42"
+    };
+
+    it("should create an action to open history panel", () => {
+      expect(openHistory(filters).type).toBe(OPEN_HISTORY);
+    });
+
+    it("should supply a payload with filters", () => {
+      expect(openHistory(filters).payload.filters).toEqual(filters);
+    });
+  });
+
+  describe("closeHistory", () => {
+    it("should create an action to close history panel", () => {
+      expect(closeHistory().type).toBe(CLOSE_HISTORY);
+    });
+
+    it("should not supply any payload", () => {
+      expect(closeHistory().payload).toBeUndefined();
+    });
+  });
+});

--- a/static/js/publisher/release/actions/releases.js
+++ b/static/js/publisher/release/actions/releases.js
@@ -1,0 +1,8 @@
+export const UPDATE_RELEASES = "UPDATE_RELEASES";
+
+export function updateReleases(releases) {
+  return {
+    type: UPDATE_RELEASES,
+    payload: { releases }
+  };
+}

--- a/static/js/publisher/release/actions/releases.test.js
+++ b/static/js/publisher/release/actions/releases.test.js
@@ -1,0 +1,15 @@
+import { UPDATE_RELEASES, updateReleases } from "./releases";
+
+describe("releases actions", () => {
+  describe("updateReleases", () => {
+    let releases = [{ revision: 1 }, { revision: 2 }];
+
+    it("should create an action to update releases list", () => {
+      expect(updateReleases(releases).type).toBe(UPDATE_RELEASES);
+    });
+
+    it("should supply a payload with releases list", () => {
+      expect(updateReleases(releases).payload.releases).toEqual(releases);
+    });
+  });
+});

--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -9,7 +9,6 @@ export default class HistoryPanel extends Component {
       <div className="p-history-panel">
         <div className="p-strip is-shallow">
           <RevisionsList
-            releases={this.props.releases}
             releasedChannels={this.props.releasedChannels}
             selectedRevisions={this.props.selectedRevisions}
             pendingReleases={this.props.pendingReleases}
@@ -25,7 +24,6 @@ export default class HistoryPanel extends Component {
 
 HistoryPanel.propTypes = {
   // state
-  releases: PropTypes.array.isRequired,
   releasedChannels: PropTypes.object.isRequired,
   selectedRevisions: PropTypes.array.isRequired,
   pendingReleases: PropTypes.object.isRequired,

--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -10,14 +10,12 @@ export default class HistoryPanel extends Component {
         <div className="p-strip is-shallow">
           <RevisionsList
             releases={this.props.releases}
-            revisionsFilters={this.props.revisionsFilters}
             releasedChannels={this.props.releasedChannels}
             selectedRevisions={this.props.selectedRevisions}
             pendingReleases={this.props.pendingReleases}
             showChannels={this.props.showChannels}
             showArchitectures={this.props.showArchitectures}
             selectRevision={this.props.selectRevision}
-            closeHistoryPanel={this.props.closeHistoryPanel}
           />
         </div>
       </div>
@@ -29,12 +27,10 @@ HistoryPanel.propTypes = {
   // state
   releases: PropTypes.array.isRequired,
   releasedChannels: PropTypes.object.isRequired,
-  revisionsFilters: PropTypes.object,
   selectedRevisions: PropTypes.array.isRequired,
   pendingReleases: PropTypes.object.isRequired,
   showChannels: PropTypes.bool,
   showArchitectures: PropTypes.bool,
   // actions
-  selectRevision: PropTypes.func.isRequired,
-  closeHistoryPanel: PropTypes.func.isRequired
+  selectRevision: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/reducers/history.js
+++ b/static/js/publisher/release/reducers/history.js
@@ -1,0 +1,26 @@
+import { OPEN_HISTORY, CLOSE_HISTORY } from "../actions/history";
+
+export default function history(
+  state = {
+    filters: null,
+    isOpen: false
+  },
+  action
+) {
+  switch (action.type) {
+    case OPEN_HISTORY:
+      return {
+        ...state,
+        isOpen: true,
+        ...action.payload
+      };
+    case CLOSE_HISTORY:
+      return {
+        ...state,
+        isOpen: false,
+        filters: null
+      };
+    default:
+      return state;
+  }
+}

--- a/static/js/publisher/release/reducers/history.test.js
+++ b/static/js/publisher/release/reducers/history.test.js
@@ -1,0 +1,53 @@
+import history from "./history";
+import { OPEN_HISTORY, CLOSE_HISTORY } from "../actions/history";
+
+describe("history", () => {
+  it("should return the initial state", () => {
+    expect(history(undefined, {})).toEqual({
+      isOpen: false,
+      filters: null
+    });
+  });
+
+  describe("on OPEN_HISTORY action", () => {
+    let openHistoryAction = {
+      type: OPEN_HISTORY,
+      payload: {
+        filters: {
+          track: "latest",
+          arch: "abc42"
+        }
+      }
+    };
+
+    it("should mark history panel open", () => {
+      const result = history({}, openHistoryAction);
+
+      expect(result.isOpen).toBe(true);
+    });
+
+    it("should set history filters", () => {
+      const result = history({}, openHistoryAction);
+
+      expect(result.filters).toEqual(openHistoryAction.payload.filters);
+    });
+  });
+
+  describe("on CLOSE_HISTORY action", () => {
+    let closeHistoryAction = {
+      type: CLOSE_HISTORY
+    };
+
+    it("should mark history panel closed", () => {
+      const result = history({}, closeHistoryAction);
+
+      expect(result.isOpen).toBe(false);
+    });
+
+    it("should remove history filters", () => {
+      const result = history({}, closeHistoryAction);
+
+      expect(result.filters).toBe(null);
+    });
+  });
+});

--- a/static/js/publisher/release/reducers/index.js
+++ b/static/js/publisher/release/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from "redux";
 
 import revisions from "./revisions";
+import history from "./history";
 
 const releases = combineReducers({
+  history,
   revisions
 });
 

--- a/static/js/publisher/release/reducers/index.js
+++ b/static/js/publisher/release/reducers/index.js
@@ -1,11 +1,13 @@
 import { combineReducers } from "redux";
 
-import revisions from "./revisions";
 import history from "./history";
+import releases from "./releases";
+import revisions from "./revisions";
 
-const releases = combineReducers({
+const releasesReducers = combineReducers({
   history,
-  revisions
+  revisions,
+  releases
 });
 
-export default releases;
+export default releasesReducers;

--- a/static/js/publisher/release/reducers/releases.js
+++ b/static/js/publisher/release/reducers/releases.js
@@ -1,0 +1,10 @@
+import { UPDATE_RELEASES } from "../actions/releases";
+
+export default function revisions(state = [], action) {
+  switch (action.type) {
+    case UPDATE_RELEASES:
+      return [...action.payload.releases];
+    default:
+      return state;
+  }
+}

--- a/static/js/publisher/release/reducers/releases.test.js
+++ b/static/js/publisher/release/reducers/releases.test.js
@@ -1,0 +1,31 @@
+import releases from "./releases";
+import { UPDATE_RELEASES } from "../actions/releases";
+
+describe("releases", () => {
+  it("should return the initial state", () => {
+    expect(releases(undefined, {})).toEqual([]);
+  });
+
+  describe("on UPDATE_REVISIONS action", () => {
+    let updateReleasesAction = {
+      type: UPDATE_RELEASES,
+      payload: {
+        releases: [{ revision: 1 }, { revision: 2 }, { revision: 3 }]
+      }
+    };
+
+    it("should add new releases to state", () => {
+      const result = releases({}, updateReleasesAction);
+
+      expect(result).toEqual(updateReleasesAction.payload.releases);
+    });
+
+    it("should replace existing releases in state", () => {
+      const initialState = [{ revision: 5 }, { revision: 6 }];
+
+      const result = releases(initialState, updateReleasesAction);
+
+      expect(result).toEqual(updateReleasesAction.payload.releases);
+    });
+  });
+});

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -9,6 +9,7 @@ import { isInDevmode } from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
 import { updateRevisions } from "./actions/revisions";
+import { openHistory, closeHistory } from "./actions/history";
 
 import {
   getNextReleasedChannels,
@@ -66,13 +67,7 @@ class ReleasesController extends Component {
       pendingReleases: {},
       pendingCloses: [],
       // list of selected revisions, to know which ones to render selected
-      selectedRevisions: [],
-      // filters for revisions list
-      // {
-      //   arch: 'architecture'
-      // }
-      revisionsFilters: null,
-      isHistoryOpen: false
+      selectedRevisions: []
     };
   }
 
@@ -471,9 +466,10 @@ class ReleasesController extends Component {
       .then(() => this.clearPendingReleases());
   }
 
+  // move to reducer ?
   toggleHistoryPanel(filters) {
-    const currentFilters = this.state.revisionsFilters;
-    const isHistoryOpen = this.state.isHistoryOpen;
+    const currentFilters = this.props.revisionsFilters;
+    const isHistoryOpen = this.props.isHistoryOpen;
 
     if (
       isHistoryOpen &&
@@ -484,24 +480,10 @@ class ReleasesController extends Component {
           filters.arch === currentFilters.arch &&
           filters.risk === currentFilters.risk))
     ) {
-      this.closeHistoryPanel();
+      this.props.closeHistoryPanel();
     } else {
-      this.openHistoryPanel(filters);
+      this.props.openHistoryPanel(filters);
     }
-  }
-
-  openHistoryPanel(filters) {
-    this.setState({
-      revisionsFilters: filters,
-      isHistoryOpen: true
-    });
-  }
-
-  closeHistoryPanel() {
-    this.setState({
-      revisionsFilters: null,
-      isHistoryOpen: false
-    });
   }
 
   render() {
@@ -540,6 +522,7 @@ class ReleasesController extends Component {
         <ReleasesTable
           // map all the state into props
           {...this.state}
+          revisionsFilters={this.props.revisionsFilters}
           // actions
           getNextReleasedChannels={this.getNextReleasedChannels.bind(this)}
           setCurrentTrack={this.setCurrentTrack.bind(this)}
@@ -551,7 +534,6 @@ class ReleasesController extends Component {
           closeChannel={this.closeChannel.bind(this)}
           toggleHistoryPanel={this.toggleHistoryPanel.bind(this)}
           selectRevision={this.selectRevision.bind(this)}
-          closeHistoryPanel={this.closeHistoryPanel.bind(this)}
         />
       </Fragment>
     );
@@ -565,18 +547,26 @@ ReleasesController.propTypes = {
   options: PropTypes.object.isRequired,
 
   revisions: PropTypes.object,
-  state: PropTypes.object,
+  isHistoryOpen: PropTypes.bool,
+  revisionsFilters: PropTypes.object,
+
+  openHistoryPanel: PropTypes.func,
+  closeHistoryPanel: PropTypes.func,
   updateRevisions: PropTypes.func
 };
 
 const mapStateToProps = state => {
   return {
+    isHistoryOpen: state.history.isOpen,
+    revisionsFilters: state.history.filters,
     revisions: state.revisions
   };
 };
 
 const mapDispatchToProps = dispatch => {
   return {
+    openHistoryPanel: filters => dispatch(openHistory(filters)),
+    closeHistoryPanel: () => dispatch(closeHistory()),
     updateRevisions: revisions => dispatch(updateRevisions(revisions))
   };
 };

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -9,6 +9,7 @@ import { isInDevmode } from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
 import { updateRevisions } from "./actions/revisions";
+import { updateReleases } from "./actions/releases";
 
 import {
   getNextReleasedChannels,
@@ -32,6 +33,7 @@ class ReleasesController extends Component {
     // init redux store
     // TODO: should be done outside component as initial state?
     this.props.updateRevisions(revisionsMap);
+    this.props.updateReleases(this.props.releasesData.releases);
 
     const releasedChannels = getReleaseDataFromChannelMap(
       this.props.channelMapsList,
@@ -48,8 +50,6 @@ class ReleasesController extends Component {
       // released channels contains channel map for each channel in current track
       // also includes 'unassigned' fake channel to show selected unassigned revision
       releasedChannels: releasedChannels,
-      // list of releases returned by API
-      releases: this.props.releasesData.releases,
       // list of all available tracks
       tracks: tracks,
       // list of architectures released to (or selected to be released to)
@@ -76,9 +76,7 @@ class ReleasesController extends Component {
     initReleasesData(revisionsMap, releasesData.releases);
 
     this.props.updateRevisions(revisionsMap);
-    this.setState({
-      releases: releasesData.releases
-    });
+    this.props.updateReleases(releasesData.releases);
   }
 
   selectRevision(revision) {
@@ -501,7 +499,6 @@ class ReleasesController extends Component {
         <ReleasesTable
           // map all the state into props
           {...this.state}
-          revisionsFilters={this.props.revisionsFilters}
           // actions
           getNextReleasedChannels={this.getNextReleasedChannels.bind(this)}
           setCurrentTrack={this.setCurrentTrack.bind(this)}
@@ -528,6 +525,7 @@ ReleasesController.propTypes = {
   isHistoryOpen: PropTypes.bool,
   revisionsFilters: PropTypes.object,
 
+  updateReleases: PropTypes.func,
   updateRevisions: PropTypes.func
 };
 
@@ -541,7 +539,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    updateRevisions: revisions => dispatch(updateRevisions(revisions))
+    updateRevisions: revisions => dispatch(updateRevisions(revisions)),
+    updateReleases: releases => dispatch(updateReleases(releases))
   };
 };
 

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -9,7 +9,6 @@ import { isInDevmode } from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
 import { updateRevisions } from "./actions/revisions";
-import { openHistory, closeHistory } from "./actions/history";
 
 import {
   getNextReleasedChannels,
@@ -466,26 +465,6 @@ class ReleasesController extends Component {
       .then(() => this.clearPendingReleases());
   }
 
-  // move to reducer ?
-  toggleHistoryPanel(filters) {
-    const currentFilters = this.props.revisionsFilters;
-    const isHistoryOpen = this.props.isHistoryOpen;
-
-    if (
-      isHistoryOpen &&
-      (filters == currentFilters ||
-        (filters &&
-          currentFilters &&
-          filters.track === currentFilters.track &&
-          filters.arch === currentFilters.arch &&
-          filters.risk === currentFilters.risk))
-    ) {
-      this.props.closeHistoryPanel();
-    } else {
-      this.props.openHistoryPanel(filters);
-    }
-  }
-
   render() {
     const hasDevmodeRevisions = Object.values(this.state.releasedChannels).some(
       archReleases => {
@@ -532,7 +511,6 @@ class ReleasesController extends Component {
           undoRelease={this.undoRelease.bind(this)}
           clearPendingReleases={this.clearPendingReleases.bind(this)}
           closeChannel={this.closeChannel.bind(this)}
-          toggleHistoryPanel={this.toggleHistoryPanel.bind(this)}
           selectRevision={this.selectRevision.bind(this)}
         />
       </Fragment>
@@ -550,8 +528,6 @@ ReleasesController.propTypes = {
   isHistoryOpen: PropTypes.bool,
   revisionsFilters: PropTypes.object,
 
-  openHistoryPanel: PropTypes.func,
-  closeHistoryPanel: PropTypes.func,
   updateRevisions: PropTypes.func
 };
 
@@ -565,8 +541,6 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    openHistoryPanel: filters => dispatch(openHistory(filters)),
-    closeHistoryPanel: () => dispatch(closeHistory()),
     updateRevisions: revisions => dispatch(updateRevisions(revisions))
   };
 };

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -104,44 +104,6 @@ function getArchsFromRevisionsMap(revisionsMap) {
   return archs.sort();
 }
 
-function getFilteredReleaseHistory(releases, revisionsMap, filters) {
-  return (
-    releases
-      // only releases of revisions (ignore closing channels)
-      .filter(release => release.revision)
-      // only releases in given architecture
-      .filter(release => {
-        return filters && filters.arch
-          ? release.architecture === filters.arch
-          : true;
-      })
-      // only releases in given track
-      .filter(release => {
-        return filters && filters.track
-          ? release.track === filters.track
-          : true;
-      })
-      // only releases in given risk
-      .filter(release => {
-        return filters && filters.risk ? release.risk === filters.risk : true;
-      })
-      // before we have branches support we ignore any releases to branches
-      .filter(release => !release.branch)
-      // only one latest release of every revision
-      .filter((release, index, all) => {
-        return all.findIndex(r => r.revision === release.revision) === index;
-      })
-      // map release history to revisions
-      .map(release => {
-        const revision = JSON.parse(
-          JSON.stringify(revisionsMap[release.revision])
-        );
-        revision.release = release;
-        return revision;
-      })
-  );
-}
-
 // for channel without release get next (less risk) channel with a release
 function getTrackingChannel(releasedChannels, track, risk, arch) {
   let tracking = null;
@@ -245,7 +207,6 @@ export {
   getPendingRelease,
   getUnassignedRevisions,
   getArchsFromRevisionsMap,
-  getFilteredReleaseHistory,
   getTracksFromChannelMap,
   getTrackingChannel,
   getRevisionsMap,

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -341,7 +341,6 @@ class ReleasesTable extends Component {
     return (
       <HistoryPanel
         key="history-panel"
-        releases={this.props.releases}
         releasedChannels={this.props.releasedChannels}
         selectedRevisions={this.props.selectedRevisions}
         pendingReleases={this.props.pendingReleases}
@@ -526,12 +525,12 @@ class ReleasesTable extends Component {
 
 ReleasesTable.propTypes = {
   // state
+  revisions: PropTypes.object.isRequired,
   releases: PropTypes.array.isRequired,
   isHistoryOpen: PropTypes.bool,
   revisionsFilters: PropTypes.object,
 
   // state (non redux)
-  revisions: PropTypes.object.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired,
@@ -558,7 +557,8 @@ const mapStateToProps = state => {
   return {
     revisionsFilters: state.history.filters,
     isHistoryOpen: state.history.isOpen,
-    revisions: state.revisions
+    revisions: state.revisions,
+    releases: state.releases
   };
 };
 

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -340,14 +340,12 @@ class ReleasesTable extends Component {
       <HistoryPanel
         key="history-panel"
         releases={this.props.releases}
-        revisionsFilters={this.props.revisionsFilters}
         releasedChannels={this.props.releasedChannels}
         selectedRevisions={this.props.selectedRevisions}
         pendingReleases={this.props.pendingReleases}
         selectRevision={this.props.selectRevision}
         showArchitectures={!!showAllColumns}
         showChannels={!!showAllColumns}
-        closeHistoryPanel={this.props.closeHistoryPanel}
       />
     );
   }
@@ -527,6 +525,10 @@ class ReleasesTable extends Component {
 ReleasesTable.propTypes = {
   // state
   releases: PropTypes.array.isRequired,
+  isHistoryOpen: PropTypes.bool,
+  revisionsFilters: PropTypes.object,
+
+  // state (non redux)
   revisions: PropTypes.object.isRequired,
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
@@ -535,9 +537,7 @@ ReleasesTable.propTypes = {
   pendingReleases: PropTypes.object.isRequired,
   pendingCloses: PropTypes.array.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  revisionsFilters: PropTypes.object,
   selectedRevisions: PropTypes.array,
-  isHistoryOpen: PropTypes.bool,
 
   // actions
   getNextReleasedChannels: PropTypes.func.isRequired,
@@ -549,12 +549,13 @@ ReleasesTable.propTypes = {
   clearPendingReleases: PropTypes.func.isRequired,
   closeChannel: PropTypes.func.isRequired,
   toggleHistoryPanel: PropTypes.func.isRequired,
-  selectRevision: PropTypes.func.isRequired,
-  closeHistoryPanel: PropTypes.func.isRequired
+  selectRevision: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
   return {
+    revisionsFilters: state.history.filters,
+    isHistoryOpen: state.history.isOpen,
     revisions: state.revisions
   };
 };

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -16,6 +16,8 @@ import HistoryPanel from "./historyPanel";
 
 import { getTrackingChannel, getUnassignedRevisions } from "./releasesState";
 
+import { toggleHistory } from "./actions/history";
+
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
 }
@@ -560,4 +562,13 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(ReleasesTable);
+const mapDispatchToProps = dispatch => {
+  return {
+    toggleHistoryPanel: filters => dispatch(toggleHistory(filters))
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ReleasesTable);

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -7,6 +7,8 @@ import format from "date-fns/format";
 import DevmodeIcon from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
+import { closeHistory } from "./actions/history";
+
 import {
   getFilteredReleaseHistory,
   getUnassignedRevisions,
@@ -214,23 +216,49 @@ class RevisionsList extends Component {
 
 RevisionsList.propTypes = {
   // state
-  releases: PropTypes.array.isRequired,
   revisionsMap: PropTypes.object.isRequired,
-  releasedChannels: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
-  selectedRevisions: PropTypes.array.isRequired,
-  pendingReleases: PropTypes.object.isRequired,
-  showChannels: PropTypes.bool,
-  showArchitectures: PropTypes.bool,
+
   // actions
-  selectRevision: PropTypes.func.isRequired,
-  closeHistoryPanel: PropTypes.func.isRequired
+  closeHistoryPanel: PropTypes.func.isRequired,
+
+  // state (TODO: move to redux)
+  // TODO:
+  // getFilteredReleaseHistory - can be selector
+  // requires: releases, revisionsMap, filters
+  releases: PropTypes.array.isRequired, // 1: for getFilteredReleaseHistory
+
+  // TODO: create selector to list selected architectures (?)
+  releasedChannels: PropTypes.object.isRequired, // 1: check if arch is selected
+
+  // TODO: just move to state
+  selectedRevisions: PropTypes.array.isRequired, // 1: isSelected
+
+  // TODO: just move to state
+  pendingReleases: PropTypes.object.isRequired, // 1: get pending release
+
+  // view props (don't depend on state)
+  showChannels: PropTypes.bool, // ~: render channels column
+  showArchitectures: PropTypes.bool, // 4: render architectures
+
+  // actions
+  selectRevision: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
   return {
+    revisionsFilters: state.history.filters,
     revisionsMap: state.revisions
   };
 };
 
-export default connect(mapStateToProps)(RevisionsList);
+const mapDispatchToProps = dispatch => {
+  return {
+    closeHistoryPanel: () => dispatch(closeHistory())
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RevisionsList);

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -218,15 +218,15 @@ RevisionsList.propTypes = {
   // state
   revisionsMap: PropTypes.object.isRequired,
   revisionsFilters: PropTypes.object,
+  // TODO:
+  // getFilteredReleaseHistory - can be selector
+  // requires: releases, revisionsMap, filters
+  releases: PropTypes.array.isRequired, // 1: for getFilteredReleaseHistory
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
 
   // state (TODO: move to redux)
-  // TODO:
-  // getFilteredReleaseHistory - can be selector
-  // requires: releases, revisionsMap, filters
-  releases: PropTypes.array.isRequired, // 1: for getFilteredReleaseHistory
 
   // TODO: create selector to list selected architectures (?)
   releasedChannels: PropTypes.object.isRequired, // 1: check if arch is selected
@@ -248,7 +248,8 @@ RevisionsList.propTypes = {
 const mapStateToProps = state => {
   return {
     revisionsFilters: state.history.filters,
-    revisionsMap: state.revisions
+    revisionsMap: state.revisions,
+    releases: state.releases
   };
 };
 

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -8,12 +8,9 @@ import DevmodeIcon from "./devmodeIcon";
 import { UNASSIGNED } from "./constants";
 
 import { closeHistory } from "./actions/history";
+import { getFilteredReleaseHistory } from "./selectors";
 
-import {
-  getFilteredReleaseHistory,
-  getUnassignedRevisions,
-  getPendingRelease
-} from "./releasesState";
+import { getUnassignedRevisions, getPendingRelease } from "./releasesState";
 
 class RevisionsList extends Component {
   revisionSelectChange(revision) {
@@ -111,9 +108,9 @@ class RevisionsList extends Component {
 
   render() {
     let { showChannels, showArchitectures } = this.props;
-    let filteredRevisions = Object.values(this.props.revisionsMap).reverse();
+    let filteredRevisions = Object.values(this.props.revisions).reverse();
     let title = "Latest revisions";
-    let filters = this.props.revisionsFilters;
+    let filters = this.props.filters;
     let isReleaseHistory = false;
     let pendingRelease = null;
 
@@ -124,7 +121,7 @@ class RevisionsList extends Component {
         showChannels = false;
 
         filteredRevisions = getUnassignedRevisions(
-          this.props.revisionsMap,
+          this.props.revisions,
           filters.arch
         );
       } else {
@@ -134,11 +131,7 @@ class RevisionsList extends Component {
           filters.risk
         }`;
 
-        filteredRevisions = getFilteredReleaseHistory(
-          this.props.releases,
-          this.props.revisionsMap,
-          filters
-        );
+        filteredRevisions = this.props.filteredReleaseHistory;
 
         pendingRelease = getPendingRelease(
           this.props.pendingReleases,
@@ -147,7 +140,7 @@ class RevisionsList extends Component {
         );
 
         if (pendingRelease) {
-          pendingRelease = this.props.revisionsMap[pendingRelease];
+          pendingRelease = this.props.revisions[pendingRelease];
         }
       }
     }
@@ -216,12 +209,11 @@ class RevisionsList extends Component {
 
 RevisionsList.propTypes = {
   // state
-  revisionsMap: PropTypes.object.isRequired,
-  revisionsFilters: PropTypes.object,
-  // TODO:
-  // getFilteredReleaseHistory - can be selector
-  // requires: releases, revisionsMap, filters
-  releases: PropTypes.array.isRequired, // 1: for getFilteredReleaseHistory
+  revisions: PropTypes.object.isRequired,
+  filters: PropTypes.object,
+
+  // computed state (selectors)
+  filteredReleaseHistory: PropTypes.array,
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
@@ -247,9 +239,9 @@ RevisionsList.propTypes = {
 
 const mapStateToProps = state => {
   return {
-    revisionsFilters: state.history.filters,
-    revisionsMap: state.revisions,
-    releases: state.releases
+    filters: state.history.filters,
+    revisions: state.revisions,
+    filteredReleaseHistory: getFilteredReleaseHistory(state)
   };
 };
 

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -1,0 +1,41 @@
+// returns release history filtered by history filters
+export function getFilteredReleaseHistory(state) {
+  const releases = state.releases;
+  const revisions = state.revisions;
+  const filters = state.history.filters;
+
+  return (
+    releases
+      // only releases of revisions (ignore closing channels)
+      .filter(release => release.revision)
+      // only releases in given architecture
+      .filter(release => {
+        return filters && filters.arch
+          ? release.architecture === filters.arch
+          : true;
+      })
+      // only releases in given track
+      .filter(release => {
+        return filters && filters.track
+          ? release.track === filters.track
+          : true;
+      })
+      // only releases in given risk
+      .filter(release => {
+        return filters && filters.risk ? release.risk === filters.risk : true;
+      })
+      // before we have branches support we ignore any releases to branches
+      .filter(release => !release.branch)
+      // only one latest release of every revision
+      .filter((release, index, all) => {
+        return all.findIndex(r => r.revision === release.revision) === index;
+      })
+      // map release history to revisions
+      .map(release => {
+        return {
+          ...revisions[release.revision],
+          release
+        };
+      })
+  );
+}

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -1,0 +1,137 @@
+import { getFilteredReleaseHistory } from "./index";
+
+import reducers from "../reducers";
+
+describe("getFilteredReleaseHistory", () => {
+  const initialState = reducers(undefined, {});
+  const stateWithRevisions = {
+    ...initialState,
+    revisions: {
+      1: { revision: 1, version: "1" },
+      2: { revision: 2, version: "2" },
+      3: { revision: 3, version: "3" }
+    }
+  };
+
+  it("should return empty list for initial state", () => {
+    expect(getFilteredReleaseHistory(initialState)).toEqual([]);
+  });
+
+  it("should return only releases of revisions (ignore closing channels)", () => {
+    const state = {
+      ...stateWithRevisions,
+      releases: [
+        { risk: "test", revision: 1 },
+        { risk: "test" },
+        { risk: "test", revision: 2 }
+      ]
+    };
+
+    const filteredHistory = getFilteredReleaseHistory(state);
+    expect(filteredHistory.every(r => r.revision)).toBe(true);
+  });
+
+  it("should return only releases in given architecture", () => {
+    const state = {
+      ...stateWithRevisions,
+      releases: [
+        { architecture: "test", revision: 1 },
+        { architecture: "test", revision: 2 },
+        { architecture: "abcd", revision: 2 },
+        { architecture: "test", revision: 3 }
+      ],
+      history: {
+        filters: {
+          arch: "test"
+        }
+      }
+    };
+
+    const filteredHistory = getFilteredReleaseHistory(state);
+    const isEveryReleaseInTestArch = filteredHistory.every(
+      r => r.release.architecture === "test"
+    );
+    expect(isEveryReleaseInTestArch).toBe(true);
+  });
+
+  it("should return only releases in given track", () => {
+    const state = {
+      ...stateWithRevisions,
+      releases: [
+        { track: "test", revision: 1 },
+        { track: "test", revision: 2 },
+        { track: "abcd", revision: 2 },
+        { track: "test", revision: 3 }
+      ],
+      history: {
+        filters: {
+          track: "test"
+        }
+      }
+    };
+
+    const filteredHistory = getFilteredReleaseHistory(state);
+    const isEveryReleaseInTestTrack = filteredHistory.every(
+      r => r.release.track === "test"
+    );
+    expect(isEveryReleaseInTestTrack).toBe(true);
+  });
+
+  it("should return only releases in given risk", () => {
+    const state = {
+      ...stateWithRevisions,
+      releases: [
+        { risk: "test", revision: 1 },
+        { risk: "test", revision: 2 },
+        { risk: "abcd", revision: 2 },
+        { risk: "test", revision: 3 }
+      ],
+      history: {
+        filters: {
+          risk: "test"
+        }
+      }
+    };
+
+    const filteredHistory = getFilteredReleaseHistory(state);
+    const isEveryReleaseInTestRisk = filteredHistory.every(
+      r => r.release.risk === "test"
+    );
+    expect(isEveryReleaseInTestRisk).toBe(true);
+  });
+
+  it("should return ignore any releases to branches", () => {
+    const state = {
+      ...stateWithRevisions,
+      releases: [
+        { branch: "test", revision: 1 },
+        { revision: 1 },
+        { revision: 2 }
+      ]
+    };
+
+    const filteredHistory = getFilteredReleaseHistory(state);
+    expect(filteredHistory.some(r => r.release.branch)).toBe(false);
+  });
+
+  it("should return only one latest release of every revision", () => {
+    const state = {
+      ...stateWithRevisions,
+      releases: [
+        { revision: 1 },
+        { revision: 2 },
+        { revision: 1 },
+        { revision: 3 }
+      ]
+    };
+
+    const filteredRevisions = getFilteredReleaseHistory(state).map(
+      r => r.revision
+    );
+
+    const isUnique =
+      new Set(filteredRevisions).size === filteredRevisions.length;
+
+    expect(isUnique).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4863,6 +4863,10 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.kebabcase@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
@@ -6497,6 +6501,16 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-mock-store@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.3.tgz#1f10528949b7ce8056c2532624f7cafa98576c6d"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
 redux@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Continuing redux migration of ReleasesList component:
- moves state of history panel into redux reducers/actions
- moves filtering of history into a selector
- adds tests for all functions

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1393.run.demo.haus/
- go to Releases page of any snap
- open Redux dev tools
- click around the table, show history of different channels
- opening/closing of panel should show up as actions in redux dev tools
- all release UI functionality should work as before