### PR TITLE
Bring back the MacOS instructions, now that snapcraft 3.0.1 is out

### DIFF
--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -11,7 +11,6 @@
       <div class="col-8">
         <ol class="p-list-step has-margin">
           {% for step in steps %}
-            {% if not loop.last %}
               <li class="p-list-step__item">
                 <h4 class="p-list-step__title">
                   <span class="p-list-step__bullet">{{ loop.index }}</span>
@@ -27,7 +26,6 @@
                   {% endif %}
                 {% endif %}
               </li>
-            {% endif %}
           {% endfor %}
           {% for step in steps %}
             {% if loop.last and step.warning %}

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -18,7 +18,7 @@
           </header>
           <span>Linux</span>
         </a>
-        <span class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center is-disabled" data-os="macos">
+        <span class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center js-os-select" data-os="macos">
           <header class="p-card__header">
             <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="">
           </header>

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -17,24 +17,23 @@
                 {{ step.action|safe }}
               </h4>
               {% if step.command %}
-                {% set snippet_value = step.command %}
-                {% set snippet_id = loop.index %}
-                {% if snippet_value.count('\n') == 0 %}
-                  {% include "/partials/_code-snippet.html" %}
-                {% else %}
-                  {% include "/partials/_code-snippet-multi.html" %}
-                {% endif %}
+              {% set snippet_value = step.command %}
+              {% set snippet_id = loop.index %}
+              {% if snippet_value.count('\n') == 0 %}
+              {% include "/partials/_code-snippet.html" %}
+              {% else %}
+              {% include "/partials/_code-snippet-multi.html" %}
               {% endif %}
+              {% endif %}
+              {% if step.warning %}
+                  <div class="p-notification--caution">
+                    <p class="p-notification__response">
+                      {{ step.warning|safe }}
+                    </p>
+                  </div>
+                {% endif %}
             </li>
           {% endfor %}
-          {% if os.startswith('macos') %}
-            <div class="p-notification--caution">
-              <p class="p-notification__response">
-                <span class="p-notification__status"></span>
-                You should change any instance of <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name).
-              </p>
-            </div>
-          {% endif %}
         </ol>
       </div>
     </div>

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -17,13 +17,13 @@
                 {{ step.action|safe }}
               </h4>
               {% if step.command %}
-              {% set snippet_value = step.command %}
-              {% set snippet_id = loop.index %}
-              {% if snippet_value.count('\n') == 0 %}
-              {% include "/partials/_code-snippet.html" %}
-              {% else %}
-              {% include "/partials/_code-snippet-multi.html" %}
-              {% endif %}
+                {% set snippet_value = step.command %}
+                {% set snippet_id = loop.index %}
+                {% if snippet_value.count('\n') == 0 %}
+                  {% include "/partials/_code-snippet.html" %}
+                {% else %}
+                  {% include "/partials/_code-snippet-multi.html" %}
+                {% endif %}
               {% endif %}
               {% if step.warning %}
                   <div class="p-notification--caution">

--- a/webapp/first_snap/content/golang/build.yaml
+++ b/webapp/first_snap/content/golang/build.yaml
@@ -9,7 +9,7 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-httplab-{name}
+      command: test-httplab-{name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>test-httplab-{name}</code>)
   manual:
@@ -22,7 +22,7 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-httplab-{name}
+      command: test-httplab-{name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>test-httplab-{name}</code>)
 macos:
@@ -30,7 +30,7 @@ macos:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
     - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command:  |
+      command: |
         brew install squashfs
         unsquashfs -l *.snap
   manual:

--- a/webapp/first_snap/content/golang/test.yaml
+++ b/webapp/first_snap/content/golang/test.yaml
@@ -1,13 +1,16 @@
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
-  - action: Return to the directory containing the snapcraft.yaml and map it into the virtual machine
+  - action: Return to the directory containing the .snap file and copy it into the virtual machine
     command: 'multipass copy-files *.snap testvm:'
-  - action: Connect to the virtual machine using Multipass
+  - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous
+    command: sudo snap install --dangerous *.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    command: test-httplab-{name}
+    warning: You should change <code>httplab</code> to <code>test-httplab-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    command: httplab
+  - action: Exit the virtual machine
+    command: exit

--- a/webapp/first_snap/content/python/build.yaml
+++ b/webapp/first_snap/content/python/build.yaml
@@ -30,7 +30,7 @@ macos:
     - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
       command: snapcraft
     - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
-      command:  |
+      command: |
         brew install squashfs
         unsquashfs -l *.snap
   manual:

--- a/webapp/first_snap/content/python/test.yaml
+++ b/webapp/first_snap/content/python/test.yaml
@@ -1,13 +1,16 @@
 macos:
   - action: Create a Linux virtual machine for testing snaps
     command: multipass launch -n testvm
-  - action: Return to the directory containing the snapcraft.yaml and map it into the virtual machine
-    command: 'multipass copy-files *.snap testvm:'
-  - action: Connect to the virtual machine using Multipass
+  - action: Return to the directory containing the .snap file and copy it into the virtual machine
+    command: 'multipass copy-files offlineimap*.snap testvm:'
+  - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous
+    command: sudo snap install --dangerous offlineimap*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine
-    command: test-offlineimap-{name}
+    warning: You should change <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    command: offlineimap -h
+  - action: Exit the virtual machine
+    command: exit

--- a/webapp/first_snap/views.py
+++ b/webapp/first_snap/views.py
@@ -107,6 +107,7 @@ def get_test(language, operating_system):
         converted_steps.append(
             {
                 "action": action,
+                "warning": step["warning"] if "warning" in step else None,
                 "command": step["command"] if "command" in step else None,
             }
         )


### PR DESCRIPTION
Snapcraft is now working on MacOS without any fiddling, so let's re-enable the MacOS flow. I've fixed a few things along the way and cleaned up the text.