### PR TITLE
Missing screenshots navigation

### DIFF
--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -29,8 +29,19 @@ export default function initScreenshots(screenshotsId) {
     }
   });
 
-  new Swiper(
-    screenshotsEl.querySelector(".swiper-container"),
-    SCREENSHOTS_CONFIG
-  );
+  const config = Object.assign(SCREENSHOTS_CONFIG, {
+    // This hack is to fix a reported Swiper issue in firefox
+    // https://github.com/nolimits4web/swiper/issues/2218
+    // Hack https://github.com/nolimits4web/swiper/issues/2218#issuecomment-388837042
+    // TODO: When the issue linked above is fixed, remove this
+    on: {
+      init() {
+        setTimeout(() => {
+          window.dispatchEvent(new Event("resize"));
+        }, 200);
+      }
+    }
+  });
+
+  new Swiper(screenshotsEl.querySelector(".swiper-container"), config);
 }


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1343

## Done
Added a hack as described [here](https://github.com/nolimits4web/swiper/issues/2218#issuecomment-388837042), to fix a [reported Swiper issue](https://github.com/nolimits4web/swiper/issues/2218) in Firefox

## QA
- Pull this branch
- `./run`
- Visit http://0.0.0.0:8004/blender
- Hard refresh the page multiple times
- Each time the navigation should appear either immediately or not-noticably delayed.