### PR TITLE
Add counter for the number of requests on badge

### DIFF
--- a/tests/tests_badge_counter.py
+++ b/tests/tests_badge_counter.py
@@ -1,6 +1,6 @@
 from flask_testing import TestCase
 from webapp.app import create_app
-from webapp.handlers import badge_counter
+from webapp.handlers import badge_counter, badge_logged_in_counter
 
 
 class TestsBadgePrometheusCounter(TestCase):
@@ -9,6 +9,7 @@ class TestsBadgePrometheusCounter(TestCase):
     def setUp(self):
         self.endpoint_url = "/static/images/badges/en/snap-store-black.svg"
         badge_counter._value.set(0.0)
+        badge_logged_in_counter._value.set(0.0)
 
     def create_app(self):
         app = create_app(testing=True)
@@ -27,3 +28,14 @@ class TestsBadgePrometheusCounter(TestCase):
 
         self.client.get(self.endpoint_url)
         assert badge_counter._value.get() == 0.0
+
+    def tests_increment_counter_logged_in(self):
+        self.client.get(self.endpoint_url)
+        assert badge_logged_in_counter._value.get() == 0.0
+
+    def tests_no_increment_logged_in(self):
+        with self.client.session_transaction() as s:
+            s["session"] = "content"
+
+        self.client.get(self.endpoint_url)
+        assert badge_logged_in_counter._value.get() == 1.0

--- a/tests/tests_badge_counter.py
+++ b/tests/tests_badge_counter.py
@@ -1,0 +1,29 @@
+from flask_testing import TestCase
+from webapp.app import create_app
+from webapp.handlers import badge_counter
+
+
+class TestsBadgePrometheusCounter(TestCase):
+    render_templates = False
+
+    def setUp(self):
+        self.endpoint_url = "/static/images/badges/en/snap-store-black.svg"
+        badge_counter._value.set(0.0)
+
+    def create_app(self):
+        app = create_app(testing=True)
+        app.secret_key = "secret_key"
+        app.config["WTF_CSRF_METHODS"] = []
+
+        return app
+
+    def tests_increment_counter(self):
+        self.client.get(self.endpoint_url)
+        assert badge_counter._value.get() == 1.0
+
+    def tests_no_increment(self):
+        with self.client.session_transaction() as s:
+            s["session"] = "content"
+
+        self.client.get(self.endpoint_url)
+        assert badge_counter._value.get() == 0.0

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -96,7 +96,8 @@ def set_handlers(app):
     @app.before_request
     def prometheus_metrics():
         if "/static/images/badges" in flask.request.url:
-            badge_counter.inc()
+            if not flask.session:
+                badge_counter.inc()
 
     @app.after_request
     def add_headers(response):

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -10,6 +10,11 @@ badge_counter = prometheus_client.Counter(
     "badge_counter", "A counter of badges requests"
 )
 
+badge_logged_in_counter = prometheus_client.Counter(
+    "badge_logged_in_counter",
+    "A counter of badges requests of logged in users",
+)
+
 
 def set_handlers(app):
     @app.context_processor
@@ -96,7 +101,9 @@ def set_handlers(app):
     @app.before_request
     def prometheus_metrics():
         if "/static/images/badges" in flask.request.url:
-            if not flask.session:
+            if flask.session:
+                badge_logged_in_counter.inc()
+            else:
                 badge_counter.inc()
 
     @app.after_request

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,8 +1,14 @@
 import flask
 import socket
+import prometheus_client
 import webapp.template_utils as template_utils
 from urllib.parse import unquote, urlparse, urlunparse
 from webapp import authentication
+
+
+badge_counter = prometheus_client.Counter(
+    "badge_counter", "A counter of badges requests"
+)
 
 
 def set_handlers(app):
@@ -86,6 +92,11 @@ def set_handlers(app):
             new_uri = urlunparse(parsed_url._replace(path=path[:-1]))
 
             return flask.redirect(new_uri)
+
+    @app.before_request
+    def prometheus_metrics():
+        if "/static/images/badges" in flask.request.url:
+            badge_counter.inc()
 
     @app.after_request
     def add_headers(response):


### PR DESCRIPTION
# Summary

Fixes #1394 
Add counter for the number of requests on badges for logged in users and not logged in users
If the requester has a session I don't increment the counter, increment the logged in counter

This will allow us to know how many users request the badge from snapcraft (logged in) and from outside (readme ...)

# QA

- `vim .env`
- add line `TALISKER_NETWORKS=172.17.0.1`
- `./run`
- http://0.0.0.0:8004/_status/metrics
- Should have a line: `badge_counter 0.0`
- Should have a line: `badge_logged_in_counter 0.0`
- In a private tab
- http://127.0.0.1:8004/static/images/badges/en/snap-store-black.svg
- GOTO http://0.0.0.0:8004/_status/metrics
- Should have a line: `badge_counter 1.0`
- Should have a line: `badge_logged_in_counter 0.0`
- http://127.0.0.1:8004/toto/publicise
- Should have a line: `badge_counter 1.0`
- Should have a line: `badge_logged_in_counter 14.0`
- This case is less going to happen, but when a user is logged in and access the badge, it will be counted as a logged in user, even from outside the website
- http://127.0.0.1:8004/static/images/badges/en/snap-store-black.svg
- Should have a line: `badge_counter 1.0`
- Should have a line: `badge_logged_in_counter 15.0`