### PR TITLE
Updates to releases confirmation

### DIFF
--- a/static/js/publisher/release/actions/history.test.js
+++ b/static/js/publisher/release/actions/history.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
-export const mockStore = configureMockStore([thunk]);
+const mockStore = configureMockStore([thunk]);
 
 import {
   OPEN_HISTORY,

--- a/static/js/publisher/release/actions/pendingCloses.js
+++ b/static/js/publisher/release/actions/pendingCloses.js
@@ -1,0 +1,8 @@
+export const CLOSE_CHANNEL = "CLOSE_CHANNEL";
+
+export function closeChannel(channel) {
+  return {
+    type: CLOSE_CHANNEL,
+    payload: { channel }
+  };
+}

--- a/static/js/publisher/release/actions/pendingCloses.test.js
+++ b/static/js/publisher/release/actions/pendingCloses.test.js
@@ -1,0 +1,15 @@
+import { CLOSE_CHANNEL, closeChannel } from "./pendingCloses";
+
+describe("pendingCloses actions", () => {
+  const channel = "test/edge";
+
+  describe("closeChannel", () => {
+    it("should create an action to close a channel", () => {
+      expect(closeChannel(channel).type).toBe(CLOSE_CHANNEL);
+    });
+
+    it("should supply a payload with channel", () => {
+      expect(closeChannel(channel).payload.channel).toEqual(channel);
+    });
+  });
+});

--- a/static/js/publisher/release/actions/pendingReleases.js
+++ b/static/js/publisher/release/actions/pendingReleases.js
@@ -31,6 +31,19 @@ export function promoteRevision(revision, channel) {
   };
 }
 
