### PR TITLE
Included link to dashboard collaboration section in published snaps

### DIFF
--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -179,6 +179,21 @@
 
         <div class="row">
           <div class="col-2">
+            Collaboration:
+          </div>
+          <div class="col-8">
+            <a class="p-link--external" href="https://dashboard.snapcraft.io/snaps/{{snap_name}}/collaboration/">Manage collaborators in dashboard.snapcraft.io</a>
+          </div>
+        </div>
+
+        <div class="p-strip is-shallow">
+          <div class="row">
+            <hr class="u-no-margin--bottom" />
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-2">
             Store:
           </div>
           <div class="col-8">


### PR DESCRIPTION
1. Pull the branch or open the demo service
2. Log in to your developer account
3. Visit a published snap
4. Collaboration should sit within `Settings` and link to dashboard