### PR TITLE
Highlight current channel and arch in releases table

### DIFF
--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -139,14 +139,25 @@ class ReleasesTable extends Component {
       }
     }
 
+    const channelName =
+      risk === UNASSIGNED ? <em>Unreleased revisions</em> : channel;
+
+    const filteredChannel =
+      this.props.filters &&
+      getChannelName(this.props.filters.track, this.props.filters.risk);
+
     return (
       <div
         className={`p-releases-table__row p-releases-table__row--channel p-releases-table__row--${risk}`}
         key={channel}
       >
         <div className="p-releases-channel">
-          <span className="p-releases-channel__name">
-            {risk === UNASSIGNED ? <em>Unreleased revisions</em> : channel}
+          <span
+            className={`p-releases-channel__name ${
+              filteredChannel === channel ? "is-active" : ""
+            }`}
+          >
+            {channelName}
           </span>
           <span className="p-releases-table__menus">
             {canBePromoted && (
@@ -315,7 +326,7 @@ class ReleasesTable extends Component {
   render() {
     const { archs, tracks } = this.props;
     const revisionsCount = Object.keys(this.props.revisions).length;
-
+    const filteredArch = this.props.filters && this.props.filters.arch;
     return (
       <Fragment>
         <div className="row">
@@ -329,7 +340,9 @@ class ReleasesTable extends Component {
               <div className="p-releases-channel" />
               {archs.map(arch => (
                 <div
-                  className="p-releases-table__cell p-releases-table__arch"
+                  className={`p-releases-table__cell p-releases-table__arch ${
+                    filteredArch === arch ? "is-active" : ""
+                  }`}
                   key={`${arch}`}
                 >
                   {arch}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -60,12 +60,18 @@
     display: flex;
     flex-shrink: 0;
     margin-right: $grid-gutter-width / 2;
-    width: 222px; // fixed width col-3
+    // TODO:
+    // width: 222px; // fixed width col-3
+    width: 230px; // temporary width until we merge menus into one
   }
 
   .p-releases-channel__name {
     flex-grow: 1;
     padding-top: ($spv-intra - .1rem);
+
+    &.is-active {
+      font-weight: bold;
+    }
   }
 
   // release cell
@@ -112,7 +118,12 @@
 
   .p-releases-table__arch {
     background: none;
+    border: 0;
     padding: ($spv-intra - .1rem) $sph-intra; // same as p-release-data
+
+    &.is-active {
+      font-weight: bold;
+    }
   }
 
   // cell contents (release info)


### PR DESCRIPTION
Fixes #1397 

Highlights currently open channel and architecture in releases table

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1414.run.demo.haus/
- go to Releases page of any snap
- click on released version to open release history
- currently open channel name and arch should be highlighted (in bold)
<img width="1028" alt="screen shot 2018-12-10 at 16 07 27" src="https://user-images.githubusercontent.com/83575/49741001-bd3cb880-fc95-11e8-9661-f9ed9f296e77.png">

