### PR TITLE
Update history panel heading to emphasise architecture and channel names

### DIFF
--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -119,7 +119,11 @@ class RevisionsList extends Component {
 
     if (filters && filters.arch) {
       if (filters.risk === UNASSIGNED) {
-        title = `Unreleased revisions: ${filters.arch}`;
+        title = (
+          <Fragment>
+            Unreleased revisions for <b>{filters.arch}</b>
+          </Fragment>
+        );
 
         filteredRevisions = getUnassignedRevisions(
           this.props.revisions,
@@ -128,9 +132,14 @@ class RevisionsList extends Component {
       } else {
         // when listing any other (real) channel, show filtered release history
         isReleaseHistory = true;
-        title = `Releases history: ${filters.arch} – ${filters.track}/${
-          filters.risk
-        }`;
+        title = (
+          <Fragment>
+            Releases history for <b>{filters.arch}</b> in{" "}
+            <b>
+              {filters.track}/{filters.risk}
+            </b>
+          </Fragment>
+        );
 
         filteredRevisions = this.props.filteredReleaseHistory;
 


### PR DESCRIPTION
Fixes #1399

Updates history panel heading to emphasise architecture and channel names.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1413.run.demo.haus/
- go to Releases page of any snap with some released revisions
- click on any released version to open releases history
- Heading should say: "Releases history for [architecture] in [channel]" with architecture and channel names in bold

<img width="1022" alt="screen shot 2018-12-07 at 13 34 11" src="https://user-images.githubusercontent.com/83575/49648067-ce32c300-fa24-11e8-8fc5-9ebd3cdd350d.png">
