### PR TITLE
Add video field to listing page

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -1,8 +1,9 @@
 import map from "./snap-details/map";
 import screenshots from "./snap-details/screenshots";
 import channelMap from "./snap-details/channelMap";
-import { storeCategories } from "./store-categories";
+import videos from "./snap-details/videos";
 import { snapDetailsPosts, seriesPosts } from "./snap-details/blog-posts";
+import { storeCategories } from "./store-categories";
 import { initFSFLanguageSelect } from "./fsf-language-select";
 import firstSnapFlow from "./first-snap-flow";
 
@@ -14,5 +15,6 @@ export {
   snapDetailsPosts,
   seriesPosts,
   initFSFLanguageSelect,
-  firstSnapFlow
+  firstSnapFlow,
+  videos
 };

--- a/static/js/public/snap-details/videos.js
+++ b/static/js/public/snap-details/videos.js
@@ -1,0 +1,30 @@
+function youtube(holderEl, url) {
+  const frame = document.createElement("iframe");
+  frame.id = "ytplayer";
+  frame.type = "text/html";
+  frame.width = 440;
+  frame.height = 248;
+  frame.src = `${url}?autoplay=0&origin=${window.location.href}`;
+  frame.setAttribute("frameborder", "0");
+  holderEl.appendChild(frame);
+}
+
+function videos(holderSelector) {
+  const holderEl = document.querySelector(holderSelector);
+
+  if (!holderEl) {
+    throw new Error("Video holder doesn't exist");
+  }
+
+  const videoType = holderEl.dataset.videoType;
+  const videoUrl = holderEl.dataset.videoUrl;
+
+  switch (videoType) {
+    case "youtube":
+      youtube(holderEl, videoUrl);
+      break;
+    default:
+  }
+}
+
+export default videos;

--- a/static/js/publisher/state.js
+++ b/static/js/publisher/state.js
@@ -12,6 +12,7 @@ const allowedKeys = [
   "public_metrics_blacklist",
   "whitelist_countries",
   "blacklist_countries",
+  "video_urls",
   "license"
 ];
 

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -13,11 +13,13 @@
 
     .p-carousel__item,
     .p-carousel__item--snap,
