### PR TITLE
Fix issue with canceling pending release

### DIFF
--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -1,0 +1,23 @@
+export const PROMOTE_REVISION = "PROMOTE_REVISION";
+export const UNDO_RELEASE = "UNDO_RELEASE";
+export const CANCEL_PENDING_RELEASES = "CANCEL_PENDING_RELEASES";
+
+export function promoteRevision(revision, channel) {
+  return {
+    type: PROMOTE_REVISION,
+    payload: { revision, channel }
+  };
+}
+
+export function undoRelease(revision, channel) {
+  return {
+    type: UNDO_RELEASE,
+    payload: { revision, channel }
+  };
+}
+
+export function cancelPendingReleases() {
+  return {
+    type: CANCEL_PENDING_RELEASES
+  };
+}

--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -1,11 +1,33 @@
-export const PROMOTE_REVISION = "PROMOTE_REVISION";
+export const RELEASE_REVISION = "RELEASE_REVISION";
 export const UNDO_RELEASE = "UNDO_RELEASE";
 export const CANCEL_PENDING_RELEASES = "CANCEL_PENDING_RELEASES";
 
-export function promoteRevision(revision, channel) {
+export function releaseRevision(revision, channel) {
   return {
-    type: PROMOTE_REVISION,
+    type: RELEASE_REVISION,
     payload: { revision, channel }
+  };
+}
+
+import { getPendingChannelMap } from "../selectors";
+
+export function promoteRevision(revision, channel) {
+  return (dispatch, getState) => {
+    const pendingChannelMap = getPendingChannelMap(getState());
+
+    // compare given revision with released revisions in this arch and channel
+    const isAlreadyReleased = revision.architectures.every(arch => {
+      const releasedRevision =
+        pendingChannelMap[channel] && pendingChannelMap[channel][arch];
+
+      return (
+        releasedRevision && releasedRevision.revision === revision.revision
+      );
+    });
+
+    if (!isAlreadyReleased) {
+      dispatch(releaseRevision(revision, channel));
+    }
   };
 }
 

--- a/static/js/publisher/release/actions/pendingReleases.test.js
+++ b/static/js/publisher/release/actions/pendingReleases.test.js
@@ -1,0 +1,53 @@
+import {
+  PROMOTE_REVISION,
+  UNDO_RELEASE,
+  CANCEL_PENDING_RELEASES,
+  promoteRevision,
+  undoRelease,
+  cancelPendingReleases
+} from "./pendingReleases";
+
+describe("pendingReleases actions", () => {
+  const revision = { revision: 1, architectures: ["test64"] };
+  const channel = "test/edge";
+
+  describe("promoteRevision", () => {
+    it("should create an action to promote revision", () => {
+      expect(promoteRevision(revision, channel).type).toBe(PROMOTE_REVISION);
+    });
+
+    it("should supply a payload with revision", () => {
+      expect(promoteRevision(revision, channel).payload.revision).toEqual(
+        revision
+      );
+    });
+
+    it("should supply a payload with channel", () => {
+      expect(promoteRevision(revision, channel).payload.channel).toEqual(
+        channel
+      );
+    });
+  });
+
+  describe("undoRelease", () => {
+    it("should create an action to undo release of revision", () => {
+      expect(undoRelease(revision, channel).type).toBe(UNDO_RELEASE);
+    });
+
+    it("should supply a payload with revision", () => {
+      expect(undoRelease(revision, channel).payload.revision).toEqual(revision);
+    });
+
+    it("should supply a payload with channel", () => {
+      expect(undoRelease(revision, channel).payload.channel).toEqual(channel);
+    });
+  });
+
+  describe("cancelPendingReleases", () => {
+    it("should create an action to cancel pending releases", () => {
+      expect(cancelPendingReleases(revision, channel).type).toBe(
+        CANCEL_PENDING_RELEASES
+      );
+    });
+  });
+});

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -8,6 +8,8 @@ import DevmodeIcon, { isInDevmode } from "../devmodeIcon";
 
 import { toggleHistory } from "../actions/history";
 
+import { getPendingChannelMap } from "../selectors";
+
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
 }
