### PR TITLE
Make blog api url available through env var

### DIFF
--- a/webapp/api/blog.py
+++ b/webapp/api/blog.py
@@ -1,7 +1,11 @@
-from webapp import api
-from webapp.api.exceptions import ApiResponseError, ApiResponseDecodeError
+import os
 
-API_URL = "https://admin.insights.ubuntu.com/wp-json/wp/v2"
+from webapp import api
+from webapp.api.exceptions import ApiResponseDecodeError, ApiResponseError
+
+API_URL = os.getenv(
+    "BLOG_API", "https://admin.insights.ubuntu.com/wp-json/wp/v2"
+)
 TAGS = [2996]  # 'snapcraft.io'
 
 


### PR DESCRIPTION
# Summary

Make blog editable thanks to environment var

# QA

- `./run`
- http://127.0.0.1:8004/blog
- Should work as usual
- Edit `.env` and add line: `BLOG_API=https://httpbin.org/status/504`
- `./run`
- http://127.0.0.1:8004/blog
- Should have a `Gateway Timeout`
- Edit `.env` and modify line: `BLOG_API=https://admin.insights.ubuntu.com/wp-json/wp/v2`
- `./run`
- http://127.0.0.1:8004/blog
- Should work as usual