### PR TITLE
Autoplay video on details pages

### DIFF
--- a/static/js/config/swiper.config.js
+++ b/static/js/config/swiper.config.js
@@ -2,7 +2,7 @@ const SCREENSHOTS = {
   freeMode: true,
   watchOverflow: true,
   slidesPerView: "auto",
-  spaceBetween: 16,
+  spaceBetween: 32,
   navigation: {
     nextEl: `.swiper-button__next`,
     prevEl: `.swiper-button__prev`

--- a/static/js/config/swiper.config.js
+++ b/static/js/config/swiper.config.js
@@ -2,7 +2,13 @@ const SCREENSHOTS = {
   freeMode: true,
   watchOverflow: true,
   slidesPerView: "auto",
+  roundLengths: true,
   spaceBetween: 32,
+  breakpoints: {
+    620: {
+      spaceBetween: 16
+    }
+  },
   navigation: {
     nextEl: `.swiper-button__next`,
     prevEl: `.swiper-button__prev`

--- a/static/js/libs/iframeSize.js
+++ b/static/js/libs/iframeSize.js
@@ -1,0 +1,45 @@
+import debounce from "./debounce";
+
+// This is a peculiar ratio because youtube seems to be 2 pixels narrower than
+// 16 / 9, so add's black lines to either side of the video
+const IFRAME_RATIO = 643 / 362;
+
+/**
+ *
+ * @param wrapperSelector   A query selector for the wrapping element
+ *                           This element is used to define how wide the iframe
+ *                           should be.
+ *                           It's also used to find the iframe element.
+ * @param maxWidth  The maximum width the iframe should go.
+ */
+function sizeIframe(wrapperSelector, maxWidth) {
+  const wrapperEl = document.querySelector(wrapperSelector);
+  if (!wrapperEl) {
+    return;
+  }
+
+  const iframe = wrapperEl.querySelector("iframe");
+
+  // asciinema is a snowflake, so treat it as such
+  if (!iframe || (iframe.name && iframe.name.indexOf("asciicast") !== -1)) {
+    return;
+  }
+
+  const width = wrapperEl.clientWidth;
+  if (width < maxWidth) {
+    iframe.width = width;
+    iframe.height = width / IFRAME_RATIO;
+  } else if (iframe.width !== maxWidth) {
+    iframe.width = maxWidth;
+    iframe.height = maxWidth / IFRAME_RATIO;
+  }
+}
+
+export default (wrapperSelector, maxWidth) => {
+  window.addEventListener(
+    "resize",
+    debounce(sizeIframe.bind(this, wrapperSelector, maxWidth), 100)
+  );
+
+  sizeIframe(wrapperSelector, maxWidth);
+};

--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -2,8 +2,20 @@ import lightbox from "./../../publisher/market/lightbox";
 import { isMobile } from "../../libs/mobile";
 import { Swiper, Navigation } from "swiper/dist/js/swiper.esm";
 import { SCREENSHOTS_CONFIG } from "../../config/swiper.config";
+import debounce from "../../libs/debounce";
 
 Swiper.use([Navigation]);
+
+const IFRAME_RATIO = 643 / 362;
+
+function sizeIframe() {
+  const iframe = document.querySelector(".js-video-slide iframe");
+
+  if (iframe) {
+    const width = iframe.clientWidth;
+    iframe.height = width / IFRAME_RATIO;
+  }
+}
 
 export default function initScreenshots(screenshotsId) {
   const screenshotsEl = document.querySelector(screenshotsId);
@@ -12,7 +24,9 @@ export default function initScreenshots(screenshotsId) {
     return;
   }
 
-  const images = Array.from(screenshotsEl.querySelectorAll("img, video"))
+  const images = Array.from(
+    screenshotsEl.querySelectorAll("img, video, .js-video-slide")
+  )
     .filter(image => image.dataset.original)
     .map(image => image.dataset.original);
 
@@ -42,6 +56,10 @@ export default function initScreenshots(screenshotsId) {
       }
     }
   });
+
+  window.addEventListener("resize", debounce(sizeIframe, 100));
+
+  sizeIframe();
 
   new Swiper(screenshotsEl.querySelector(".swiper-container"), config);
 }

--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -2,20 +2,9 @@ import lightbox from "./../../publisher/market/lightbox";
 import { isMobile } from "../../libs/mobile";
 import { Swiper, Navigation } from "swiper/dist/js/swiper.esm";
 import { SCREENSHOTS_CONFIG } from "../../config/swiper.config";
-import debounce from "../../libs/debounce";
+import iframeSize from "../../libs/iframeSize";
 
 Swiper.use([Navigation]);
-
-const IFRAME_RATIO = 643 / 362;
-
-function sizeIframe() {
-  const iframe = document.querySelector(".js-video-slide iframe");
-
-  if (iframe) {
-    const width = iframe.clientWidth;
-    iframe.height = width / IFRAME_RATIO;
-  }
-}
 
 export default function initScreenshots(screenshotsId) {
   const screenshotsEl = document.querySelector(screenshotsId);
@@ -57,9 +46,8 @@ export default function initScreenshots(screenshotsId) {
     }
   });
 
-  window.addEventListener("resize", debounce(sizeIframe, 100));
-
-  sizeIframe();
+  // We need to resize the iframe on window resize
+  iframeSize("#js-snap-screenshots", 643);
 
   new Swiper(screenshotsEl.querySelector(".swiper-container"), config);
 }