@@ -117,7 +119,7 @@ class ReleasesTableCell extends Component {
       risk,
       arch,
       channelMap,
-      nextReleases,
+      pendingChannelMap,
       pendingCloses,
       filters,
       revisions
@@ -125,7 +127,8 @@ class ReleasesTableCell extends Component {
     const channel = getChannelName(track, risk);
 
     // current revision to show (released or pending)
-    let currentRevision = nextReleases[channel] && nextReleases[channel][arch];
+    let currentRevision =
+      pendingChannelMap[channel] && pendingChannelMap[channel][arch];
     // already released revision
     let releasedRevision = channelMap[channel] && channelMap[channel][arch];
 
@@ -189,10 +192,10 @@ ReleasesTableCell.propTypes = {
   channelMap: PropTypes.object,
   filters: PropTypes.object,
   revisions: PropTypes.object,
+  pendingChannelMap: PropTypes.object,
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
   // non-redux
-  nextReleases: PropTypes.object,
   pendingCloses: PropTypes.array,
   undoRelease: PropTypes.func.isRequired,
   // props
@@ -205,7 +208,8 @@ const mapStateToProps = state => {
   return {
     channelMap: state.channelMap,
     revisions: state.revisions,
-    filters: state.history.filters
+    filters: state.history.filters,
+    pendingChannelMap: getPendingChannelMap(state)
   };
 };
 

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -7,6 +7,7 @@ import { getTrackingChannel, getUnassignedRevisions } from "../releasesState";
 import DevmodeIcon, { isInDevmode } from "../devmodeIcon";
 
 import { toggleHistory } from "../actions/history";
+import { undoRelease } from "../actions/pendingReleases";
 
 import { getPendingChannelMap } from "../selectors";
 
@@ -195,9 +196,9 @@ ReleasesTableCell.propTypes = {
   pendingChannelMap: PropTypes.object,
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
+  undoRelease: PropTypes.func.isRequired,
   // non-redux
   pendingCloses: PropTypes.array,
-  undoRelease: PropTypes.func.isRequired,
   // props
   track: PropTypes.string,
   risk: PropTypes.string,
@@ -215,7 +216,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    toggleHistoryPanel: filters => dispatch(toggleHistory(filters))
+    toggleHistoryPanel: filters => dispatch(toggleHistory(filters)),
+    undoRelease: (revision, channel) => dispatch(undoRelease(revision, channel))
   };
 };
 

--- a/static/js/publisher/release/historyPanel.js
+++ b/static/js/publisher/release/historyPanel.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 
 import RevisionsList from "./revisionsList";
 
@@ -8,14 +7,9 @@ export default class HistoryPanel extends Component {
     return (
       <div className="p-history-panel">
         <div className="p-strip is-shallow">
-          <RevisionsList pendingReleases={this.props.pendingReleases} />
+          <RevisionsList />
         </div>
       </div>
     );
   }
 }
-
-HistoryPanel.propTypes = {
-  // state (non-redux)
-  pendingReleases: PropTypes.object.isRequired
-};

--- a/static/js/publisher/release/reducers/index.js
+++ b/static/js/publisher/release/reducers/index.js
@@ -2,12 +2,14 @@ import { combineReducers } from "redux";
 
 import channelMap from "./channelMap";
 import history from "./history";
+import pendingReleases from "./pendingReleases";
 import releases from "./releases";
 import revisions from "./revisions";
 
 const releasesReducers = combineReducers({
   channelMap,
   history,
+  pendingReleases,
   revisions,
   releases
 });

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -1,5 +1,5 @@
 import {
-  PROMOTE_REVISION,
+  RELEASE_REVISION,
   UNDO_RELEASE,
   CANCEL_PENDING_RELEASES
 } from "../actions/pendingReleases";
@@ -23,7 +23,7 @@ function removePendingRelease(state, revision, channel) {
   return state;
 }
 
-function promoteRevision(state = {}, revision, channel) {
+function releaseRevision(state = {}, revision, channel) {
   state = { ...state };
 
   // cancel any other pending release for the same channel in same architectures
@@ -69,8 +69,8 @@ function promoteRevision(state = {}, revision, channel) {
 // to prevent duplication of revison data
 export default function pendingReleases(state = {}, action) {
   switch (action.type) {
-    case PROMOTE_REVISION:
-      return promoteRevision(
+    case RELEASE_REVISION:
+      return releaseRevision(
         state,
         action.payload.revision,
         action.payload.channel

--- a/static/js/publisher/release/reducers/pendingReleases.js
+++ b/static/js/publisher/release/reducers/pendingReleases.js
@@ -1,0 +1,89 @@
+import {
+  PROMOTE_REVISION,
+  UNDO_RELEASE,
+  CANCEL_PENDING_RELEASES
+} from "../actions/pendingReleases";
+
+function removePendingRelease(state, revision, channel) {
+  if (state[revision.revision]) {
+    const channels = [...state[revision.revision].channels];
+
+    if (channels.includes(channel)) {
+      state = { ...state };
+      channels.splice(channels.indexOf(channel), 1);
+      state[revision.revision].channels = channels;
+    }
+
+    if (channels.length === 0) {
+      state = { ...state };
+      delete state[revision.revision];
+    }
+  }
+
+  return state;
+}
+
+function promoteRevision(state = {}, revision, channel) {
+  state = { ...state };
+
+  // cancel any other pending release for the same channel in same architectures
+  revision.architectures.forEach(arch => {
+    Object.keys(state).forEach(revisionId => {
+      const pendingRelease = state[revisionId];
+
+      if (
+        pendingRelease.channels.includes(channel) &&
+        pendingRelease.revision.architectures.includes(arch)
+      ) {
+        state = removePendingRelease(state, pendingRelease.revision, channel);
+      }
+    });
+  });
+
+  // promote revision to channel
+  let channels =
+    state[revision.revision] && state[revision.revision].channels
+      ? [...state[revision.revision].channels, channel]
+      : [channel];
+
+  // make sure channels are unique
+  channels = channels.filter((item, i, ar) => ar.indexOf(item) === i);
+
+  state[revision.revision] = {
+    revision,
+    channels
+  };
+
+  return state;
+}
+// revisions to be released:
+// key is the id of revision to release
+// value is object containing release object and channels to release to
+// {
+//  <revisionId>: {
+//    revision: { revision: <revisionId>, version, ... },
+//    channels: [ ... ]
+//  }
+// }
+// TODO: remove `revision` from here, use only data from `revisions` state
+// to prevent duplication of revison data
+export default function pendingReleases(state = {}, action) {
+  switch (action.type) {
+    case PROMOTE_REVISION:
+      return promoteRevision(
+        state,
+        action.payload.revision,
+        action.payload.channel
+      );
+    case UNDO_RELEASE:
+      return removePendingRelease(
+        state,
+        action.payload.revision,
+        action.payload.channel
+      );
+    case CANCEL_PENDING_RELEASES:
+      return {};
+    default:
+      return state;
+  }
+}

--- a/static/js/publisher/release/reducers/pendingReleases.test.js
+++ b/static/js/publisher/release/reducers/pendingReleases.test.js
@@ -1,6 +1,6 @@
 import pendingReleases from "./pendingReleases";
 import {
-  PROMOTE_REVISION,
+  RELEASE_REVISION,
   UNDO_RELEASE,
   CANCEL_PENDING_RELEASES
 } from "../actions/pendingReleases";
@@ -10,9 +10,9 @@ describe("pendingReleases", () => {
     expect(pendingReleases(undefined, {})).toEqual({});
   });
 
-  describe("on PROMOTE_REVISION action", () => {
-    let promoteRevisionAction = {
-      type: PROMOTE_REVISION,
+  describe("on RELEASE_REVISION action", () => {
+    let releaseRevisionAction = {
+      type: RELEASE_REVISION,
       payload: {
         revision: { revision: 1, architectures: ["abc42", "test64"] },
         channel: "test/edge"
@@ -23,12 +23,12 @@ describe("pendingReleases", () => {
       const emptyState = {};
 
       it("should add promoted revision to state", () => {
-        const result = pendingReleases(emptyState, promoteRevisionAction);
+        const result = pendingReleases(emptyState, releaseRevisionAction);
 
         expect(result).toEqual({
           1: {
-            revision: promoteRevisionAction.payload.revision,
-            channels: [promoteRevisionAction.payload.channel]
+            revision: releaseRevisionAction.payload.revision,
+            channels: [releaseRevisionAction.payload.channel]
           }
         });
       });
@@ -46,16 +46,16 @@ describe("pendingReleases", () => {
       it("should add new channel to list of pending releases", () => {
         const result = pendingReleases(
           stateWithSamePendingRevision,
-          promoteRevisionAction
+          releaseRevisionAction
         );
 
         expect(result).toEqual({
           ...stateWithSamePendingRevision,
           1: {
-            revision: promoteRevisionAction.payload.revision,
+            revision: releaseRevisionAction.payload.revision,
             channels: [
               ...stateWithSamePendingRevision[1].channels,
-              promoteRevisionAction.payload.channel
+              releaseRevisionAction.payload.channel
             ]
           }
         });
@@ -79,14 +79,14 @@ describe("pendingReleases", () => {
       it("should add promoted revision to state", () => {
         const result = pendingReleases(
           stateWithPendingReleases,
-          promoteRevisionAction
+          releaseRevisionAction
         );
 
         expect(result).toEqual({
           ...stateWithPendingReleases,
           1: {
-            revision: promoteRevisionAction.payload.revision,
-            channels: [promoteRevisionAction.payload.channel]
+            revision: releaseRevisionAction.payload.revision,
+            channels: [releaseRevisionAction.payload.channel]
           }
         });
       });
@@ -114,13 +114,13 @@ describe("pendingReleases", () => {
       it("should add promoted revision to state", () => {
         const result = pendingReleases(
           stateWithPendingReleases,
-          promoteRevisionAction
+          releaseRevisionAction
         );
 
         expect(result).toMatchObject({
           1: {
-            revision: promoteRevisionAction.payload.revision,
-            channels: [promoteRevisionAction.payload.channel]
+            revision: releaseRevisionAction.payload.revision,
+            channels: [releaseRevisionAction.payload.channel]
           }
         });
       });
@@ -128,7 +128,7 @@ describe("pendingReleases", () => {
       it("should remove pending releases from same arch and channel", () => {
         const result = pendingReleases(
           stateWithPendingReleases,
-          promoteRevisionAction
+          releaseRevisionAction
         );
 
         expect(Object.keys(result)).not.toContain(4);

--- a/static/js/publisher/release/reducers/pendingReleases.test.js
+++ b/static/js/publisher/release/reducers/pendingReleases.test.js
@@ -1,0 +1,251 @@
+import pendingReleases from "./pendingReleases";
+import {
+  PROMOTE_REVISION,
+  UNDO_RELEASE,
+  CANCEL_PENDING_RELEASES
+} from "../actions/pendingReleases";
+
+describe("pendingReleases", () => {
+  it("should return the initial state", () => {
+    expect(pendingReleases(undefined, {})).toEqual({});
+  });
+
+  describe("on PROMOTE_REVISION action", () => {
+    let promoteRevisionAction = {
+      type: PROMOTE_REVISION,
+      payload: {
+        revision: { revision: 1, architectures: ["abc42", "test64"] },
+        channel: "test/edge"
+      }
+    };
+
+    describe("when state is empty", () => {
+      const emptyState = {};
+
+      it("should add promoted revision to state", () => {
+        const result = pendingReleases(emptyState, promoteRevisionAction);
+
+        expect(result).toEqual({
+          1: {
+            revision: promoteRevisionAction.payload.revision,
+            channels: [promoteRevisionAction.payload.channel]
+          }
+        });
+      });
+    });
+
+    describe("when this revision is pending release to different channel", () => {
+      const stateWithSamePendingRevision = {
+        // same revision in different channel
+        1: {
+          revision: { revision: 1, architectures: ["abc42", "test64"] },
+          channels: ["other/edge"]
+        }
+      };
+
+      it("should add new channel to list of pending releases", () => {
+        const result = pendingReleases(
+          stateWithSamePendingRevision,
+          promoteRevisionAction
+        );
+
+        expect(result).toEqual({
+          ...stateWithSamePendingRevision,
+          1: {
+            revision: promoteRevisionAction.payload.revision,
+            channels: [
+              ...stateWithSamePendingRevision[1].channels,
+              promoteRevisionAction.payload.channel
+            ]
+          }
+        });
+      });
+    });
+
+    describe("when other revisions have pending releases", () => {
+      const stateWithPendingReleases = {
+        // same architecture different channel
+        2: {
+          revision: { revision: 2, architectures: ["test64"] },
+          channels: ["other/edge"]
+        },
+        // same channel different architacture
+        3: {
+          revision: { revision: 3, architectures: ["armf"] },
+          channels: ["test/edge"]
+        }
+      };
+
+      it("should add promoted revision to state", () => {
+        const result = pendingReleases(
+          stateWithPendingReleases,
+          promoteRevisionAction
+        );
+
+        expect(result).toEqual({
+          ...stateWithPendingReleases,
+          1: {
+            revision: promoteRevisionAction.payload.revision,
+            channels: [promoteRevisionAction.payload.channel]
+          }
+        });
+      });
+    });
+
+    describe("when other release is pending in same arch and channel", () => {
+      const stateWithPendingReleases = {
+        // same architecture different channel
+        2: {
+          revision: { revision: 2, architectures: ["test64"] },
+          channels: ["other/edge"]
+        },
+        // same channel different architacture
+        3: {
+          revision: { revision: 3, architectures: ["armf"] },
+          channels: ["test/edge"]
+        },
+        // same architecture, same channel
+        4: {
+          revision: { revision: 3, architectures: ["test64"] },
+          channels: ["test/edge"]
+        }
+      };
+
+      it("should add promoted revision to state", () => {
+        const result = pendingReleases(
+          stateWithPendingReleases,
+          promoteRevisionAction
+        );
+
+        expect(result).toMatchObject({
+          1: {
+            revision: promoteRevisionAction.payload.revision,
+            channels: [promoteRevisionAction.payload.channel]
+          }
+        });
+      });
+
+      it("should remove pending releases from same arch and channel", () => {
+        const result = pendingReleases(
+          stateWithPendingReleases,
+          promoteRevisionAction
+        );
+
+        expect(Object.keys(result)).not.toContain(4);
+      });
+    });
+  });
+
+  describe("on UNDO_RELEASE action", () => {
+    const undoReleaseAction = {
+      type: UNDO_RELEASE,
+      payload: {
+        revision: { revision: 1, architectures: ["abc42", "test64"] },
+        channel: "test/edge"
+      }
+    };
+
+    describe("when state is empty", () => {
+      const emptyState = {};
+
+      it("should not change state if revision is not pending", () => {
+        const result = pendingReleases(emptyState, undoReleaseAction);
+
+        expect(result).toBe(emptyState);
+      });
+    });
+
+    describe("when revision has pending releases into different channels", () => {
+      const stateWithRevisionInOtherChannel = {
+        1: {
+          revision: { revision: 1, architectures: ["abc42", "test64"] },
+          channels: ["latest/beta", "other/stable"]
+        }
+      };
+
+      it("should not change the state", () => {
+        const result = pendingReleases(
+          stateWithRevisionInOtherChannel,
+          undoReleaseAction
+        );
+
+        expect(result).toBe(stateWithRevisionInOtherChannel);
+      });
+    });
+
+    describe("when revision has pending release into given channel", () => {
+      const stateWithRevisionInChannel = {
+        1: {
+          revision: { revision: 1, architectures: ["abc42", "test64"] },
+          channels: ["latest/beta", "test/edge", "other/stable"]
+        }
+      };
+
+      it("should remove given channel from pending releases", () => {
+        const result = pendingReleases(
+          stateWithRevisionInChannel,
+          undoReleaseAction
+        );
+
+        expect(result).toEqual({
+          1: {
+            ...stateWithRevisionInChannel[1],
+            channels: ["latest/beta", "other/stable"]
+          }
+        });
+      });
+    });
+
+    describe("when revision has pending release only into given channel", () => {
+      const stateWithRevisionInChannel = {
+        1: {
+          revision: { revision: 1, architectures: ["abc42", "test64"] },
+          channels: ["test/edge"]
+        }
+      };
+
+      it("should remove revision from the state", () => {
+        const result = pendingReleases(
+          stateWithRevisionInChannel,
+          undoReleaseAction
+        );
+
+        expect(result).toEqual({});
+      });
+    });
+  });
+
+  describe("on CANCEL_PENDING_RELEASES action", () => {
+    let cancelPendingReleasesAction = {
+      type: CANCEL_PENDING_RELEASES
+    };
+
+    describe("when state is empty", () => {
+      const emptyState = {};
+
+      it("should not change the state", () => {
+        const result = pendingReleases(emptyState, cancelPendingReleasesAction);
+
+        expect(result).toEqual(emptyState);
+      });
+    });
+
+    describe("when there are pending releases", () => {
+      const stateWithPendingReleases = {
+        1: {
+          revision: { revision: 1, architectures: ["abc42", "test64"] },
+          channels: ["latest/beta", "other/stable"]
+        }
+      };
+
+      it("should remove all pending releases", () => {
+        const result = pendingReleases(
+          stateWithPendingReleases,
+          cancelPendingReleasesAction
+        );
+
+        expect(result).toEqual({});
+      });
+    });
+  });
+});

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -381,8 +381,6 @@ class ReleasesController extends Component {
         <ReleasesTable
           // map all the state into props
           {...this.state}
-          // TODO: remove
-          pendingReleases={this.props.pendingReleases}
           // actions
           getNextReleasedChannels={this.getNextReleasedChannels.bind(this)}
           setCurrentTrack={this.setCurrentTrack.bind(this)}

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -103,7 +103,7 @@ class ReleasesController extends Component {
         const channels = pendingReleases[revision].channels;
 
         if (channels.includes(channel)) {
-          this.props.undoRelease(revision, channel);
+          this.props.undoRelease(pendingReleases[revision].revision, channel);
         }
       });
 
@@ -134,11 +134,6 @@ class ReleasesController extends Component {
     this.setState({
       error: null
     });
-  }
-
-  // TODO: remove, use action directly
-  undoRelease(revision, channel) {
-    this.props.undoRelease(revision, channel);
   }
 
   // TODO: remove when pendingCloses are moved to redux
@@ -380,8 +375,6 @@ class ReleasesController extends Component {
           promoteRevision={this.promoteRevision.bind(this)}
           // can be moved now (?) - together with getNextReleasedChannels
           promoteChannel={this.promoteChannel.bind(this)}
-          // can be moved now
-          undoRelease={this.undoRelease.bind(this)}
           // depends on pendingCloses
           clearPendingReleases={this.clearPendingReleases.bind(this)}
           // depends on pendingCloses

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -80,7 +80,7 @@ class ReleasesController extends Component {
 
     if (archRevisions) {
       Object.keys(archRevisions).forEach(arch => {
-        this.promoteRevision(archRevisions[arch], targetChannel);
+        this.props.promoteRevision(archRevisions[arch], targetChannel);
       });
     }
   }
@@ -113,34 +113,12 @@ class ReleasesController extends Component {
     });
   }
 
-  // TODO: move to action creator
-  promoteRevision(revision, channel) {
-    const releasedChannels = this.props.pendingChannelMap;
-
-    // compare given revision with released revisions in this arch and channel
-    const isAlreadyReleased = revision.architectures.every(arch => {
-      const releasedRevision =
-        releasedChannels[channel] && releasedChannels[channel][arch];
-
-      return (
-        releasedRevision && releasedRevision.revision === revision.revision
-      );
-    });
-
-    if (!isAlreadyReleased) {
-      this.props.promoteRevision(revision, channel);
-    }
-
-    this.setState({
-      error: null
-    });
-  }
-
   // TODO: remove when pendingCloses are moved to redux
   clearPendingReleases() {
     this.props.cancelPendingReleases();
     this.setState({
-      pendingCloses: []
+      pendingCloses: [],
+      error: null
     });
   }
 
@@ -327,7 +305,7 @@ class ReleasesController extends Component {
       };
     });
 
-    this.setState({ isLoading: true });
+    this.setState({ isLoading: true, error: null });
     this.fetchReleases(releases)
       .then(() => this.fetchCloses(pendingCloses))
       .then(() => this.fetchUpdatedReleasesHistory())
@@ -370,9 +348,6 @@ class ReleasesController extends Component {
           setCurrentTrack={this.setCurrentTrack.bind(this)}
           // triggers posting data to API
           releaseRevisions={this.releaseRevisions.bind(this)}
-          // TODO: move out to redux (?)
-          // depends on state of released revisoins
-          promoteRevision={this.promoteRevision.bind(this)}
           // can be moved now (?) - together with getNextReleasedChannels
           promoteChannel={this.promoteChannel.bind(this)}
           // depends on pendingCloses

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -19,10 +19,9 @@ import {
   undoRelease,
   cancelPendingReleases
 } from "./actions/pendingReleases";
-import { hasDevmodeRevisions } from "./selectors";
+import { hasDevmodeRevisions, getPendingChannelMap } from "./selectors";
 
 import {
-  getNextReleasedChannels,
   getArchsFromRevisionsMap,
   getTracksFromChannelMap,
   getRevisionsMap,
@@ -75,17 +74,8 @@ class ReleasesController extends Component {
     this.setState({ currentTrack: track });
   }
 
-  // get channel map data updated with any pending releases
-  // TODO: move to state/selector (when pendingReleases are moved)
-  getNextReleasedChannels() {
-    return getNextReleasedChannels(
-      this.props.releasedChannels,
-      this.props.pendingReleases
-    );
-  }
-
   promoteChannel(channel, targetChannel) {
-    const releasedChannels = this.getNextReleasedChannels();
+    const releasedChannels = this.props.pendingChannelMap;
     const archRevisions = releasedChannels[channel];
 
     if (archRevisions) {
@@ -125,7 +115,7 @@ class ReleasesController extends Component {
 
   // TODO: move to action creator
   promoteRevision(revision, channel) {
-    const releasedChannels = this.getNextReleasedChannels();
+    const releasedChannels = this.props.pendingChannelMap;
 
     // compare given revision with released revisions in this arch and channel
     const isAlreadyReleased = revision.architectures.every(arch => {
@@ -382,7 +372,6 @@ class ReleasesController extends Component {
           // map all the state into props
           {...this.state}
           // actions
-          getNextReleasedChannels={this.getNextReleasedChannels.bind(this)}
           setCurrentTrack={this.setCurrentTrack.bind(this)}
           // triggers posting data to API
           releaseRevisions={this.releaseRevisions.bind(this)}
@@ -415,6 +404,7 @@ ReleasesController.propTypes = {
   releasedChannels: PropTypes.object,
   hasDevmodeRevisions: PropTypes.bool,
   pendingReleases: PropTypes.object,
+  pendingChannelMap: PropTypes.object,
 
   closeChannelSuccess: PropTypes.func,
   releaseRevisionSuccess: PropTypes.func,
@@ -434,7 +424,8 @@ const mapStateToProps = state => {
     revisions: state.revisions,
     releasedChannels: state.channelMap,
     hasDevmodeRevisions: hasDevmodeRevisions(state),
-    pendingReleases: state.pendingReleases
+    pendingReleases: state.pendingReleases,
+    pendingChannelMap: getPendingChannelMap(state)
   };
 };
 

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -163,30 +163,7 @@ function getPendingRelease(pendingReleases, arch, channel) {
   return pendingRelease;
 }
 
-// get channel map data updated with any pending releases
-function getNextReleasedChannels(releasedChannels, pendingReleases) {
-  const nextReleaseData = JSON.parse(JSON.stringify(releasedChannels));
-
-  // for each release
-  Object.keys(pendingReleases).forEach(releasedRevision => {
-    pendingReleases[releasedRevision].channels.forEach(channel => {
-      const revision = pendingReleases[releasedRevision].revision;
-
-      if (!nextReleaseData[channel]) {
-        nextReleaseData[channel] = {};
-      }
-
-      revision.architectures.forEach(arch => {
-        nextReleaseData[channel][arch] = revision;
-      });
-    });
-  });
-
-  return nextReleaseData;
-}
-
 export {
-  getNextReleasedChannels,
   getPendingRelease,
   getUnassignedRevisions,
   getArchsFromRevisionsMap,

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -185,23 +185,6 @@ function getNextReleasedChannels(releasedChannels, pendingReleases) {
   return nextReleaseData;
 }
 
-// remove pending revisions from given channel
-function removePendingRelease(pendingReleases, revision, channel) {
-  if (pendingReleases[revision.revision]) {
-    const channels = pendingReleases[revision.revision].channels;
-
-    if (channels.includes(channel)) {
-      channels.splice(channels.indexOf(channel), 1);
-    }
-
-    if (channels.length === 0) {
-      delete pendingReleases[revision.revision];
-    }
-  }
-
-  return pendingReleases;
-}
-
 export {
   getNextReleasedChannels,
   getPendingRelease,
@@ -210,7 +193,6 @@ export {
   getTracksFromChannelMap,
   getTrackingChannel,
   getRevisionsMap,
-  removePendingRelease,
   initReleasesData,
   getReleaseDataFromChannelMap
 };

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -17,6 +17,7 @@ import HistoryPanel from "./historyPanel";
 import ReleasesTableCell from "./components/releasesTableCell";
 
 import { toggleHistory } from "./actions/history";
+import { promoteRevision } from "./actions/pendingReleases";
 
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
@@ -395,7 +396,9 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    toggleHistoryPanel: filters => dispatch(toggleHistory(filters))
+    toggleHistoryPanel: filters => dispatch(toggleHistory(filters)),
+    promoteRevision: (revision, channel) =>
+      dispatch(promoteRevision(revision, channel))
   };
 };
 

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -177,12 +177,7 @@ class ReleasesTable extends Component {
   }
 
   renderHistoryPanel() {
-    return (
-      <HistoryPanel
-        key="history-panel"
-        pendingReleases={this.props.pendingReleases}
-      />
-    );
+    return <HistoryPanel key="history-panel" />;
   }
 
   renderRows() {
@@ -364,6 +359,7 @@ ReleasesTable.propTypes = {
   isHistoryOpen: PropTypes.bool,
   filters: PropTypes.object,
   channelMap: PropTypes.object.isRequired,
+  pendingReleases: PropTypes.object.isRequired,
 
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
@@ -372,7 +368,6 @@ ReleasesTable.propTypes = {
   archs: PropTypes.array.isRequired,
   tracks: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired,
-  pendingReleases: PropTypes.object.isRequired,
   pendingCloses: PropTypes.array.isRequired,
   isLoading: PropTypes.bool.isRequired,
 
@@ -393,7 +388,8 @@ const mapStateToProps = state => {
     isHistoryOpen: state.history.isOpen,
     revisions: state.revisions,
     releases: state.releases,
-    channelMap: state.channelMap
+    channelMap: state.channelMap,
+    pendingReleases: state.pendingReleases
   };
 };
 

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -46,7 +46,6 @@ class ReleasesTable extends Component {
         risk={risk}
         arch={arch}
         pendingCloses={this.props.pendingCloses}
-        undoRelease={this.props.undoRelease}
       />
     );
   }
@@ -378,7 +377,6 @@ ReleasesTable.propTypes = {
   setCurrentTrack: PropTypes.func.isRequired,
   promoteRevision: PropTypes.func.isRequired,
   promoteChannel: PropTypes.func.isRequired,
-  undoRelease: PropTypes.func.isRequired,
   clearPendingReleases: PropTypes.func.isRequired,
   closeChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -212,6 +212,7 @@ RevisionsList.propTypes = {
   // state
   revisions: PropTypes.object.isRequired,
   filters: PropTypes.object,
+  pendingReleases: PropTypes.object.isRequired,
 
   // computed state (selectors)
   showAllColumns: PropTypes.bool,
@@ -221,10 +222,7 @@ RevisionsList.propTypes = {
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
-  selectRevision: PropTypes.func.isRequired,
-
-  // state (TODO: move to redux)
-  pendingReleases: PropTypes.object.isRequired // 1: get pending release
+  selectRevision: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
@@ -232,6 +230,7 @@ const mapStateToProps = state => {
     showAllColumns: !state.history.filters,
     filters: state.history.filters,
     revisions: state.revisions,
+    pendingReleases: state.pendingReleases,
     selectedRevisions: getSelectedRevisions(state),
     filteredReleaseHistory: getFilteredReleaseHistory(state),
     selectedArchitectures: getSelectedArchitectures(state)

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -71,3 +71,26 @@ export function hasDevmodeRevisions(state) {
     return Object.values(archReleases).some(isInDevmode);
   });
 }
+
+// get channel map data updated with any pending releases
+export function getPendingChannelMap(state) {
+  const { channelMap, pendingReleases } = state;
+  const pendingChannelMap = JSON.parse(JSON.stringify(channelMap));
+
+  // for each release
+  Object.keys(pendingReleases).forEach(releasedRevision => {
+    pendingReleases[releasedRevision].channels.forEach(channel => {
+      const revision = pendingReleases[releasedRevision].revision;
+
+      if (!pendingChannelMap[channel]) {
+        pendingChannelMap[channel] = {};
+      }
+
+      revision.architectures.forEach(arch => {
+        pendingChannelMap[channel][arch] = revision;
+      });
+    });
+  });
+
+  return pendingChannelMap;
+}

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -259,4 +259,58 @@ describe("getPendingChannelMap", () => {
       );
     });
   });
+
+  describe("when there are pending releases to other channels", () => {
+    const stateWithPendingReleases = {
+      channelMap: {
+        "test/edge": {
+          test64: { revision: 1 }
+        }
+      },
+      pendingReleases: {
+        2: {
+          revision: { revision: 2, architectures: ["test64"] },
+          channels: ["latest/stable"]
+        }
+      }
+    };
+
+    it("should return channel map with pending revisions added", () => {
+      expect(getPendingChannelMap(stateWithPendingReleases)).toEqual({
+        ...stateWithPendingReleases.channelMap,
+        "latest/stable": {
+          test64: {
+            ...stateWithPendingReleases.pendingReleases[2].revision
+          }
+        }
+      });
+    });
+  });
+
+  describe("when there are pending releases overriding existing releases", () => {
+    const stateWithPendingReleases = {
+      channelMap: {
+        "test/edge": {
+          test64: { revision: 1 }
+        }
+      },
+      pendingReleases: {
+        2: {
+          revision: { revision: 2, architectures: ["test64"] },
+          channels: ["test/edge"]
+        }
+      }
+    };
+
+    it("should return channel map with pending revisions", () => {
+      expect(getPendingChannelMap(stateWithPendingReleases)).toEqual({
+        ...stateWithPendingReleases.channelMap,
+        "test/edge": {
+          test64: {
+            ...stateWithPendingReleases.pendingReleases[2].revision
+          }
+        }
+      });
+    });
+  });
 });

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -3,6 +3,7 @@ import {
   getFilteredReleaseHistory,
   getSelectedRevisions,
   getSelectedArchitectures,
+  getPendingChannelMap,
   hasDevmodeRevisions
 } from "./index";
 
@@ -238,5 +239,24 @@ describe("hasDevmodeRevisions", () => {
 
   it("should be true if any revision has devel grade", () => {
     expect(hasDevmodeRevisions(stateWithGradeDevel)).toBe(true);
+  });
+});
+
+describe("getPendingChannelMap", () => {
+  describe("when there are no pending releases", () => {
+    const stateWithNoPendingReleases = {
+      channelMap: {
+        "test/edge": {
+          test64: { revision: 1 }
+        }
+      },
+      pendingReleases: {}
+    };
+
+    it("should return channel map as it is", () => {
+      expect(getPendingChannelMap(stateWithNoPendingReleases)).toEqual(
+        stateWithNoPendingReleases.channelMap
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #1409 

Makes sure canceling pending revisions is properly propagated to revision history component.
Moves `pendingReleases` data from component state into Redux as part of #1384

### QA
- ./run or demo
- go to Releases page of any snap
- promote some revisions or a channel
- click on a cell with pending release (yellow background)
- pending release should appear on top of history of given channel-architecture
- click X in the cell to cancel this release
- promoted release should disappear from the cell and from the top of history
- make sure other functions around releasing work as expected