+export function promoteChannel(channel, targetChannel) {
+  return (dispatch, getState) => {
+    const pendingChannelMap = getPendingChannelMap(getState());
+    const pendingInChannel = pendingChannelMap[channel];
+
+    if (pendingInChannel) {
+      Object.values(pendingInChannel).forEach(revision => {
+        dispatch(promoteRevision(revision, targetChannel));
+      });
+    }
+  };
+}
+
 export function undoRelease(revision, channel) {
   return {
     type: UNDO_RELEASE,

--- a/static/js/publisher/release/actions/pendingReleases.test.js
+++ b/static/js/publisher/release/actions/pendingReleases.test.js
@@ -11,6 +11,7 @@ import {
   CANCEL_PENDING_RELEASES,
   releaseRevision,
   promoteRevision,
+  promoteChannel,
   undoRelease,
   cancelPendingReleases
 } from "./pendingReleases";
@@ -53,7 +54,7 @@ describe("pendingReleases actions", () => {
     });
 
     describe("when revision is already released in this arch and channel", () => {
-      const stateWithReleasedRevsion = {
+      const stateWithReleasedRevision = {
         ...initialState,
         channelMap: {
           "test/edge": {
@@ -63,12 +64,62 @@ describe("pendingReleases actions", () => {
       };
 
       it("should not dispatch RELEASE_REVISION action", () => {
-        const store = mockStore(stateWithReleasedRevsion);
+        const store = mockStore(stateWithReleasedRevision);
 
         store.dispatch(promoteRevision(revision, channel));
 
         const actions = store.getActions();
         expect(actions).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("promoteChannel", () => {
+    const targetChannel = "test/stable";
+
+    describe("when nothing is released yet", () => {
+      it("should not dispatch RELEASE_REVISION action", () => {
+        const store = mockStore(initialState);
+
+        store.dispatch(promoteChannel(channel, targetChannel));
+
+        const actions = store.getActions();
+        expect(actions).toHaveLength(0);
+      });
+    });
+
+    describe("when revisions are in source channel", () => {
+      const revision2 = { revision: 2, architectures: ["abc42"] };
+      const stateWithReleasedRevisions = {
+        ...initialState,
+        channelMap: {
+          "test/edge": {
+            test64: { ...revision },
+            abc42: { ...revision2 }
+          }
+        }
+      };
+
+      it("should dispatch RELEASE_REVISION for each revision to promote", () => {
+        const store = mockStore(stateWithReleasedRevisions);
+
+        store.dispatch(promoteChannel(channel, targetChannel));
+
+        const actions = store.getActions();
+        expect(actions).toContainEqual({
+          type: RELEASE_REVISION,
+          payload: {
+            revision,
+            channel: targetChannel
+          }
+        });
+        expect(actions).toContainEqual({
+          type: RELEASE_REVISION,
+          payload: {
+            revision: revision2,
+            channel: targetChannel
+          }
+        });
       });
     });
   });

--- a/static/js/publisher/release/actions/pendingReleases.test.js
+++ b/static/js/publisher/release/actions/pendingReleases.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
-export const mockStore = configureMockStore([thunk]);
+const mockStore = configureMockStore([thunk]);
 
 import reducers from "../reducers";
 

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -1,0 +1,94 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+class ReleasesConfirm extends Component {
+  onRevertClick() {
+    this.props.clearPendingReleases();
+  }
+
+  onApplyClick() {
+    this.props.releaseRevisions();
+  }
+
+  render() {
+    const { pendingReleases, pendingCloses, isLoading } = this.props;
+    const releasesCount = Object.keys(pendingReleases).length;
+    const closesCount = pendingCloses.length;
+
+    return (
+      (releasesCount > 0 || closesCount > 0) && (
+        <div className="p-releases-confirm">
+          <span className="p-tooltip">
+            <i className="p-icon--question" />{" "}
+            {releasesCount > 0 && (
+              <span>
+                {releasesCount} revision
+                {releasesCount > 1 ? "s" : ""} to release.
+              </span>
+            )}{" "}
+            {closesCount > 0 && (
+              <span>
+                {closesCount} channel
+                {closesCount > 1 ? "s" : ""} to close.
+              </span>
+            )}
+            <span
+              className="p-tooltip__message"
+              role="tooltip"
+              id="default-tooltip"
+            >
+              {Object.keys(pendingReleases).map(revId => {
+                const release = pendingReleases[revId];
+
+                return (
+                  <span key={revId}>
+                    {release.revision.version} ({release.revision.revision}){" "}
+                    {release.revision.architectures.join(", ")} to{" "}
+                    {release.channels.join(", ")}
+                    {"\n"}
+                  </span>
+                );
+              })}
+              {closesCount > 0 && (
+                <span>Close channels: {pendingCloses.join(", ")}</span>
+              )}
+            </span>
+          </span>{" "}
+          <div className="p-releases-confirm__buttons">
+            <button
+              className="p-button--positive is-inline u-no-margin--bottom"
+              disabled={isLoading}
+              onClick={this.onApplyClick.bind(this)}
+            >
+              {isLoading ? "Loading..." : "Apply"}
+            </button>
+            <button
+              className="p-button--neutral u-no-margin--bottom"
+              onClick={this.onRevertClick.bind(this)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )
+    );
+  }
+}
+
+ReleasesConfirm.propTypes = {
+  pendingReleases: PropTypes.object.isRequired,
+  pendingCloses: PropTypes.array.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+
+  releaseRevisions: PropTypes.func.isRequired,
+  clearPendingReleases: PropTypes.func.isRequired
+};
+
+const mapStateToProps = state => {
+  return {
+    pendingReleases: state.pendingReleases
+  };
+};
+
+export default connect(mapStateToProps)(ReleasesConfirm);

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
@@ -19,42 +19,48 @@ class ReleasesConfirm extends Component {
     return (
       (releasesCount > 0 || closesCount > 0) && (
         <div className="p-releases-confirm">
-          <span className="p-tooltip">
-            <i className="p-icon--question" />{" "}
-            {releasesCount > 0 && (
-              <span>
-                {releasesCount} revision
-                {releasesCount > 1 ? "s" : ""} to release.
-              </span>
-            )}{" "}
-            {closesCount > 0 && (
-              <span>
-                {closesCount} channel
-                {closesCount > 1 ? "s" : ""} to close.
-              </span>
-            )}
-            <span
-              className="p-tooltip__message"
-              role="tooltip"
-              id="default-tooltip"
-            >
-              {Object.keys(pendingReleases).map(revId => {
-                const release = pendingReleases[revId];
+          {releasesCount > 0 && (
+            <Fragment>
+              <span className="p-tooltip">
+                <span className="p-help">
+                  {releasesCount} revision
+                  {releasesCount > 1 ? "s" : ""}
+                </span>
+                <span className="p-tooltip__message" role="tooltip">
+                  Release revisions:
+                  <br />
+                  {Object.keys(pendingReleases).map(revId => {
+                    const release = pendingReleases[revId];
 
-                return (
-                  <span key={revId}>
-                    {release.revision.version} ({release.revision.revision}){" "}
-                    {release.revision.architectures.join(", ")} to{" "}
-                    {release.channels.join(", ")}
-                    {"\n"}
-                  </span>
-                );
-              })}
-              {closesCount > 0 && (
-                <span>Close channels: {pendingCloses.join(", ")}</span>
-              )}
-            </span>
-          </span>{" "}
+                    return (
+                      <span key={revId}>
+                        <b>{release.revision.revision}</b> (
+                        {release.revision.version}){" "}
+                        {release.revision.architectures.join(", ")} to{" "}
+                        {release.channels.join(", ")}
+                        {"\n"}
+                      </span>
+                    );
+                  })}
+                </span>
+              </span>{" "}
+              to release.
+            </Fragment>
+          )}{" "}
+          {closesCount > 0 && (
+            <Fragment>
+              <span className="p-tooltip">
+                <span className="p-help">
+                  {closesCount} channel
+                  {closesCount > 1 ? "s" : ""}
+                </span>
+                <span className="p-tooltip__message" role="tooltip">
+                  Close channels: {pendingCloses.join(", ")}
+                </span>
+              </span>{" "}
+              to close.
+            </Fragment>
+          )}{" "}
           <div className="p-releases-confirm__buttons">
             <button
               className="p-button--positive is-inline u-no-margin--bottom"

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -2,9 +2,11 @@ import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
+import { cancelPendingReleases } from "../actions/pendingReleases";
+
 class ReleasesConfirm extends Component {
   onRevertClick() {
-    this.props.clearPendingReleases();
+    this.props.cancelPendingReleases();
   }
 
   onApplyClick() {
@@ -88,13 +90,23 @@ ReleasesConfirm.propTypes = {
   isLoading: PropTypes.bool.isRequired,
 
   releaseRevisions: PropTypes.func.isRequired,
-  clearPendingReleases: PropTypes.func.isRequired
+  cancelPendingReleases: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
   return {
+    pendingCloses: state.pendingCloses,
     pendingReleases: state.pendingReleases
   };
 };
 
-export default connect(mapStateToProps)(ReleasesConfirm);
+const mapDispatchToProps = dispatch => {
+  return {
+    cancelPendingReleases: () => dispatch(cancelPendingReleases())
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ReleasesConfirm);

--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -1,0 +1,50 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+class ReleasesHeading extends Component {
+  onTrackChange(event) {
+    this.props.setCurrentTrack(event.target.value);
+  }
+
+  renderTrackDropdown(tracks) {
+    return (
+      <form className="p-form p-form--inline u-float--right">
+        <div className="p-form__group">
+          <label htmlFor="track-dropdown" className="p-form__label">
+            Show revisions released in
+          </label>
+          <div className="p-form__control u-clearfix">
+            <select
+              id="track-dropdown"
+              onChange={this.onTrackChange.bind(this)}
+            >
+              {tracks.map(track => (
+                <option key={`${track}`} value={track}>
+                  {track}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </form>
+    );
+  }
+
+  render() {
+    const tracks = this.props.tracks;
+
+    return (
+      <div className="u-clearfix">
+        <h4 className="u-float--left">Releases available to install</h4>
+        {tracks.length > 1 && this.renderTrackDropdown(tracks)}
+      </div>
+    );
+  }
+}
+
+ReleasesHeading.propTypes = {
+  tracks: PropTypes.array.isRequired,
+  setCurrentTrack: PropTypes.func.isRequired
+};
+
+export default ReleasesHeading;

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -193,12 +193,11 @@ ReleasesTableCell.propTypes = {
   channelMap: PropTypes.object,
   filters: PropTypes.object,
   revisions: PropTypes.object,
+  pendingCloses: PropTypes.array,
   pendingChannelMap: PropTypes.object,
   // actions
   toggleHistoryPanel: PropTypes.func.isRequired,
   undoRelease: PropTypes.func.isRequired,
-  // non-redux
-  pendingCloses: PropTypes.array,
   // props
   track: PropTypes.string,
   risk: PropTypes.string,
@@ -210,6 +209,7 @@ const mapStateToProps = state => {
     channelMap: state.channelMap,
     revisions: state.revisions,
     filters: state.history.filters,
+    pendingCloses: state.pendingCloses,
     pendingChannelMap: getPendingChannelMap(state)
   };
 };

--- a/static/js/publisher/release/reducers/index.js
+++ b/static/js/publisher/release/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 
 import channelMap from "./channelMap";
 import history from "./history";
+import pendingCloses from "./pendingCloses";
 import pendingReleases from "./pendingReleases";
 import releases from "./releases";
 import revisions from "./revisions";
@@ -9,6 +10,7 @@ import revisions from "./revisions";
 const releasesReducers = combineReducers({
   channelMap,
   history,
+  pendingCloses,
   pendingReleases,
   revisions,
   releases

--- a/static/js/publisher/release/reducers/pendingCloses.js
+++ b/static/js/publisher/release/reducers/pendingCloses.js
@@ -1,5 +1,8 @@
 import { CLOSE_CHANNEL } from "../actions/pendingCloses";
-import { CANCEL_PENDING_RELEASES } from "../actions/pendingReleases";
+import {
+  RELEASE_REVISION,
+  CANCEL_PENDING_RELEASES
+} from "../actions/pendingReleases";
 
 // channels to be closed:
 // [ "track/risk", ... ]
@@ -10,6 +13,14 @@ export default function pendingCloses(state = [], action) {
         return state;
       }
       return [...state, action.payload.channel];
+    case RELEASE_REVISION:
+      if (!state.includes(action.payload.channel)) {
+        return state;
+      }
+      state = [...state];
+      // remove channel released to from closing channels
+      state.splice(state.indexOf(action.payload.channel), 1);
+      return state;
     case CANCEL_PENDING_RELEASES:
       return [];
     default:

--- a/static/js/publisher/release/reducers/pendingCloses.js
+++ b/static/js/publisher/release/reducers/pendingCloses.js
@@ -1,0 +1,18 @@
+import { CLOSE_CHANNEL } from "../actions/pendingCloses";
+import { CANCEL_PENDING_RELEASES } from "../actions/pendingReleases";
+
+// channels to be closed:
+// [ "track/risk", ... ]
+export default function pendingCloses(state = [], action) {
+  switch (action.type) {
+    case CLOSE_CHANNEL:
+      if (state.includes(action.payload.channel)) {
+        return state;
+      }
+      return [...state, action.payload.channel];
+    case CANCEL_PENDING_RELEASES:
+      return [];
+    default:
+      return state;
+  }
+}

--- a/static/js/publisher/release/reducers/pendingCloses.test.js
+++ b/static/js/publisher/release/reducers/pendingCloses.test.js
@@ -1,0 +1,83 @@
+import pendingCloses from "./pendingCloses";
+
+import { CLOSE_CHANNEL } from "../actions/pendingCloses";
+import { CANCEL_PENDING_RELEASES } from "../actions/pendingReleases";
+
+describe("pendingCloses", () => {
+  it("should return the initial state", () => {
+    expect(pendingCloses(undefined, {})).toEqual([]);
+  });
+
+  describe("on CLOSE_CHANNEL action", () => {
+    const channel = "test/edge";
+    const closeChannelAction = {
+      type: CLOSE_CHANNEL,
+      payload: { channel }
+    };
+
+    describe("when state is empty", () => {
+      const emptyState = [];
+
+      it("should add channel to pending closes", () => {
+        const result = pendingCloses(emptyState, closeChannelAction);
+
+        expect(result).toEqual([channel]);
+      });
+    });
+
+    describe("when other channels are pending close", () => {
+      const stateWithOtherPendingCloses = ["latest/candidate", "test/beta"];
+
+      it("should add channel to pending closes", () => {
+        const result = pendingCloses(
+          stateWithOtherPendingCloses,
+          closeChannelAction
+        );
+
+        expect(result).toEqual([...stateWithOtherPendingCloses, channel]);
+      });
+    });
+
+    describe("when the same channel is already pending close", () => {
+      const stateWithPendingCloses = ["test/edge", "latest/candidate"];
+
+      it("should not add duplicated channel to pending closes", () => {
+        const result = pendingCloses(
+          stateWithPendingCloses,
+          closeChannelAction
+        );
+
+        expect(result).toEqual(stateWithPendingCloses);
+      });
+    });
+  });
+
+  describe("on CANCEL_PENDING_RELEASES action", () => {
+    let cancelPendingReleasesAction = {
+      type: CANCEL_PENDING_RELEASES
+    };
+
+    describe("when state is empty", () => {
+      const emptyState = [];
+
+      it("should not change the state", () => {
+        const result = pendingCloses(emptyState, cancelPendingReleasesAction);
+
+        expect(result).toEqual(emptyState);
+      });
+    });
+
+    describe("when there are pending closes", () => {
+      const stateWithPendingCloses = ["test/edge", "latest/candidate"];
+
+      it("should remove all pending releases", () => {
+        const result = pendingCloses(
+          stateWithPendingCloses,
+          cancelPendingReleasesAction
+        );
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+});

--- a/static/js/publisher/release/reducers/pendingCloses.test.js
+++ b/static/js/publisher/release/reducers/pendingCloses.test.js
@@ -1,7 +1,10 @@
 import pendingCloses from "./pendingCloses";
 
 import { CLOSE_CHANNEL } from "../actions/pendingCloses";
-import { CANCEL_PENDING_RELEASES } from "../actions/pendingReleases";
+import {
+  RELEASE_REVISION,
+  CANCEL_PENDING_RELEASES
+} from "../actions/pendingReleases";
 
 describe("pendingCloses", () => {
   it("should return the initial state", () => {
@@ -48,6 +51,52 @@ describe("pendingCloses", () => {
         );
 
         expect(result).toEqual(stateWithPendingCloses);
+      });
+    });
+  });
+
+  describe("on RELEASE_REVISION action", () => {
+    const releaseRevisionAction = {
+      type: RELEASE_REVISION,
+      payload: {
+        revision: { revision: 1, architectures: ["test64"] },
+        channel: "test/edge"
+      }
+    };
+
+    describe("when there are no closed channels", () => {
+      const emptyState = [];
+
+      it("should not change the state", () => {
+        const result = pendingCloses(emptyState, releaseRevisionAction);
+
+        expect(result).toBe(emptyState);
+      });
+    });
+
+    describe("when releasing to channel that is not pending close", () => {
+      const stateWithOtherPendingCloses = ["latest/candidate", "test/beta"];
+
+      it("should not change the state", () => {
+        const result = pendingCloses(
+          stateWithOtherPendingCloses,
+          releaseRevisionAction
+        );
+
+        expect(result).toBe(stateWithOtherPendingCloses);
+      });
+    });
+
+    describe("when releasing to channel that is pending close", () => {
+      const stateWithPendingCloses = ["test/edge", "latest/candidate"];
+
+      it("should remove pending close of the channel released to", () => {
+        const result = pendingCloses(
+          stateWithPendingCloses,
+          releaseRevisionAction
+        );
+
+        expect(result).toEqual(["latest/candidate"]);
       });
     });
   });

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -5,7 +5,8 @@ import "whatwg-fetch";
 
 import ReleasesTable from "./releasesTable";
 import Notification from "./notification";
-import ReleasesHeading from "./components/ReleasesHeading";
+import ReleasesHeading from "./components/releasesHeading";
+import ReleasesConfirm from "./components/releasesConfirm";
 
 import { updateRevisions } from "./actions/revisions";
 import { updateReleases } from "./actions/releases";
@@ -344,18 +345,22 @@ class ReleasesController extends Component {
             tracks={this.state.tracks}
             setCurrentTrack={this.setCurrentTrack.bind(this)}
           />
+          <ReleasesConfirm
+            pendingCloses={this.state.pendingCloses}
+            isLoading={this.state.isLoading}
+            // triggers posting data to API
+            releaseRevisions={this.releaseRevisions.bind(this)}
+            // depends on pendingCloses
+            clearPendingReleases={this.clearPendingReleases.bind(this)}
+          />
         </div>
 
         <ReleasesTable
           // map all the state into props
           {...this.state}
           // actions
-          // triggers posting data to API
-          releaseRevisions={this.releaseRevisions.bind(this)}
           // can be moved now (?) - together with getNextReleasedChannels
           promoteChannel={this.promoteChannel.bind(this)}
-          // depends on pendingCloses
-          clearPendingReleases={this.clearPendingReleases.bind(this)}
           // depends on pendingCloses
           closeChannel={this.closeChannel.bind(this)}
         />

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -5,6 +5,7 @@ import "whatwg-fetch";
 
 import ReleasesTable from "./releasesTable";
 import Notification from "./notification";
+import ReleasesHeading from "./components/ReleasesHeading";
 
 import { updateRevisions } from "./actions/revisions";
 import { updateReleases } from "./actions/releases";
@@ -339,13 +340,16 @@ class ReleasesController extends Component {
               .
             </Notification>
           )}
+          <ReleasesHeading
+            tracks={this.state.tracks}
+            setCurrentTrack={this.setCurrentTrack.bind(this)}
+          />
         </div>
 
         <ReleasesTable
           // map all the state into props
           {...this.state}
           // actions
-          setCurrentTrack={this.setCurrentTrack.bind(this)}
           // triggers posting data to API
           releaseRevisions={this.releaseRevisions.bind(this)}
           // can be moved now (?) - together with getNextReleasedChannels

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -271,6 +271,7 @@ ReleasesTable.propTypes = {
   pendingChannelMap: PropTypes.object,
 
   // actions
+  promoteRevision: PropTypes.func.isRequired,
   toggleHistoryPanel: PropTypes.func.isRequired,
 
   // state (non redux)
@@ -279,7 +280,6 @@ ReleasesTable.propTypes = {
   pendingCloses: PropTypes.array.isRequired,
 
   // actions (non redux)
-  promoteRevision: PropTypes.func.isRequired,
   promoteChannel: PropTypes.func.isRequired,
   closeChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -17,21 +17,14 @@ import HistoryPanel from "./historyPanel";
 import ReleasesTableCell from "./components/releasesTableCell";
 
 import { toggleHistory } from "./actions/history";
-import { promoteRevision } from "./actions/pendingReleases";
+import { promoteChannel } from "./actions/pendingReleases";
+import { closeChannel } from "./actions/pendingCloses";
 
 function getChannelName(track, risk) {
   return risk === UNASSIGNED ? risk : `${track}/${risk}`;
 }
 
 class ReleasesTable extends Component {
-  releaseClick(revision, track, risk) {
-    let targetRisk;
-    targetRisk = RISKS[RISKS.indexOf(risk) - 1];
-    if (targetRisk) {
-      this.props.promoteRevision(revision, `${track}/${targetRisk}`);
-    }
-  }
-
   handleShowRevisionsClick(event) {
     this.props.toggleHistoryPanel();
 
@@ -267,21 +260,18 @@ ReleasesTable.propTypes = {
   isHistoryOpen: PropTypes.bool,
   filters: PropTypes.object,
   channelMap: PropTypes.object.isRequired,
+  pendingCloses: PropTypes.array.isRequired,
 
   pendingChannelMap: PropTypes.object,
 
   // actions
-  promoteRevision: PropTypes.func.isRequired,
+  closeChannel: PropTypes.func.isRequired,
   toggleHistoryPanel: PropTypes.func.isRequired,
+  promoteChannel: PropTypes.func.isRequired,
 
   // state (non redux)
   archs: PropTypes.array.isRequired,
-  currentTrack: PropTypes.string.isRequired,
-  pendingCloses: PropTypes.array.isRequired,
-
-  // actions (non redux)
-  promoteChannel: PropTypes.func.isRequired,
-  closeChannel: PropTypes.func.isRequired
+  currentTrack: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => {
@@ -291,6 +281,7 @@ const mapStateToProps = state => {
     revisions: state.revisions,
     releases: state.releases,
     channelMap: state.channelMap,
+    pendingCloses: state.pendingCloses,
     pendingChannelMap: getPendingChannelMap(state)
   };
 };
@@ -298,8 +289,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     toggleHistoryPanel: filters => dispatch(toggleHistory(filters)),
-    promoteRevision: (revision, channel) =>
-      dispatch(promoteRevision(revision, channel))
+    promoteChannel: (channel, targetChannel) =>
+      dispatch(promoteChannel(channel, targetChannel)),
+    closeChannel: channel => dispatch(closeChannel(channel))
   };
 };
 

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -223,30 +223,6 @@ class ReleasesTable extends Component {
     return rows;
   }
 
-  renderTrackDropdown(tracks) {
-    return (
-      <form className="p-form p-form--inline u-float--right">
-        <div className="p-form__group">
-          <label htmlFor="track-dropdown" className="p-form__label">
-            Show revisions released in
-          </label>
-          <div className="p-form__control u-clearfix">
-            <select
-              id="track-dropdown"
-              onChange={this.onTrackChange.bind(this)}
-            >
-              {tracks.map(track => (
-                <option key={`${track}`} value={track}>
-                  {track}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </form>
-    );
-  }
-
   renderReleasesConfirm() {
     const { pendingReleases, pendingCloses, isLoading } = this.props;
     const releasesCount = Object.keys(pendingReleases).length;
@@ -311,10 +287,6 @@ class ReleasesTable extends Component {
     );
   }
 
-  onTrackChange(event) {
-    this.props.setCurrentTrack(event.target.value);
-  }
-
   onRevertClick() {
     this.props.clearPendingReleases();
   }
@@ -324,16 +296,12 @@ class ReleasesTable extends Component {
   }
 
   render() {
-    const { archs, tracks } = this.props;
+    const { archs } = this.props;
     const revisionsCount = Object.keys(this.props.revisions).length;
     const filteredArch = this.props.filters && this.props.filters.arch;
     return (
       <Fragment>
         <div className="row">
-          <div className="u-clearfix">
-            <h4 className="u-float--left">Releases available to install</h4>
-            {tracks.length > 1 && this.renderTrackDropdown(tracks)}
-          </div>
           {this.renderReleasesConfirm()}
           <div className="p-releases-table">
             <div className="p-releases-table__row p-releases-table__row--heading">
@@ -381,14 +349,12 @@ ReleasesTable.propTypes = {
 
   // state (non redux)
   archs: PropTypes.array.isRequired,
-  tracks: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired,
   pendingCloses: PropTypes.array.isRequired,
   isLoading: PropTypes.bool.isRequired,
 
   // actions (non redux)
   releaseRevisions: PropTypes.func.isRequired,
-  setCurrentTrack: PropTypes.func.isRequired,
   promoteRevision: PropTypes.func.isRequired,
   promoteChannel: PropTypes.func.isRequired,
   clearPendingReleases: PropTypes.func.isRequired,

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -223,78 +223,6 @@ class ReleasesTable extends Component {
     return rows;
   }
 
-  renderReleasesConfirm() {
-    const { pendingReleases, pendingCloses, isLoading } = this.props;
-    const releasesCount = Object.keys(pendingReleases).length;
-    const closesCount = pendingCloses.length;
-
-    return (
-      (releasesCount > 0 || closesCount > 0) && (
-        <div className="p-releases-confirm">
-          <span className="p-tooltip">
-            <i className="p-icon--question" />{" "}
-            {releasesCount > 0 && (
-              <span>
-                {releasesCount} revision
-                {releasesCount > 1 ? "s" : ""} to release.
-              </span>
-            )}{" "}
-            {closesCount > 0 && (
-              <span>
-                {closesCount} channel
-                {closesCount > 1 ? "s" : ""} to close.
-              </span>
-            )}
-            <span
-              className="p-tooltip__message"
-              role="tooltip"
-              id="default-tooltip"
-            >
-              {Object.keys(pendingReleases).map(revId => {
-                const release = pendingReleases[revId];
-
-                return (
-                  <span key={revId}>
-                    {release.revision.version} ({release.revision.revision}){" "}
-                    {release.revision.architectures.join(", ")} to{" "}
-                    {release.channels.join(", ")}
-                    {"\n"}
-                  </span>
-                );
-              })}
-              {closesCount > 0 && (
-                <span>Close channels: {pendingCloses.join(", ")}</span>
-              )}
-            </span>
-          </span>{" "}
-          <div className="p-releases-confirm__buttons">
-            <button
-              className="p-button--positive is-inline u-no-margin--bottom"
-              disabled={isLoading}
-              onClick={this.onApplyClick.bind(this)}
-            >
-              {isLoading ? "Loading..." : "Apply"}
-            </button>
-            <button
-              className="p-button--neutral u-no-margin--bottom"
-              onClick={this.onRevertClick.bind(this)}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )
-    );
-  }
-
-  onRevertClick() {
-    this.props.clearPendingReleases();
-  }
-
-  onApplyClick() {
-    this.props.releaseRevisions();
-  }
-
   render() {
     const { archs } = this.props;
     const revisionsCount = Object.keys(this.props.revisions).length;
@@ -302,7 +230,6 @@ class ReleasesTable extends Component {
     return (
       <Fragment>
         <div className="row">
-          {this.renderReleasesConfirm()}
           <div className="p-releases-table">
             <div className="p-releases-table__row p-releases-table__row--heading">
               <div className="p-releases-channel" />
@@ -340,7 +267,6 @@ ReleasesTable.propTypes = {
   isHistoryOpen: PropTypes.bool,
   filters: PropTypes.object,
   channelMap: PropTypes.object.isRequired,
-  pendingReleases: PropTypes.object.isRequired,
 
   pendingChannelMap: PropTypes.object,
 
@@ -351,13 +277,10 @@ ReleasesTable.propTypes = {
   archs: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired,
   pendingCloses: PropTypes.array.isRequired,
-  isLoading: PropTypes.bool.isRequired,
 
   // actions (non redux)
-  releaseRevisions: PropTypes.func.isRequired,
   promoteRevision: PropTypes.func.isRequired,
   promoteChannel: PropTypes.func.isRequired,
-  clearPendingReleases: PropTypes.func.isRequired,
   closeChannel: PropTypes.func.isRequired
 };
 
@@ -368,7 +291,6 @@ const mapStateToProps = state => {
     revisions: state.revisions,
     releases: state.releases,
     channelMap: state.channelMap,
-    pendingReleases: state.pendingReleases,
     pendingChannelMap: getPendingChannelMap(state)
   };
 };

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -210,6 +210,11 @@
 
   // HELPERS
 
+  .p-help {
+    border-bottom: 1px dashed $color-mid-dark;
+    cursor: help;
+  }
+
   .p-icon-button {
     padding: $spv-nudge - $px $sph-intra--condensed * 1.5 - ($px * 2);
 


### PR DESCRIPTION
Fixes #1398 
Fixes #1424 

- Removes (?) icon from release confirmation. Shows tooltips when hover over releases/closes count.
- Fixes the issue when promoting into channel pending close (#1424)
- Moves closed channels state into Redux

### QA
- ./run or demo
- go to Releases page of any snap
- promote some channel, close some channel
- There should be no (?) icon in confirmation box, hovering over 'X releases' or 'X closes' should show tooltips with details
- Try to reproduce issue #1424 (promote something into channel that is pending close) - it shouldn't be possible anymore

<img width="1029" alt="screen shot 2018-12-11 at 13 20 38" src="https://user-images.githubusercontent.com/83575/49800353-950d9200-fd47-11e8-8595-ce5efed1af8a.png">