--- a/static/js/public/snap-details/videos.js
+++ b/static/js/public/snap-details/videos.js
@@ -1,12 +1,28 @@
-function youtube(holderEl, url) {
-  const frame = document.createElement("iframe");
-  frame.id = "ytplayer";
-  frame.type = "text/html";
-  frame.width = 440;
-  frame.height = 248;
-  frame.src = `${url}?autoplay=0&origin=${window.location.href}`;
-  frame.setAttribute("frameborder", "0");
-  holderEl.appendChild(frame);
+function vimeo() {
+  const vimeoPlayerScript = document.createElement("script");
+  vimeoPlayerScript.src = "https://player.vimeo.com/api/player.js";
+  const firstScript = document.getElementsByTagName("script")[0];
+  firstScript.parentNode.insertBefore(vimeoPlayerScript, firstScript);
+
+  const frame = document.getElementById("vimeoplayer");
+
+  const vimeoReady = () => {
+    const player = new window.Vimeo.Player(frame);
+    player.on("play", function() {
+      player.setVolume(0);
+    });
+    player.play();
+  };
+
+  const checkVimeo = () => {
+    if (window.Vimeo) {
+      vimeoReady();
+    } else {
+      setTimeout(checkVimeo, 200);
+    }
+  };
+
+  checkVimeo();
 }
 
 function videos(holderSelector) {
@@ -17,13 +33,9 @@ function videos(holderSelector) {
   }
 
   const videoType = holderEl.dataset.videoType;
-  const videoUrl = holderEl.dataset.videoUrl;
 
-  switch (videoType) {
-    case "youtube":
-      youtube(holderEl, videoUrl);
-      break;
-    default:
+  if (videoType === "vimeo") {
+    vimeo();
   }
 }
 

--- a/static/js/public/snap-details/videos.js
+++ b/static/js/public/snap-details/videos.js
@@ -25,6 +25,34 @@ function vimeo() {
   checkVimeo();
 }
 
+function asciinema(holderEl) {
+  const asciinemaPlayer = holderEl.querySelector("iframe");
+
+  if (!asciinemaPlayer) {
+    setTimeout(asciinema.bind(this, holderEl), 200);
+    return;
+  }
+
+  const parent = asciinemaPlayer.parentNode;
+  const blocker = holderEl.querySelector(".p-carousel__item-blocker");
+
+  blocker.addEventListener("click", e => {
+    e.stopImmediatePropagation();
+    if (document.fullscreenEnabled) {
+      parent.requestFullscreen();
+    }
+  });
+
+  document.addEventListener("fullscreenchange", () => {
+    const fullScreenEl = document.fullscreenElement;
+    if (fullScreenEl && fullScreenEl === parent) {
+      parent.classList.add("is-fullscreen");
+    } else {
+      parent.classList.remove("is-fullscreen");
+    }
+  });
+}
+
 function videos(holderSelector) {
   const holderEl = document.querySelector(holderSelector);
 
@@ -36,6 +64,8 @@ function videos(holderSelector) {
 
   if (videoType === "vimeo") {
     vimeo();
+  } else if (videoType === "asciinema") {
+    asciinema(holderEl);
   }
 }
 

--- a/static/js/public/snap-details/videos.js
+++ b/static/js/public/snap-details/videos.js
@@ -29,7 +29,7 @@ function videos(holderSelector) {
   const holderEl = document.querySelector(holderSelector);
 
   if (!holderEl) {
-    throw new Error("Video holder doesn't exist");
+    return;
   }
 
   const videoType = holderEl.dataset.videoType;

--- a/static/js/publisher/market/lightbox.js
+++ b/static/js/publisher/market/lightbox.js
@@ -1,3 +1,5 @@
+import iframeSize from "../../libs/iframeSize";
+
 function openLightbox(url, images) {
   const lightboxEl = initLightboxEl(images);
 
@@ -77,6 +79,9 @@ const loadLightboxImage = (lightboxEl, url, images) => {
     video.classList.add("figlio");
     contentEl.appendChild(video);
     contentEl.style.opacity = "1";
+
+    // We need to resize the iframe on window resize
+    iframeSize(".vbox-content", 1200);
   } else {
     let media;
 

--- a/static/js/publisher/market/lightbox.js
+++ b/static/js/publisher/market/lightbox.js
@@ -1,5 +1,3 @@
-import iframeSize from "../../libs/iframeSize";
-
 function openLightbox(url, images) {
   const lightboxEl = initLightboxEl(images);
 
@@ -55,64 +53,32 @@ const loadLightboxImage = (lightboxEl, url, images) => {
     contentEl.removeChild(currentMedia);
   }
 
-  if (url === "video") {
-    const windowWidth = window.innerWidth;
-    const video = document
-      .querySelector(".js-video-slide iframe")
-      .cloneNode(true);
-
-    let src = video.src;
-    if (src) {
-      if (src.indexOf("mute=1")) {
-        src = src.split("mute=1").join("mute=0");
-      }
-      if (src.indexOf("autoplay=1")) {
-        src = src.split("autoplay=1").join("autoplay=0");
-      }
-
-      video.src = src;
-    }
-    const ratio = video.width / video.height;
-    video.width = windowWidth - 64;
-    video.height = video.width / ratio;
-    video.id = "lightbox-player";
-    video.classList.add("figlio");
-    contentEl.appendChild(video);
+  let media;
+  // load media
+  if (url.includes(".gif")) {
+    media = document.createElement("video");
+    media.autoplay = true;
+    media.loop = true;
+    media.classList.add("figlio");
+    contentEl.appendChild(media);
     contentEl.style.opacity = "1";
 
-    // We need to resize the iframe on window resize
-    iframeSize(".vbox-content", 1200);
-  } else {
-    let media;
+    const originalEl = document.body.querySelector(`[data-original="${url}"]`);
 
-    // load media
-    if (url.includes(".gif")) {
-      media = document.createElement("video");
-      media.autoplay = true;
-      media.loop = true;
-      media.classList.add("figlio");
-      contentEl.appendChild(media);
-      contentEl.style.opacity = "1";
-
-      const originalEl = document.body.querySelector(
-        `[data-original="${url}"]`
-      );
-
-      if (media.canPlayType("video/webm")) {
-        media.src = originalEl.querySelector("[type='video/webm']").src;
-      } else if (media.canPlayType("video/mp4")) {
-        media.src = originalEl.querySelector("[type='video/mp4']").src;
-      }
-    } else {
-      media = new Image();
-      media.classList.add("figlio");
-      contentEl.appendChild(media);
-
-      media.addEventListener("load", () => {
-        contentEl.style.opacity = "1";
-      });
-      media.src = url;
+    if (media.canPlayType("video/webm")) {
+      media.src = originalEl.querySelector("[type='video/webm']").src;
+    } else if (media.canPlayType("video/mp4")) {
+      media.src = originalEl.querySelector("[type='video/mp4']").src;
     }
+  } else {
+    media = new Image();
+    media.classList.add("figlio");
+    contentEl.appendChild(media);
+
+    media.addEventListener("load", () => {
+      contentEl.style.opacity = "1";
+    });
+    media.src = url;
   }
 
   // update prev/next buttons

--- a/static/js/publisher/market/lightbox.js
+++ b/static/js/publisher/market/lightbox.js
@@ -45,41 +45,69 @@ const initLightboxEl = () => {
 };
 
 const loadLightboxImage = (lightboxEl, url, images) => {
-  let media;
-  // hide content before it loads
   const contentEl = lightboxEl.querySelector(".vbox-content");
+  // hide content before it loads
   contentEl.style.opacity = "0";
-
   const currentMedia = contentEl.querySelector(".figlio");
   if (currentMedia) {
     contentEl.removeChild(currentMedia);
   }
 
-  // load media
-  if (url.includes(".gif")) {
-    media = document.createElement("video");
-    media.autoplay = true;
-    media.loop = true;
-    media.classList.add("figlio");
-    contentEl.appendChild(media);
-    contentEl.style.opacity = "1";
+  if (url === "video") {
+    const windowWidth = window.innerWidth;
+    const video = document
+      .querySelector(".js-video-slide iframe")
+      .cloneNode(true);
 
-    const originalEl = document.body.querySelector(`[data-original="${url}"]`);
+    let src = video.src;
+    if (src) {
+      if (src.indexOf("mute=1")) {
+        src = src.split("mute=1").join("mute=0");
+      }
+      if (src.indexOf("autoplay=1")) {
+        src = src.split("autoplay=1").join("autoplay=0");
+      }
 
-    if (media.canPlayType("video/webm")) {
-      media.src = originalEl.querySelector("[type='video/webm']").src;
-    } else if (media.canPlayType("video/mp4")) {
-      media.src = originalEl.querySelector("[type='video/mp4']").src;
+      video.src = src;
     }
+    const ratio = video.width / video.height;
+    video.width = windowWidth - 64;
+    video.height = video.width / ratio;
+    video.id = "lightbox-player";
+    video.classList.add("figlio");
+    contentEl.appendChild(video);
+    contentEl.style.opacity = "1";
   } else {
-    media = new Image();
-    media.classList.add("figlio");
-    contentEl.appendChild(media);
+    let media;
 
-    media.addEventListener("load", () => {
+    // load media
+    if (url.includes(".gif")) {
+      media = document.createElement("video");
+      media.autoplay = true;
+      media.loop = true;
+      media.classList.add("figlio");
+      contentEl.appendChild(media);
       contentEl.style.opacity = "1";
-    });
-    media.src = url;
+
+      const originalEl = document.body.querySelector(
+        `[data-original="${url}"]`
+      );
+
+      if (media.canPlayType("video/webm")) {
+        media.src = originalEl.querySelector("[type='video/webm']").src;
+      } else if (media.canPlayType("video/mp4")) {
+        media.src = originalEl.querySelector("[type='video/mp4']").src;
+      }
+    } else {
+      media = new Image();
+      media.classList.add("figlio");
+      contentEl.appendChild(media);
+
+      media.addEventListener("load", () => {
+        contentEl.style.opacity = "1";
+      });
+      media.src = url;
+    }
   }
 
   // update prev/next buttons

--- a/static/js/publisher/market/lightbox.test.js
+++ b/static/js/publisher/market/lightbox.test.js
@@ -1,0 +1,103 @@
+import lightbox from "./lightbox";
+
+describe("lightbox", () => {
+  afterEach(() => {
+    document.querySelector(".vbox-preloader").remove();
+    document.querySelector(".vbox-container").remove();
+    document.querySelector(".vbox-title").remove();
+    document.querySelector(".vbox-num").remove();
+    document.querySelector(".vbox-close").remove();
+    document.querySelector(".vbox-next").remove();
+    document.querySelector(".vbox-prev").remove();
+  });
+
+  describe("standard images", () => {
+    const urls = [
+      "https://dashboard.snapcraft.io/site_media/appmedia/2018/12/space_06hkcxJ.png"
+    ];
+    const images = urls.map(src => {
+      const img = new Image();
+      img.src = src;
+    });
+
+    beforeEach(() => {
+      lightbox.openLightbox(urls[0], images);
+    });
+
+    it("inits", () => {
+      expect(document.querySelector(".vbox-preloader")).toBeDefined();
+      expect(document.querySelector(".vbox-container")).toBeDefined();
+      expect(document.querySelector(".vbox-content")).toBeDefined();
+      expect(document.querySelector(".vbox-title")).toBeDefined();
+      expect(document.querySelector(".vbox-num")).toBeDefined();
+      expect(document.querySelector(".vbox-close")).toBeDefined();
+      expect(document.querySelector(".vbox-next")).toBeDefined();
+      expect(document.querySelector(".vbox-prev")).toBeDefined();
+    });
+  });
+
+  describe("gifs", () => {
+    const urls = ["https://media.giphy.com/media/gw3IWyGkC0rsazTi/giphy.gif"];
+    const images = urls.map(src => {
+      const img = new Image();
+      img.src = src;
+    });
+
+    beforeEach(() => {
+      lightbox.openLightbox(urls[0], images);
+    });
+
+    it("inits", () => {
+      expect(document.querySelector(".vbox-preloader")).toBeDefined();
+      expect(document.querySelector(".vbox-container")).toBeDefined();
+      expect(document.querySelector(".vbox-content")).toBeDefined();
+      expect(document.querySelector(".vbox-title")).toBeDefined();
+      expect(document.querySelector(".vbox-num")).toBeDefined();
+      expect(document.querySelector(".vbox-close")).toBeDefined();
+      expect(document.querySelector(".vbox-next")).toBeDefined();
+      expect(document.querySelector(".vbox-prev")).toBeDefined();
+    });
+  });
+
+  describe("videos", () => {
+    const urls = ["video"];
+    const images = urls.map(src => {
+      const img = new Image();
+      img.src = src;
+    });
+
+    let jsVideoSlide;
+    let iframe;
+
+    beforeEach(() => {
+      jsVideoSlide = document.createElement("div");
+      jsVideoSlide.className = "js-video-slide";
+
+      iframe = document.createElement("iframe");
+      iframe.src = "?mute=1&autoplay=1";
+      iframe.width = "10";
+      iframe.height = "10";
+
+      jsVideoSlide.appendChild(iframe);
+      document.body.appendChild(jsVideoSlide);
+
+      lightbox.openLightbox(urls[0], images);
+    });
+
+    afterEach(() => {
+      jsVideoSlide.remove();
+      iframe.remove();
+    });
+
+    it("inits", () => {
+      expect(document.querySelector(".vbox-preloader")).toBeDefined();
+      expect(document.querySelector(".vbox-container")).toBeDefined();
+      expect(document.querySelector(".vbox-content")).toBeDefined();
+      expect(document.querySelector(".vbox-title")).toBeDefined();
+      expect(document.querySelector(".vbox-num")).toBeDefined();
+      expect(document.querySelector(".vbox-close")).toBeDefined();
+      expect(document.querySelector(".vbox-next")).toBeDefined();
+      expect(document.querySelector(".vbox-prev")).toBeDefined();
+    });
+  });
+});

--- a/static/js/publisher/market/lightbox.test.js
+++ b/static/js/publisher/market/lightbox.test.js
@@ -58,46 +58,4 @@ describe("lightbox", () => {
       expect(document.querySelector(".vbox-prev")).toBeDefined();
     });
   });
-
-  describe("videos", () => {
-    const urls = ["video"];
-    const images = urls.map(src => {
-      const img = new Image();
-      img.src = src;
-    });
-
-    let jsVideoSlide;
-    let iframe;
-
-    beforeEach(() => {
-      jsVideoSlide = document.createElement("div");
-      jsVideoSlide.className = "js-video-slide";
-
-      iframe = document.createElement("iframe");
-      iframe.src = "?mute=1&autoplay=1";
-      iframe.width = "10";
-      iframe.height = "10";
-
-      jsVideoSlide.appendChild(iframe);
-      document.body.appendChild(jsVideoSlide);
-
-      lightbox.openLightbox(urls[0], images);
-    });
-
-    afterEach(() => {
-      jsVideoSlide.remove();
-      iframe.remove();
-    });
-
-    it("inits", () => {
-      expect(document.querySelector(".vbox-preloader")).toBeDefined();
-      expect(document.querySelector(".vbox-container")).toBeDefined();
-      expect(document.querySelector(".vbox-content")).toBeDefined();
-      expect(document.querySelector(".vbox-title")).toBeDefined();
-      expect(document.querySelector(".vbox-num")).toBeDefined();
-      expect(document.querySelector(".vbox-close")).toBeDefined();
-      expect(document.querySelector(".vbox-next")).toBeDefined();
-      expect(document.querySelector(".vbox-prev")).toBeDefined();
-    });
-  });
 });

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -4,6 +4,7 @@
   $carousel-buttons-breakpoint: $breakpoint-medium;
 
   .p-carousel {
+    margin: 1.5rem 0;
     position: relative;
 
     .p-carousel__item--snap {
@@ -15,13 +16,13 @@
     .p-carousel__item--screenshot,
     .p-carousel__item--video {
       box-sizing: border-box;
-      text-align: center;
       transform-origin: top left;
     }
 
     .p-carousel__item--screenshot,
     .p-carousel__item--video {
       cursor: pointer;
+      text-align: center;
 
       img,
       video,
@@ -29,10 +30,6 @@
         display: block;
         margin-bottom: 0;
         max-width: 100%;
-      }
-
-      img,
-      video {
         max-height: 362px;
       }
     }
@@ -49,9 +46,29 @@
       margin: 0 auto;
       max-width: 643px;
       width: 100%;
+      background: $color-x-dark;
+
+      .p-carousel__item-blocker {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
 
       .asciicast {
         margin: 0 auto !important;
+
+        &.is-fullscreen {
+          display: flex !important;
+          align-items: center !important;
+
+          iframe {
+            max-height: 100%;
+            max-width: 100%;
+            width: 100% !important;
+          }
+        }
       }
 
       iframe {
@@ -60,7 +77,8 @@
       }
     }
 
-    .p-carousel__item--screenshot {
+    .p-carousel__item--screenshot,
+    .p-carousel__item-blocker {
       &:hover {
         &::after {
           background-color: $color-x-light;

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -15,6 +15,8 @@
     .p-carousel__item--screenshot,
     .p-carousel__item--video {
       box-sizing: border-box;
+      text-align: center;
+      transform-origin: top left;
     }
 
     .p-carousel__item--screenshot,
@@ -25,8 +27,13 @@
       video,
       iframe {
         display: block;
-        max-height: 362px;
+        margin-bottom: 0;
         max-width: 100%;
+      }
+
+      img,
+      video {
+        max-height: 362px;
       }
     }
 
@@ -39,11 +46,17 @@
     }
 
     .p-carousel__item--asciinema {
-      width: 492px;
       margin: 0 auto;
+      max-width: 643px;
+      width: 100%;
 
       .asciicast {
-        margin: 0 !important;
+        margin: 0 auto !important;
+      }
+
+      iframe {
+        display: block !important;
+        margin: 0 auto !important;
       }
     }
 
@@ -151,6 +164,7 @@
   }
 
   .swiper-wrapper {
+    align-items: center;
     box-sizing: content-box;
     display: flex;
     height: 100%;

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -4,7 +4,6 @@
   $carousel-buttons-breakpoint: $breakpoint-medium;
 
   .p-carousel {
-    margin: $spv-inter--scaleable 0;
     position: relative;
 
     .p-carousel__item--snap {
@@ -23,9 +22,10 @@
       cursor: pointer;
 
       img,
-      video {
+      video,
+      iframe {
         display: block;
-        max-height: 248px;
+        max-height: 362px;
         max-width: 100%;
       }
     }
@@ -40,6 +40,7 @@
 
     .p-carousel__item--asciinema {
       width: 492px;
+      margin: 0 auto;
 
       .asciicast {
         margin: 0 !important;

--- a/static/sass/_patterns_carousel.scss
+++ b/static/sass/_patterns_carousel.scss
@@ -30,6 +30,22 @@
       }
     }
 
+    .p-carousel__item--video {
+      position: relative;
+
+      iframe {
+        margin-bottom: 0;
+      }
+    }
+
+    .p-carousel__item--asciinema {
+      width: 492px;
+
+      .asciicast {
+        margin: 0 !important;
+      }
+    }
+
     .p-carousel__item--screenshot {
       &:hover {
         &::after {

--- a/static/sass/_snapcraft_details_heading.scss
+++ b/static/sass/_snapcraft_details_heading.scss
@@ -6,6 +6,7 @@
 
   .p-snap-heading {
     display: flex;
+    flex-wrap: wrap;
 
 
     &__icon {
@@ -20,6 +21,7 @@
 
     &__title {
       flex-grow: 1;
+      flex-shrink: 0;
       margin: 0;
       overflow: hidden;
     }
@@ -31,33 +33,33 @@
     }
 
     &__publisher {
-      margin-top: $sp-x-small;
+      margin-top: -.5rem;
     }
 
     @media screen and (min-width: $breakpoint-medium) {
-      flex-direction: column;
-
       &__title {
-        margin-top: $sp-x-small;
+        margin-top: -2 * $sp-x-small;
       }
     }
   }
 
   .p-snap-install-buttons {
     text-align: right;
+    flex-grow: 1;
 
     .p-snap-install-buttons__install,
     .p-snap-install-buttons__versions {
       position: relative;
+      margin-bottom: 2 * $sp-unit;
       z-index: 5;
     }
 
     @media screen and (min-width: $breakpoint-medium) {
-      margin-top: 8.5 * $sp-unit; // align with snap name baseline
+      margin-top: $sp-unit; // align with snap name baseline
     }
 
     button:last-child {
-      margin-bottom: 0;
+      margin-right: 0;
     }
 
     .p-snap-install-buttons__install {

--- a/templates/partials/_snap-screenshot.html
+++ b/templates/partials/_snap-screenshot.html
@@ -1,0 +1,16 @@
+<div class="p-carousel__item--screenshot swiper-slide">
+  {% if screenshot.endswith('.gif') %}
+  <video autoplay loop muted playsinline data-original="{{ screenshot }}">
+    <source src="https://res.cloudinary.com/canonical/image/fetch/f_webm/{{ screenshot }}" type="video/webm">
+    <source src="https://res.cloudinary.com/canonical/image/fetch/f_mp4/{{ screenshot }}" type="video/mp4">
+    <img src="https://res.cloudinary.com/canonical/image/fetch/f_jpg,q_auto,f_auto,w_430/{{ screenshot }}" />
+  </video>
+  {% else %}
+  <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }}"
+       srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }} 215w,
+                          https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_860/{{ screenshot }} 430w"
+       sizes="(min-width: 1031px) 430px,
+                          (max-width: 1030px) and (min-width: 876px) 430px,
+                          (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_1170/{{ screenshot }}" alt="">
+  {% endif %}
+</div>

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -7,4 +7,5 @@
           src="{{ video.url }}?loop=1&title=0&byline=0&portrait=0"></iframe>
 {% elif video.type == "asciinema" %}
   <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-loop="1" data-preload="0"></script>
+  <div class="p-carousel__item-blocker"></div>
 {% endif %}

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,10 +1,10 @@
 {% if video.type == "youtube" %}
-  <iframe id="ytplayer" type="text/html" width="440" height="248"
+  <iframe id="ytplayer" type="text/html" width="643" height="362"
           src="{{ video.url }}?autoplay=1&mute=1&loop=1&modestbranding=1&playlist={{ video.id }}" frameborder="0"></iframe>
 {% elif video.type == "vimeo" %}
-  <iframe id="vimeoplayer" width="440" height="248" frameborder="0"
+  <iframe id="vimeoplayer" width="643" height="362" frameborder="0"
           webkitallowfullscreen mozallowfullscreen allowfullscreen
           src="{{ video.url }}?loop=1&title=0&byline=0&portrait=0"></iframe>
 {% elif video.type == "asciinema" %}
-  <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-loop="1" data-preload="0" data-cols="80"></script>
+  <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-loop="1" data-preload="0"></script>
 {% endif %}

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,10 +1,10 @@
 {% if video.type == "youtube" %}
   <iframe id="ytplayer" type="text/html" width="440" height="248"
-          src="{{ video.url }}?autoplay=1&mute=1" frameborder="0"></iframe>
+          src="{{ video.url }}?autoplay=1&mute=1&loop=1&modestbranding=1&playlist={{ video.id }}" frameborder="0"></iframe>
 {% elif video.type == "vimeo" %}
   <iframe id="vimeoplayer" width="440" height="248" frameborder="0"
           webkitallowfullscreen mozallowfullscreen allowfullscreen
-          src="{{ video.url }}"></iframe>
+          src="{{ video.url }}?loop=1&title=0&byline=0&portrait=0"></iframe>
 {% elif video.type == "asciinema" %}
   <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-loop="1" data-preload="0" data-cols="80"></script>
 {% endif %}

--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -1,0 +1,10 @@
+{% if video.type == "youtube" %}
+  <iframe id="ytplayer" type="text/html" width="440" height="248"
+          src="{{ video.url }}?autoplay=1&mute=1" frameborder="0"></iframe>
+{% elif video.type == "vimeo" %}
+  <iframe id="vimeoplayer" width="440" height="248" frameborder="0"
+          webkitallowfullscreen mozallowfullscreen allowfullscreen
+          src="{{ video.url }}"></iframe>
+{% elif video.type == "asciinema" %}
+  <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-loop="1" data-preload="0" data-cols="80"></script>
+{% endif %}

--- a/templates/partials/blog-card--minimal.html
+++ b/templates/partials/blog-card--minimal.html
@@ -1,7 +1,5 @@
-<div class="col-4 p-card--post">
-  <div class="p-card__content">
-    <h3 class="p-heading--four">
-      <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
-    </h3>
-  </div>
+<div class="col-4">
+  <h3 class="p-heading--four">
+    <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
+  </h3>
 </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -231,7 +231,7 @@
                 </p>
                 {% endif %}
                 <p class="p-form-help-text">
-                  Vimeo, YouTube or asciicinema URL
+                  Vimeo, YouTube or asciinema URL
                 </p>
               </div>
             </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -109,12 +109,12 @@
     <div class="p-strip--light is-shallow">
       <div class="row">
         {% if (videos and screenshots) or (not videos and (screenshots and screenshots|length > 1)) %}
-          <div class="p-carousel" id="js-snap-screenshots">
+          <div class="p-carousel u-no-margin--bottom u-no-margin--top" id="js-snap-screenshots">
             <div class="swiper-container">
               <div class="swiper-wrapper">
                 {% for video in videos %}
                   <div class="p-carousel__item--video p-carousel__item--{{ video.type }} swiper-slide">
-                    <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}" data-video-id="{{video.id}}" data-original="video">
+                    <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}" data-video-id="{{video.id}}">
                       {% include "partials/_video.html" %}
                     </div>
                   </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -44,9 +44,8 @@
 {% endblock %}
 
 {% block content %}
-  <div class="p-strip--light is-shallow">
+  <div class="p-strip--light is-shallow snapcraft-banner-background">
     <div class="row">
-      <div class="col-7">
         <div class="p-snap-heading">
           {% if icon_url %}
             <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
@@ -68,10 +67,9 @@
               {% endif %}
             </p>
           </div>
-        </div>
-      </div>
+
       {% if not webapp_config['STORE_QUERY'] %}
-        <div class="col-5 p-snap-install-buttons">
+        <div class="p-snap-install-buttons">
           <button
             class="p-button--neutral p-snap-install-buttons__versions"
             data-js="open-channel-map"
@@ -90,7 +88,7 @@
           {% endif %}
         </div>
       {% else %}
-        <div class="col-5 p-snap-install-buttons">
+        <div class="p-snap-install-buttons">
           <div class="p-code-snippet">
             <input class="p-code-snippet__input" id="snap-install-stable" value="sudo snap install {{ package_name }}" readonly="readonly">
             <button class="p-code-snippet__action js-clipboard-copy" data-clipboard-target="#snap-install-stable">
@@ -99,6 +97,7 @@
           </div>
         </div>
       {% endif %}
+        </div>
     </div>
   </div>
 
@@ -107,47 +106,46 @@
   {% endif %}
 
   {% if screenshots or videos %}
-    <div class="p-strip is-shallow">
+    <div class="p-strip--light is-shallow">
       <div class="row">
-        <div class="p-carousel" id="js-snap-screenshots">
-          <div class="swiper-container">
-            <div class="swiper-wrapper">
+        {% if (videos and screenshots) or (not videos and len(screenshots) > 1) %}
+          <div class="p-carousel" id="js-snap-screenshots">
+            <div class="swiper-container">
+              <div class="swiper-wrapper">
+                {% for video in videos %}
+                  <div class="p-carousel__item--video p-carousel__item--{{ video.type }} swiper-slide">
+                    <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}" data-video-id="{{video.id}}" data-original="video">
+                      {% include "partials/_video.html" %}
+                    </div>
+                  </div>
+                {% endfor %}
+                {% for screenshot in screenshots %}
+                  {% include "partials/_snap-screenshot.html" %}
+                {% endfor %}
+              </div>
+            </div>
+            <button class="p-carousel__next swiper-button__next">Next</button>
+            <button class="p-carousel__prev swiper-button__prev">Previous</button>
+          </div>
+        {% else %}
+          <div class="p-carousel" id="js-snap-screenshots">
+            {% if videos %}
               {% for video in videos %}
-                <div class="p-carousel__item--video p-carousel__item--{{ video.type }} swiper-slide">
-                  <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">
+                <div class="p-carousel__item--video p-carousel__item--{{ video.type }}">
+                  <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}" data-video-id="{{video.id}}" data-original="video">
                     {% include "partials/_video.html" %}
                   </div>
                 </div>
               {% endfor %}
+            {% else %}
               {% for screenshot in screenshots %}
-                <div class="p-carousel__item--screenshot swiper-slide">
-                  {% if screenshot.endswith('.gif') %}
-                  <video autoplay loop muted playsinline data-original="{{ screenshot }}">
-                    <source src="https://res.cloudinary.com/canonical/image/fetch/f_webm/{{ screenshot }}" type="video/webm">
-                    <source src="https://res.cloudinary.com/canonical/image/fetch/f_mp4/{{ screenshot }}" type="video/mp4">
-                    <img src="https://res.cloudinary.com/canonical/image/fetch/f_jpg,q_auto,f_auto,w_430/{{ screenshot }}" />
-                  </video>
-                  {% else %}
-                    <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }}"
-                      srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_430/{{ screenshot }} 215w,
-                        https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_860/{{ screenshot }} 430w"
-                      sizes="(min-width: 1031px) 430px,
-                        (max-width: 1030px) and (min-width: 876px) 430px,
-                        (max-width: 760px) 215px" data-original="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_1170/{{ screenshot }}" alt="">
-                  {% endif %}
+                <div class="p-carousel__item--screenshot">
+                  {% include "partials/_snap-screenshot.html" %}
                 </div>
               {% endfor %}
-            </div>
+            {% endif %}
           </div>
-          <button class="p-carousel__next swiper-button__next">Next</button>
-          <button class="p-carousel__prev swiper-button__prev">Previous</button>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-12">
-        <hr />
+        {% endif %}
       </div>
     </div>
   {% endif %}
@@ -167,6 +165,7 @@
         {% endif %}
       </div>
       <div class="col-4">
+        <h4>Details for {{ snap_title }}</h4>
         <table class="p-table-key-value">
           <tr><th>License</th><td>{{ license }}</td></tr>
           <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
@@ -183,15 +182,14 @@
     </div>
     <div class="p-strip is-shallow">
       <div class="row">
-        <h4>Related blog posts</h4>
+        <div class="col-3">
+          <h3 class="p-heading--four">Related blog posts</h3>
+        </div>
       </div>
       <div class="row u-equal-height" data-js="blog-article-list" data-snap="{{ package_name }}">
-      </div>
     </div>
   </div>
-  {% set article_title = {'rendered': '${title}'} %}
-  {% set article = {'slug': '${slug}', 'title': article_title} %}
-  <script type="text/template" id="blog-article-template">{% include 'partials/blog-card--minimal.html' %}</script>
+
   {% if countries or normalized_os %}
     <div class="row">
       <div class="col-12">
@@ -242,6 +240,19 @@
       </div>
     </div>
   {% endif %}
+
+  {# templates #}
+  {% set article_title = {'rendered': '${title}'} %}
+  {% set article = {'slug': '${slug}', 'title': article_title} %}
+  <script type="text/template" id="blog-article-template">{% include 'partials/blog-card--minimal.html' %}</script>
+
+  {% set video = {'type': 'youtube', 'url': '${url}', 'id': '${id}'} %}
+  <script type="text/template" id="video-youtube-template">{% include 'partials/_video.html' %}</script>
+  {% set video = {'type': 'vimeo', 'url': '${url}', 'id': '${id}'} %}
+  <script type="text/template" id="video-vimeo-template">{% include 'partials/_video.html' %}</script>
+  {% set video = {'type': 'asciinema', 'url': '${url}', 'id': '${id}'} %}
+  <script type="text/template" id="video-asciinema-template">{% include 'partials/_video.html' %}</script>
+
 {% endblock %}
 
 {% block scripts_modules %}

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -108,7 +108,7 @@
   {% if screenshots or videos %}
     <div class="p-strip--light is-shallow">
       <div class="row">
-        {% if (videos and screenshots) or (not videos and len(screenshots) > 1) %}
+        {% if (videos and screenshots) or (not videos and (screenshots and screenshots|length > 1)) %}
           <div class="p-carousel" id="js-snap-screenshots">
             <div class="swiper-container">
               <div class="swiper-wrapper">

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -106,12 +106,19 @@
     {% include "store/snap-details/_channel_map.html" %}
   {% endif %}
 
-  {% if screenshots %}
+  {% if screenshots or videos %}
     <div class="p-strip is-shallow">
       <div class="row">
         <div class="p-carousel" id="js-snap-screenshots">
           <div class="swiper-container">
             <div class="swiper-wrapper">
+              {% for video in videos %}
+                <div class="p-carousel__item--video p-carousel__item--{{ video.type }} swiper-slide">
+                  <div class="js-video-slide" data-video-type="{{video.type}}" data-video-url="{{video.url}}">
+                    {% include "partials/_video.html" %}
+                  </div>
+                </div>
+              {% endfor %}
               {% for screenshot in screenshots %}
                 <div class="p-carousel__item--screenshot swiper-slide">
                   {% if screenshot.endswith('.gif') %}
@@ -247,6 +254,12 @@
     Raven.context(function () {
       try {
         snapcraft.public.screenshots('#js-snap-screenshots');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      try {
+        snapcraft.public.videos('.js-video-slide');
       } catch(e) {
         Raven.captureException(e);
       }

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -261,14 +261,23 @@ class StoreLogicTest(unittest.TestCase):
         youtube_url = "https://youtube.com/watch?v=123"
         embed = logic.get_video_embed_code(youtube_url)
         self.assertEqual(
-            embed, {"type": "youtube", "url": "https://youtube.com/embed/123"}
+            embed,
+            {
+                "type": "youtube",
+                "url": "https://youtube.com/embed/123",
+                "id": "123",
+            },
         )
 
         vimeo_url = "https://vimeo.com/123123"
         embed = logic.get_video_embed_code(vimeo_url)
         self.assertEqual(
             embed,
-            {"type": "vimeo", "url": "https://player.vimeo.com/video/123123"},
+            {
+                "type": "vimeo",
+                "url": "https://player.vimeo.com/video/123123",
+                "id": "123123",
+            },
         )
 
         asciicinema_url = "https://asciinema.org/a/123"

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -275,5 +275,9 @@ class StoreLogicTest(unittest.TestCase):
         embed = logic.get_video_embed_code(asciicinema_url)
         self.assertEqual(
             embed,
-            {"type": "asciinema", "url": "https://asciinema.org/a/123.js"},
+            {
+                "type": "asciinema",
+                "url": "https://asciinema.org/a/123.js",
+                "id": "123",
+            },
         )

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -325,4 +325,8 @@ def get_video_embed_code(url):
             "url": url.replace("vimeo.com/", "player.vimeo.com/video/"),
         }
     if "asciinema" in url:
-        return {"type": "asciinema", "url": url + ".js"}
+        return {
+            "type": "asciinema",
+            "url": url + ".js",
+            "id": url.rsplit("/", 1)[-1],
+        }

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -327,6 +327,7 @@ def get_video_embed_code(url):
         return {
             "type": "vimeo",
             "url": url.replace("vimeo.com/", "player.vimeo.com/video/"),
+            "id": url.rsplit("/", 1)[-1],
         }
     if "asciinema" in url:
         return {

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -318,7 +318,11 @@ def get_video_embed_code(url):
     :returns: Embed code
     """
     if "youtube" in url:
-        return {"type": "youtube", "url": url.replace("watch?v=", "embed/")}
+        return {
+            "type": "youtube",
+            "url": url.replace("watch?v=", "embed/"),
+            "id": url.rsplit("?v=", 1)[-1],
+        }
     if "vimeo" in url:
         return {
             "type": "vimeo",


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/786
Fixes https://github.com/canonicalltd/snap-squad/issues/787
and implements https://github.com/canonical-websites/snapcraft.io/pull/1461

## QA
- Pull the branch
- `./run`
- Add an appropriate video to a public snap
- Visit the public snap page
- See the video
- Try with youtube, vimeo and asciinema
- Make sure that the videos are OK with and without screenshots
- Make sure the lightbox works when navigating to the video from another screenshot*
- Remove the video text to ensure the video is removed
- /lukewh-test, /test-lukewh and /test-lukewh-2 all have examples


*I've not hacked a way to open the lightbox by clicking on the videos as this seemed like it was overriding default behaviour.
