### PR TITLE
Pass feature snaps to store view

### DIFF
--- a/tests/store/tests_get_store_view.py
+++ b/tests/store/tests_get_store_view.py
@@ -1,0 +1,119 @@
+import responses
+from flask_testing import TestCase
+from webapp.app import create_app
+
+
+class GetStoreViewTest(TestCase):
+    render_templates = False
+
+    def setUp(self):
+        self.categories_api_url = "".join(
+            ["https://api.snapcraft.io/api/v1/", "snaps/sections"]
+        )
+        self.featured_snaps_api_url = "".join(
+            [
+                "https://api.snapcraft.io/api/v1/",
+                "snaps/search",
+                "?confinement=strict,classic&section=featured&scope=wide",
+                "&fields=package_name,title,icon_url",
+            ]
+        )
+        self.endpoint_url = "/store"
+
+    def create_app(self):
+        app = create_app(testing=True)
+        app.secret_key = "secret_key"
+        app.config["WTF_CSRF_METHODS"] = []
+
+        return app
+
+    @responses.activate
+    def test_get_store_view(self):
+        payload_categories = {}
+        payload_featured_snaps = {}
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.categories_api_url,
+                json=payload_categories,
+                status=200,
+            )
+        )
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.featured_snaps_api_url,
+                json=payload_featured_snaps,
+                status=200,
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 2
+        assert response.status_code == 200
+
+        self.assert_template_used("store/store.html")
+
+    @responses.activate
+    def test_get_store_view_fail_categories(self):
+        payload_categories = {}
+        payload_featured_snaps = {}
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.categories_api_url,
+                json=payload_categories,
+                status=500,
+            )
+        )
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.featured_snaps_api_url,
+                json=payload_featured_snaps,
+                status=200,
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 2
+        assert response.status_code == 502
+
+        self.assert_template_used("store/store.html")
+
+    @responses.activate
+    def test_get_store_view_fail_featured_snaps(self):
+        payload_categories = {}
+        payload_featured_snaps = {}
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.categories_api_url,
+                json=payload_categories,
+                status=200,
+            )
+        )
+
+        responses.add(
+            responses.Response(
+                method="GET",
+                url=self.featured_snaps_api_url,
+                json=payload_featured_snaps,
+                status=500,
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 2
+        assert response.status_code == 200
+
+        self.assert_template_used("store/store.html")
+        self.assert_context("featured_snaps", [])

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -121,7 +121,6 @@ def store_blueprint(store_query=None, testing=False):
             page = floor(offset / size) + 1
 
         error_info = {}
-        featured_snaps = []
         categories_results = []
         searched_results = []
 
@@ -152,15 +151,6 @@ def store_blueprint(store_query=None, testing=False):
             ),
         )
 
-        if not snaps_results:
-            featured_snaps_results = []
-            try:
-                featured_snaps_results = api.get_featured_snaps()
-            except ApiError as api_error:
-                status_code, error_info = _handle_errors(api_error)
-
-            featured_snaps = logic.get_searched_snaps(featured_snaps_results)
-
         context = {
             "query": snap_searched,
             "category": snap_category,
@@ -168,7 +158,6 @@ def store_blueprint(store_query=None, testing=False):
             "categories": categories,
             "snaps": snaps_results,
             "links": links,
-            "featured_snaps": featured_snaps,
             "error_info": error_info,
         }
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -66,10 +66,18 @@ def store_blueprint(store_query=None, testing=False):
 
         categories = logic.get_categories(categories_results)
 
+        try:
+            featured_snaps_results = api.get_featured_snaps()
+        except ApiError as api_error:
+            featured_snaps_results = []
+
+        featured_snaps = logic.get_searched_snaps(featured_snaps_results)
+
         return (
             flask.render_template(
                 "store/store.html",
                 categories=categories,
+                featured_snaps=featured_snaps,
                 error_info=error_info,
             ),
             status_code,


### PR DESCRIPTION
# Summary

- we use to diplay feature snaps to the store page when no snap was found, not anymore. So removed the api call to get feature snaps
- Pass feature snaps to be able to diplay faster snaps on the store page  instead of having a long list of loaders

# QA

- `./run`
- http://127.0.0.1:8004/store
- Should still work
- http://127.0.0.1:8004/search?category=&q=asdfasdfasdf
- Page should still work as usual