-    .p-carousel__item--screenshot {
+    .p-carousel__item--screenshot,
+    .p-carousel__item--video {
       box-sizing: border-box;
     }
 
-    .p-carousel__item--screenshot {
+    .p-carousel__item--screenshot,
+    .p-carousel__item--video {
       cursor: pointer;
 
       img,
@@ -26,7 +28,9 @@
         max-height: 248px;
         max-width: 100%;
       }
+    }
 
+    .p-carousel__item--screenshot {
       &:hover {
         &::after {
           background-color: $color-x-light;

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -216,6 +216,36 @@
 
         <div class="row">
           <div class="col-8">
+            <div class="p-form-validation {% if field_errors and field_errors['video_urls'] %}is-error{% endif %}">
+              <label>Video: </label>
+              <div class="p-form-validation__field">
+                <input
+                  class="p-form-validation__input"
+                  type="text"
+                  name="video_urls"
+                  value="{{ video_urls[0] }}"
+                />
+                {% if field_errors and field_errors['video_urls'] %}
+                <p class="p-form-validation__message">
+                  <strong>Error:</strong> {{ field_errors['video_urls'] }}
+                </p>
+                {% endif %}
+                <p class="p-form-help-text">
+                  Vimeo, YouTube or asciicinema url
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-strip is-shallow">
+          <div class="row">
+            <hr class="u-no-margin--bottom" />
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-8">
             <div class="p-form-validation {% if field_errors and field_errors['website'] %}is-error{% endif %}">
               <label>Developer website: </label>
               <div class="p-form-validation__field">

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -231,7 +231,7 @@
                 </p>
                 {% endif %}
                 <p class="p-form-help-text">
-                  Vimeo, YouTube or asciicinema url
+                  Vimeo, YouTube or asciicinema URL
                 </p>
               </div>
             </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -112,12 +112,12 @@
         <div class="p-carousel" id="js-snap-screenshots">
           <div class="swiper-container">
             <div class="swiper-wrapper">
-              <!--{% for video in videos %}-->
-                <!--<div class="p-carousel__item&#45;&#45;video swiper-slide">-->
-                  <!--<div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">-->
-                  <!--</div>-->
-                <!--</div>-->
-              <!--{% endfor %}-->
+              {# {% for video in videos %}
+                <div class="p-carousel__item--video swiper-slide">
+                  <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">
+                  </div>
+                </div>
+              {% endfor %} #}
               {% for screenshot in screenshots %}
                 <div class="p-carousel__item--screenshot swiper-slide">
                   {% if screenshot.endswith('.gif') %}

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -106,12 +106,18 @@
     {% include "store/snap-details/_channel_map.html" %}
   {% endif %}
 
-  {% if screenshots %}
+  {% if screenshots or videos %}
     <div class="p-strip is-shallow">
       <div class="row">
         <div class="p-carousel" id="js-snap-screenshots">
           <div class="swiper-container">
             <div class="swiper-wrapper">
+              {% for video in videos %}
+                <div class="p-carousel__item--video swiper-slide">
+                  <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">
+                  </div>
+                </div>
+              {% endfor %}
               {% for screenshot in screenshots %}
                 <div class="p-carousel__item--screenshot swiper-slide">
                   {% if screenshot.endswith('.gif') %}
@@ -247,6 +253,12 @@
     Raven.context(function () {
       try {
         snapcraft.public.screenshots('#js-snap-screenshots');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      try {
+        snapcraft.public.videos('.js-video-slide');
       } catch(e) {
         Raven.captureException(e);
       }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -106,18 +106,18 @@
     {% include "store/snap-details/_channel_map.html" %}
   {% endif %}
 
-  {% if screenshots or videos %}
+  {% if screenshots %}
     <div class="p-strip is-shallow">
       <div class="row">
         <div class="p-carousel" id="js-snap-screenshots">
           <div class="swiper-container">
             <div class="swiper-wrapper">
-              {% for video in videos %}
-                <div class="p-carousel__item--video swiper-slide">
-                  <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">
-                  </div>
-                </div>
-              {% endfor %}
+              <!--{% for video in videos %}-->
+                <!--<div class="p-carousel__item&#45;&#45;video swiper-slide">-->
+                  <!--<div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">-->
+                  <!--</div>-->
+                <!--</div>-->
+              <!--{% endfor %}-->
               {% for screenshot in screenshots %}
                 <div class="p-carousel__item--screenshot swiper-slide">
                   {% if screenshot.endswith('.gif') %}

--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -150,3 +150,34 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_template_used("publisher/listing.html")
 
         self.assert_context("screenshot_urls", ["this is a url"])
+
+    @responses.activate
+    def test_videos(self):
+        payload = {
+            "snap_id": "id",
+            "snap_name": self.snap_name,
+            "title": "Snap title",
+            "summary": "This is a summary",
+            "description": "This is a description",
+            "media": [],
+            "publisher": {"display-name": "The publisher", "username": "toto"},
+            "private": True,
+            "channel_maps_list": [{"map": [{"info": "info"}]}],
+            "contact": "contact adress",
+            "website": "website_url",
+            "public_metrics_enabled": True,
+            "public_metrics_blacklist": True,
+            "license": "license",
+            "video_urls": ["https://youtube.com/watch?v=1234"],
+        }
+
+        responses.add(responses.GET, self.api_url, json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+
+        assert response.status_code == 200
+        self.assert_template_used("publisher/listing.html")
+
+        self.assert_context("video_urls", ["https://youtube.com/watch?v=1234"])

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -256,3 +256,24 @@ class StoreLogicTest(unittest.TestCase):
                 {"name": "Test", "slug": "test"},
             ],
         )
+
+    def test_get_video_embed_code(self):
+        youtube_url = "https://youtube.com/watch?v=123"
+        embed = logic.get_video_embed_code(youtube_url)
+        self.assertEqual(
+            embed, {"type": "youtube", "url": "https://youtube.com/embed/123"}
+        )
+
+        vimeo_url = "https://vimeo.com/123123"
+        embed = logic.get_video_embed_code(vimeo_url)
+        self.assertEqual(
+            embed,
+            {"type": "vimeo", "url": "https://player.vimeo.com/video/123123"},
+        )
+
+        asciicinema_url = "https://asciinema.org/a/123"
+        embed = logic.get_video_embed_code(asciicinema_url)
+        self.assertEqual(
+            embed,
+            {"type": "asciinema", "url": "https://asciinema.org/a/123.js"},
+        )

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -228,6 +228,7 @@ def filter_changes_data(changes):
         "whitelist_countries",
         "blacklist_countries",
         "license",
+        "video_urls",
     ]
 
     return {key: changes[key] for key in whitelist if key in changes}

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -441,7 +441,11 @@ def post_listing_snap(snap_name):
                     else snap_details["website"] or ""
                 ),
                 "public_metrics_enabled": details_metrics_enabled,
-                "video_urls": snap_details["video_urls"],
+                "video_urls": (
+                    [changes["video_urls"]]
+                    if "video_urls" in changes
+                    else snap_details["video_urls"]
+                ),
                 "public_metrics_blacklist": details_blacklist,
                 "license": license,
                 "license_type": license_type,

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -308,3 +308,14 @@ def get_version(channel_map, track, risk):
                     return release["version"]
 
     return None
+
+
+def get_video_embed_code(url):
+    """Get the embed code for videos
+
+    :param url: The url of the video
+
+    :returns: Embed code
+    """
+    if "youtube" in url:
+        return {"type": "youtube", "url": url.replace("watch?v=", "embed/")}

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -319,3 +319,10 @@ def get_video_embed_code(url):
     """
     if "youtube" in url:
         return {"type": "youtube", "url": url.replace("watch?v=", "embed/")}
+    if "vimeo" in url:
+        return {
+            "type": "vimeo",
+            "url": url.replace("vimeo.com/", "player.vimeo.com/video/"),
+        }
+    if "asciinema" in url:
+        return {"type": "asciinema", "url": url + ".js"}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -352,6 +352,12 @@ def store_blueprint(store_query=None, testing=False):
             m["url"] for m in details["snap"]["media"] if m["type"] == "icon"
         ]
 
+        videos = [
+            logic.get_video_embed_code(m["url"])
+            for m in details["snap"]["media"]
+            if m["type"] == "video"
+        ]
+
         # until default tracks are supported by the API we special case node
         # to use 10, rather then latest
         default_track = "10" if details["name"] == "node" else "latest"
@@ -386,6 +392,7 @@ def store_blueprint(store_query=None, testing=False):
             "publisher": details["snap"]["publisher"]["display-name"],
             "username": details["snap"]["publisher"]["username"],
             "screenshots": screenshots,
+            "videos": videos,
             "prices": details["snap"]["prices"],
             "contact": details["snap"].get("contact"),
             "website": details["snap"].get("website"),


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/785

## Done
- Added a Video field
- Ensured API errors are displayed above the field
- Added temporary youtube output to snap details page for testing

## QA
- Pull the branch
- `./run`

### Setting a valid url
- Visit http://0.0.0.0:8004/:snap_name:/listing
- Add a video URL in the correct format
- Save
- Should succeed

### Setting an invalid url
- Visit http://0.0.0.0:8004/:snap_name:/listing
- Add a random string to the video field
- Save
- Should error with a message about formatting

### Testing propagation to public pages
- Visit http://0.0.0.0:8004/:snap_name:/listing
- Add a valid youtube url
- Save
- Visit http://0.0.0.0:8004/:snap_name:
- The first item in the carousel should be the video