### PR TITLE
Update to new name of CDK

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -12,7 +12,7 @@
         &copy; 2018 Canonical Ltd. <br/>
         Ubuntu and Canonical are registered trademarks of Canonical Ltd.
         <br/>
-        Powered by <a href="https://www.ubuntu.com/kubernetes">the Canonical Distribution of Kubernetes</a>
+        Powered by <a href="https://www.ubuntu.com/kubernetes">the Charmed Distribution of Kubernetes</a>
       <p>
         <small>
           <a


### PR DESCRIPTION
Canonical has changed the brand name of its Kubernetes distribution to the "Charmed Distribution of Kubernetes". See https://www.ubuntu.com/kubernetes/features