### PR TITLE
Update highlight styles of releases table

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -31,14 +31,10 @@ class ReleasesTableCell extends Component {
   renderRevision(revision, isPending) {
     return (
       <Fragment>
-        {isPending ? (
-          <span className="p-release-data__icon">&rarr;</span>
-        ) : (
-          isInDevmode(revision) && (
-            <span className="p-release-data__icon">
-              <DevmodeIcon revision={revision} showTooltip={false} />
-            </span>
-          )
+        {isInDevmode(revision) && (
+          <span className="p-release-data__icon">
+            <DevmodeIcon revision={revision} showTooltip={false} />
+          </span>
         )}
         <span className="p-release-data__info">
           <span className="p-release-data__title">{revision.revision}</span>
@@ -82,7 +78,6 @@ class ReleasesTableCell extends Component {
   renderCloseChannel() {
     return (
       <Fragment>
-        <span className="p-release-data__icon">&rarr;</span>
         <em>close channel</em>
         <span className="p-tooltip__message">Pending channel close</span>
       </Fragment>

--- a/static/js/publisher/release/reducers/history.js
+++ b/static/js/publisher/release/reducers/history.js
@@ -1,4 +1,6 @@
 import { OPEN_HISTORY, CLOSE_HISTORY } from "../actions/history";
+import { RELEASE_REVISION } from "../actions/pendingReleases";
+import { CLOSE_CHANNEL } from "../actions/pendingCloses";
 
 export default function history(
   state = {
@@ -15,6 +17,8 @@ export default function history(
         ...action.payload
       };
     case CLOSE_HISTORY:
+    case RELEASE_REVISION:
+    case CLOSE_CHANNEL:
       return {
         ...state,
         isOpen: false,

--- a/static/js/publisher/release/reducers/history.test.js
+++ b/static/js/publisher/release/reducers/history.test.js
@@ -1,5 +1,7 @@
 import history from "./history";
 import { OPEN_HISTORY, CLOSE_HISTORY } from "../actions/history";
+import { RELEASE_REVISION } from "../actions/pendingReleases";
+import { CLOSE_CHANNEL } from "../actions/pendingCloses";
 
 describe("history", () => {
   it("should return the initial state", () => {
@@ -46,6 +48,42 @@ describe("history", () => {
 
     it("should remove history filters", () => {
       const result = history({}, closeHistoryAction);
+
+      expect(result.filters).toBe(null);
+    });
+  });
+
+  describe("on RELEASE_REVISION action", () => {
+    let releaseRevisionAction = {
+      type: RELEASE_REVISION
+    };
+
+    it("should mark history panel closed", () => {
+      const result = history({}, releaseRevisionAction);
+
+      expect(result.isOpen).toBe(false);
+    });
+
+    it("should remove history filters", () => {
+      const result = history({}, releaseRevisionAction);
+
+      expect(result.filters).toBe(null);
+    });
+  });
+
+  describe("on CLOSE_CHANNEL action", () => {
+    let closeChanneAction = {
+      type: CLOSE_CHANNEL
+    };
+
+    it("should mark history panel closed", () => {
+      const result = history({}, closeChanneAction);
+
+      expect(result.isOpen).toBe(false);
+    });
+
+    it("should remove history filters", () => {
+      const result = history({}, closeChanneAction);
 
       expect(result.filters).toBe(null);
     });

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -144,14 +144,12 @@ class ReleasesTable extends Component {
         className={`p-releases-table__row p-releases-table__row--channel p-releases-table__row--${risk}`}
         key={channel}
       >
-        <div className="p-releases-channel">
-          <span
-            className={`p-releases-channel__name ${
-              filteredChannel === channel ? "is-active" : ""
-            }`}
-          >
-            {channelName}
-          </span>
+        <div
+          className={`p-releases-channel ${
+            filteredChannel === channel ? "is-active" : ""
+          }`}
+        >
+          <span className="p-releases-channel__name">{channelName}</span>
           <span className="p-releases-table__menus">
             {canBePromoted && (
               <PromoteButton
@@ -223,7 +221,11 @@ class ReleasesTable extends Component {
     return (
       <Fragment>
         <div className="row">
-          <div className="p-releases-table">
+          <div
+            className={`p-releases-table ${
+              this.props.isHistoryOpen && this.props.filters ? "has-active" : ""
+            }`}
+          >
             <div className="p-releases-table__row p-releases-table__row--heading">
               <div className="p-releases-channel" />
               {archs.map(arch => (

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -1,5 +1,5 @@
 @mixin snapcraft-release {
-  $color-highlighted: #fff8ee;
+  $color-highlighted: #ffecd4;
 
   // RELEASES CONFIRM
 
@@ -63,15 +63,20 @@
     // TODO:
     // width: 222px; // fixed width col-3
     width: 230px; // temporary width until we merge menus into one
+
+    .has-active & {
+      opacity: .5;
+    }
+
+    &:hover,
+    &.is-active {
+      opacity: 1;
+    }
   }
 
   .p-releases-channel__name {
     flex-grow: 1;
     padding-top: ($spv-intra - .1rem);
-
-    &.is-active {
-      font-weight: bold;
-    }
   }
 
   // release cell
@@ -88,8 +93,8 @@
     position: relative;
     transition-duration: 0s; // vf-animation doesn't allow to do that
 
-    &.is-unassigned {
-      background-color: $color-x-light;
+    .has-active & {
+      opacity: .5;
     }
 
     &.is-clickable:focus,
@@ -97,11 +102,13 @@
     &.is-active {
       @include vf-animation (#{background-color, border-color}, fast, in);
       background-color: $color-x-light;
-      border-color: $color-mid-dark;
       cursor: pointer;
+      opacity: 1;
     }
 
     &.is-active {
+      border-color: $color-mid-dark;
+
       .p-release-data__title {
         font-weight: bold;
       }
@@ -120,10 +127,6 @@
     background: none;
     border: 0;
     padding: ($spv-intra - .1rem) $sph-intra; // same as p-release-data
-
-    &.is-active {
-      font-weight: bold;
-    }
   }
 
   // cell contents (release info)


### PR DESCRIPTION
Fixes #1457

Updates the styles of releases table:
- changes highlight colour to be more distinct
- fades out inactive cells (when history panel is open)
- no border on hover
- removes -> arrow from pending releases
- closes history panel when channel is promoted or closed

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1470.run.demo.haus/
- go to releases page of any snap
- select some revisions (cells should be highlighted in yellowish tone)
- open history panel of some cell
- promote some channel - history panel should be closed
- there should be no arrows in pending revisions
- click around, promote, close, etc - everything should work

<img width="1050" alt="screen shot 2018-12-18 at 13 23 00" src="https://user-images.githubusercontent.com/83575/50153924-1e810f00-02c8-11e9-8325-ff26f119e564.png">
