### PR TITLE
Update styling of devmode not to look like warning

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -46,25 +46,33 @@ class ReleasesTableCell extends Component {
         </span>
         <span className="p-tooltip__message">
           {isPending && "Pending release of:"}
-          <div>
+
+          <div className="p-tooltip__group">
             Revision: <b>{revision.revision}</b>
-          </div>
-          <div>
+            <br />
             Version: <b>{revision.version}</b>
+            {isInDevmode(revision) && (
+              <Fragment>
+                <br />
+                {revision.confinement === "devmode" ? (
+                  <Fragment>
+                    Confinement: <b>devmode</b>
+                  </Fragment>
+                ) : (
+                  <Fragment>
+                    Grade: <b>devel</b>
+                  </Fragment>
+                )}
+              </Fragment>
+            )}
           </div>
 
           {isInDevmode(revision) && (
-            <Fragment>
-              {revision.confinement === "devmode" ? (
-                <div>
-                  Confinement: <b>devmode</b>
-                </div>
-              ) : (
-                <div>
-                  Grade: <b>devel</b>
-                </div>
-              )}
-            </Fragment>
+            <div className="p-tooltip__group">
+              Revisions in devmode can’t be promoted
+              <br />
+              to stable or candidate channels.
+            </div>
           )}
         </span>
       </Fragment>

--- a/static/js/publisher/release/devmodeIcon.js
+++ b/static/js/publisher/release/devmodeIcon.js
@@ -12,7 +12,7 @@ export default function DevmodeIcon({ revision, showTooltip }) {
         className="p-tooltip p-tooltip--btm-center"
         aria-describedby={`revision-devmode-${revision.revision}`}
       >
-        <i className="p-icon--warning" />
+        <i className="p-icon--information" />
 
         {showTooltip && (
           <span

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -272,7 +272,7 @@ class ReleasesController extends Component {
             </Notification>
           )}
           {this.props.hasDevmodeRevisions && (
-            <Notification appearance="caution">
+            <Notification>
               Revisions in development mode cannot be released to stable or
               candidate channels.
               <br />

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -17,7 +17,7 @@ import {
   closeChannelSuccess
 } from "./actions/channelMap";
 import { undoRelease, cancelPendingReleases } from "./actions/pendingReleases";
-import { hasDevmodeRevisions, getPendingChannelMap } from "./selectors";
+import { getPendingChannelMap } from "./selectors";
 
 import {
   getArchsFromRevisionsMap,
@@ -271,22 +271,6 @@ class ReleasesController extends Component {
               {this.state.error}
             </Notification>
           )}
-          {this.props.hasDevmodeRevisions && (
-            <Notification>
-              Revisions in development mode cannot be released to stable or
-              candidate channels.
-              <br />
-              You can read more about{" "}
-              <a href="https://docs.snapcraft.io/t/snap-confinement/6233">
-                <code>devmode</code> confinement
-              </a>{" "}
-              and{" "}
-              <a href="https://docs.snapcraft.io/t/snapcraft-yaml-reference/4276">
-                <code>devel</code> grade
-              </a>
-              .
-            </Notification>
-          )}
           <ReleasesHeading
             tracks={this.state.tracks}
             setCurrentTrack={this.setCurrentTrack.bind(this)}
@@ -318,7 +302,6 @@ ReleasesController.propTypes = {
   isHistoryOpen: PropTypes.bool,
   revisionsFilters: PropTypes.object,
   releasedChannels: PropTypes.object,
-  hasDevmodeRevisions: PropTypes.bool,
   pendingCloses: PropTypes.array,
   pendingReleases: PropTypes.object,
   pendingChannelMap: PropTypes.object,
@@ -339,7 +322,6 @@ const mapStateToProps = state => {
     revisionsFilters: state.history.filters,
     revisions: state.revisions,
     releasedChannels: state.channelMap,
-    hasDevmodeRevisions: hasDevmodeRevisions(state),
     pendingCloses: state.pendingCloses,
     pendingReleases: state.pendingReleases,
     pendingChannelMap: getPendingChannelMap(state)

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -4,7 +4,8 @@ import { connect } from "react-redux";
 import distanceInWords from "date-fns/distance_in_words_strict";
 import format from "date-fns/format";
 
-import DevmodeIcon from "./devmodeIcon";
+import DevmodeIcon, { isInDevmode } from "./devmodeIcon";
+import Notification from "./notification";
 import { UNASSIGNED } from "./constants";
 
 import { closeHistory } from "./actions/history";
@@ -155,9 +156,10 @@ class RevisionsList extends Component {
       }
     }
 
+    const hasDevmodeRevisions = filteredRevisions.some(isInDevmode);
     return (
       <Fragment>
-        <div>
+        <div className="u-clearfix">
           <h4 className="u-float--left">{title}</h4>
           <a
             style={{ marginTop: "0.5rem" }}
@@ -166,6 +168,22 @@ class RevisionsList extends Component {
             className="p-icon--close u-float--right"
           />
         </div>
+        {hasDevmodeRevisions && (
+          <Notification>
+            Revisions in development mode cannot be released to stable or
+            candidate channels.
+            <br />
+            You can read more about{" "}
+            <a href="https://docs.snapcraft.io/t/snap-confinement/6233">
+              <code>devmode</code> confinement
+            </a>{" "}
+            and{" "}
+            <a href="https://docs.snapcraft.io/t/snapcraft-yaml-reference/4276">
+              <code>devel</code> grade
+            </a>
+            .
+          </Notification>
+        )}
         <table className="p-revisions-list">
           <thead>
             <tr>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -265,4 +265,8 @@
     cursor: not-allowed;
     opacity: .5;
   }
+
+  .p-tooltip__group {
+    margin-top: $sp-x-small;
+  }
 }


### PR DESCRIPTION
Fixes #1420 

Changes icon of devmode revisions and moves notification into history panel.

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1431.run.demo.haus/
- go to Releases page of a snap with devmode revisions
- devmode icon should be "info" [i] instead of warning
- open history panel of some channel - if any of the revisions in history is in devmode notification should appear with more information about devmode
- if any revision in history panel is not in devmode no warning should be shown

<img width="1019" alt="screen shot 2018-12-12 at 11 27 14" src="https://user-images.githubusercontent.com/83575/49863643-078e7880-fe01-11e8-821d-faf12799c4d9.png">
