### PR TITLE
Revision vs version

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -28,30 +28,39 @@ class ReleasesTableCell extends Component {
   renderRevision(revision, isPending) {
     return (
       <Fragment>
-        <span className="p-release-data">
-          {isPending ? (
-            <span className="p-release-data__icon">&rarr;</span>
-          ) : (
-            isInDevmode(revision) && (
-              <span className="p-release-data__icon">
-                <DevmodeIcon revision={revision} showTooltip={false} />
-              </span>
-            )
-          )}
-          <span className="p-release-data__info">
-            <span className="p-release-data__title">{revision.revision}</span>
-            <span className="p-release-data__meta">{revision.version}</span>
-          </span>
+        {isPending ? (
+          <span className="p-release-data__icon">&rarr;</span>
+        ) : (
+          isInDevmode(revision) && (
+            <span className="p-release-data__icon">
+              <DevmodeIcon revision={revision} showTooltip={false} />
+            </span>
+          )
+        )}
+        <span className="p-release-data__info">
+          <span className="p-release-data__title">{revision.revision}</span>
+          <span className="p-release-data__meta">{revision.version}</span>
         </span>
         <span className="p-tooltip__message">
-          {isPending && "Pending release of "}
-          {revision.version} ({revision.revision})
+          {isPending && "Pending release of:"}
+          <div>
+            Revision: <b>{revision.revision}</b>
+          </div>
+          <div>
+            Version: <b>{revision.version}</b>
+          </div>
+
           {isInDevmode(revision) && (
             <Fragment>
-              <br />
-              {revision.confinement === "devmode"
-                ? "confinement: devmode"
-                : "grade: devel"}
+              {revision.confinement === "devmode" ? (
+                <div>
+                  Confinement: <b>devmode</b>
+                </div>
+              ) : (
+                <div>
+                  Grade: <b>devel</b>
+                </div>
+              )}
             </Fragment>
           )}
         </span>
@@ -62,10 +71,8 @@ class ReleasesTableCell extends Component {
   renderCloseChannel() {
     return (
       <Fragment>
-        <span className="p-release-data">
-          <span className="p-release-data__icon">&rarr;</span>
-          <em>close channel</em>
-        </span>
+        <span className="p-release-data__icon">&rarr;</span>
+        <em>close channel</em>
         <span className="p-tooltip__message">Pending channel close</span>
       </Fragment>
     );
@@ -74,30 +81,30 @@ class ReleasesTableCell extends Component {
   renderEmpty(isUnassigned, unassignedCount, trackingChannel) {
     return (
       <Fragment>
-        <span className="p-release-data">
-          {isUnassigned ? (
-            <Fragment>
-              <span className="p-release-data__icon">
-                <i className="p-icon--plus" />
+        {isUnassigned ? (
+          <Fragment>
+            <span className="p-release-data__icon">
+              <i className="p-icon--plus" />
+            </span>
+            <span className="p-release-data__info">
+              <span className="p-release-data__title">Add revision</span>
+              <span className="p-release-data__meta">
+                {unassignedCount} available
               </span>
-              <span className="p-release-data__info">
-                <span className="p-release-data__title">Add revision</span>
-                <span className="p-release-data__meta">
-                  {unassignedCount} available
-                </span>
-              </span>
-            </Fragment>
-          ) : (
-            <Fragment>
-              <span className="p-release-data__info--empty">
-                {trackingChannel ? "↑" : "–"}
-              </span>
-            </Fragment>
-          )}
-        </span>
+            </span>
+          </Fragment>
+        ) : (
+          <Fragment>
+            <span className="p-release-data__info--empty">
+              {trackingChannel ? "↑" : "–"}
+            </span>
+          </Fragment>
+        )}
         {!isUnassigned && (
           <span className="p-tooltip__message">
-            {trackingChannel ? `Tracking channel ${trackingChannel}` : "None"}
+            {trackingChannel
+              ? `Tracking channel ${trackingChannel}`
+              : "Nothing currently released"}
           </span>
         )}
       </Fragment>
@@ -148,7 +155,7 @@ class ReleasesTableCell extends Component {
         className={className}
         onClick={this.handleReleaseCellClick.bind(this, arch, risk, track)}
       >
-        <div className="p-tooltip p-tooltip--btm-center">
+        <div className="p-release-data p-tooltip p-tooltip--btm-center">
           {isChannelPendingClose
             ? this.renderCloseChannel()
             : currentRevision

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -1,0 +1,245 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import { UNASSIGNED } from "../constants";
+import { getTrackingChannel, getUnassignedRevisions } from "../releasesState";
+import DevmodeIcon, { isInDevmode } from "../devmodeIcon";
+
+import { toggleHistory } from "../actions/history";
+
+function getChannelName(track, risk) {
+  return risk === UNASSIGNED ? risk : `${track}/${risk}`;
+}
+
+class ReleasesTableCell extends Component {
+  getRevisionToDisplay(channelMap, nextReleases, channel, arch) {
+    const pendingRelease = nextReleases[channel] && nextReleases[channel][arch];
+    const currentRelease = channelMap[channel] && channelMap[channel][arch];
+
+    return pendingRelease || currentRelease;
+  }
+
+  handleReleaseCellClick(arch, risk, track, event) {
+    this.props.toggleHistoryPanel({ arch, risk, track });
+
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  undoClick(revision, track, risk, event) {
+    event.stopPropagation();
+    this.props.undoRelease(revision, `${track}/${risk}`);
+  }
+
+  renderRevisionCell(
+    track,
+    risk,
+    arch,
+    channelMap,
+    nextChannelReleases,
+    pendingCloses,
+    filters,
+    revisions
+  ) {
+    const channel = getChannelName(track, risk);
+
+    let thisRevision = this.getRevisionToDisplay(
+      channelMap,
+      nextChannelReleases,
+      channel,
+      arch
+    );
+    let thisPreviousRevision = channelMap[channel] && channelMap[channel][arch];
+
+    const hasPendingRelease =
+      thisRevision &&
+      (!thisPreviousRevision ||
+        thisPreviousRevision.revision !== thisRevision.revision);
+
+    const isChannelClosed = pendingCloses.includes(channel);
+    const isPending = hasPendingRelease || isChannelClosed;
+    const trackingChannel = getTrackingChannel(channelMap, track, risk, arch);
+
+    const isUnassigned = risk === UNASSIGNED;
+    const isActive = filters && filters.arch === arch && filters.risk === risk;
+    const isHighlighted = isPending || (isUnassigned && thisRevision);
+    const className = `p-releases-table__cell is-clickable ${
+      isUnassigned ? "is-unassigned" : ""
+    } ${isActive ? "is-active" : ""} ${isHighlighted ? "is-highlighted" : ""}`;
+    const unassignedCount = getUnassignedRevisions(revisions, arch).length;
+
+    return (
+      <div
+        className={className}
+        onClick={this.handleReleaseCellClick.bind(this, arch, risk, track)}
+      >
+        <div className="p-tooltip p-tooltip--btm-center">
+          <span className="p-release-data">
+            {thisPreviousRevision &&
+              isInDevmode(thisPreviousRevision) &&
+              !isPending && (
+                <span className="p-release-data__icon">
+                  <DevmodeIcon
+                    revision={thisPreviousRevision}
+                    showTooltip={false}
+                  />
+                </span>
+              )}
+
+            {isPending ? (
+              <Fragment>
+                <span className="p-release-data__icon">&rarr;</span>
+                {hasPendingRelease ? (
+                  <span className="p-release-data__info is-pending">
+                    <span className="p-release-data__version">
+                      {thisRevision.version}
+                    </span>
+                    <span className="p-release-data__revision">
+                      {thisRevision.revision}
+                    </span>
+                  </span>
+                ) : (
+                  <em>close channel</em>
+                )}
+              </Fragment>
+            ) : thisPreviousRevision ? (
+              <span className="p-release-data__info">
+                <span className="p-release-data__version">
+                  {thisPreviousRevision.version}
+                </span>
+                <span className="p-release-data__revision">
+                  {thisPreviousRevision.revision}
+                </span>
+              </span>
+            ) : isUnassigned ? (
+              <Fragment>
+                <span className="p-release-data__icon">
+                  <i className="p-icon--plus" />
+                </span>
+                <span className="p-release-data__info">
+                  <span className="p-release-data__version">Add revision</span>
+                  <span className="p-release-data__revision">
+                    {unassignedCount} available
+                  </span>
+                </span>
+              </Fragment>
+            ) : (
+              <span className="p-release-data__info--empty">
+                {trackingChannel ? "↑" : "–"}
+              </span>
+            )}
+          </span>
+
+          {(hasPendingRelease ||
+            isChannelClosed ||
+            trackingChannel ||
+            (thisPreviousRevision && isInDevmode(thisPreviousRevision))) && (
+            <span className="p-tooltip__message">
+              {thisPreviousRevision
+                ? `${thisPreviousRevision.version} (${
+                    thisPreviousRevision.revision
+                  })`
+                : hasPendingRelease || !trackingChannel
+                  ? "None"
+                  : `Tracking channel ${trackingChannel}`}
+              {hasPendingRelease && (
+                <span>
+                  {" "}
+                  &rarr; {`${thisRevision.version} (${thisRevision.revision})`}
+                </span>
+              )}
+              {isChannelClosed && (
+                <span>
+                  {" "}
+                  &rarr; <em>close channel</em>
+                </span>
+              )}
+              {thisPreviousRevision &&
+                isInDevmode(thisPreviousRevision) && (
+                  <Fragment>
+                    <br />
+                    {thisPreviousRevision.confinement === "devmode"
+                      ? "confinement: devmode"
+                      : "grade: devel"}
+                  </Fragment>
+                )}
+            </span>
+          )}
+        </div>
+        {hasPendingRelease && (
+          <div className="p-release-buttons">
+            <button
+              className="p-action-button p-tooltip p-tooltip--btm-center"
+              onClick={this.undoClick.bind(this, thisRevision, track, risk)}
+            >
+              <i className="p-icon--close" />
+              <span className="p-tooltip__message">
+                Cancel promoting this revision
+              </span>
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const {
+      track,
+      risk,
+      arch,
+      channelMap,
+      nextReleases,
+      pendingCloses,
+      filters,
+      revisions
+    } = this.props;
+    return this.renderRevisionCell(
+      track,
+      risk,
+      arch,
+      channelMap,
+      nextReleases,
+      pendingCloses,
+      filters,
+      revisions
+    );
+  }
+}
+
+ReleasesTableCell.propTypes = {
+  // state
+  channelMap: PropTypes.object,
+  filters: PropTypes.object,
+  revisions: PropTypes.object,
+  // actions
+  toggleHistoryPanel: PropTypes.func.isRequired,
+  // non-redux
+  nextReleases: PropTypes.object,
+  pendingCloses: PropTypes.array,
+  undoRelease: PropTypes.func.isRequired,
+  // props
+  track: PropTypes.string,
+  risk: PropTypes.string,
+  arch: PropTypes.string
+};
+
+const mapStateToProps = state => {
+  return {
+    channelMap: state.channelMap,
+    revisions: state.revisions,
+    filters: state.history.filters
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    toggleHistoryPanel: filters => dispatch(toggleHistory(filters))
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ReleasesTableCell);

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -39,10 +39,8 @@ class ReleasesTableCell extends Component {
             )
           )}
           <span className="p-release-data__info">
-            <span className="p-release-data__version">{revision.version}</span>
-            <span className="p-release-data__revision">
-              {revision.revision}
-            </span>
+            <span className="p-release-data__title">{revision.revision}</span>
+            <span className="p-release-data__meta">{revision.version}</span>
           </span>
         </span>
         <span className="p-tooltip__message">
@@ -83,8 +81,8 @@ class ReleasesTableCell extends Component {
                 <i className="p-icon--plus" />
               </span>
               <span className="p-release-data__info">
-                <span className="p-release-data__version">Add revision</span>
-                <span className="p-release-data__revision">
+                <span className="p-release-data__title">Add revision</span>
+                <span className="p-release-data__meta">
                   {unassignedCount} available
                 </span>
               </span>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -97,7 +97,7 @@
     }
 
     &.is-active {
-      .p-release-data__version {
+      .p-release-data__title {
         font-weight: bold;
       }
     }
@@ -129,8 +129,7 @@
   }
 
   .p-release-data__info {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    max-width: 100%;
     white-space: nowrap;
 
     &.is-pending {
@@ -148,10 +147,12 @@
     white-space: nowrap;
   }
 
-  .p-release-data__revision {
+  .p-release-data__meta {
     color: $color-mid-dark;
     display: block;
     font-size: .8em;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   // actions

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -79,7 +79,6 @@
     margin-left: 1px;
     max-width: 25.2%; // fill the whole space for 3 archs
     min-width: 100px;
-    padding: ($spv-intra - .1rem) $sph-intra;
     position: relative;
     transition-duration: 0s; // vf-animation doesn't allow to do that
 
@@ -100,6 +99,10 @@
       .p-release-data__title {
         font-weight: bold;
       }
+
+      .p-tooltip__message {
+        display: none;
+      }
     }
 
     &.is-highlighted {
@@ -109,6 +112,7 @@
 
   .p-releases-table__arch {
     background: none;
+    padding: ($spv-intra - .1rem) $sph-intra; // same as p-release-data
   }
 
   // cell contents (release info)
@@ -121,7 +125,10 @@
 
   .p-release-data {
     display: flex;
+    height: 100%;
     max-width: 100%;
+    padding: ($spv-intra - .1rem) $sph-intra; // p-releases-table__arch
+    padding-right: .6rem; // give it a bit more space for version ellipsis
   }
 
   .p-release-data__icon {


### PR DESCRIPTION
Fixes #1395 
Fixes #1396 

Swaps places of revision and version in releases table.
Improves the tooltips positioning and text (should show for whole table cell including padding, should always show when there is a revision released, etc).

Did also a bit of refactoring (extracting table cell rendering to separate component and splitting it into more manageable chunks). That's why the diff is significantly bigger then the bugs it fixes suggest.

Changes relevant to bugfixes are in commits: https://github.com/canonical-websites/snapcraft.io/commit/6742b3d10490b1e9f6df8549febf6fc0e2c2f185 https://github.com/canonical-websites/snapcraft.io/commit/42f16711b6d0a261e22f5b74fda9c37d68393aa7

### QA
- ./run or demo
- go to Releases page of any snap
- in releases table revision number should be on top with smaller version number below
- make sure long version numbers use ellipsis but are fully visible in the tooltip
- select some revisions, close some channel, release something, make sure there are no regressions (due to refactoring)

<img width="1016" alt="screen shot 2018-12-05 at 17 36 16" src="https://user-images.githubusercontent.com/83575/49529505-737b5900-f8b6-11e8-90ae-c5602ca8bd87.png">
