### PR TITLE
Remove failed fetch throw for store

### DIFF
--- a/static/js/public/store-categories.js
+++ b/static/js/public/store-categories.js
@@ -35,13 +35,13 @@ function getCategory(holder) {
   return fetch(url)
     .then(response => {
       if (!response.ok) {
-        throw `Response not ok for ${category} category \`${url}\``;
+        console.warn(`Response not ok for ${category} category \`${url}\``); // eslint-disable-line no-console
       }
       return response.text();
     })
     .then(writeCategory)
     .catch(error => {
-      throw new Error(error);
+      console.warn(error); // eslint-disable-line no-console
     });
 }
 

--- a/static/js/public/store-categories.js
+++ b/static/js/public/store-categories.js
@@ -35,14 +35,12 @@ function getCategory(holder) {
   return fetch(url)
     .then(response => {
       if (!response.ok) {
-        console.warn(`Response not ok for ${category} category \`${url}\``); // eslint-disable-line no-console
+        return;
       }
       return response.text();
     })
     .then(writeCategory)
-    .catch(error => {
-      console.warn(error); // eslint-disable-line no-console
-    });
+    .catch(() => {});
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1466

We don't need to report these failures to sentry as most of the time it's because someone navigates from the page before all categories have fetched and if a category doesn't load it's not a "failure" as such.

Also any genuine status codes will be shown in Grafana.

I've also added es-lint overrides for these as it's important for debugging for users.