### PR TITLE
Add served categories

### DIFF
--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -58,9 +58,16 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": False,
             "license": "License",
             "video_urls": [],
+            "categories": {},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
+        responses.add(
+            responses.GET,
+            "https://api.snapcraft.io/api/v1/snaps/sections",
+            json=[],
+            status=200,
+        )
 
         endpoint = "?".join([self.endpoint_url, "from=test"])
 
@@ -107,9 +114,16 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": [],
+            "categories": {},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
+        responses.add(
+            responses.GET,
+            "https://api.snapcraft.io/api/v1/snaps/sections",
+            json=[],
+            status=200,
+        )
 
         response = self.client.get(self.endpoint_url)
 
@@ -138,9 +152,16 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": [],
+            "categories": {},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
+        responses.add(
+            responses.GET,
+            "https://api.snapcraft.io/api/v1/snaps/sections",
+            json=[],
+            status=200,
+        )
 
         response = self.client.get(self.endpoint_url)
 
@@ -169,9 +190,16 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": ["https://youtube.com/watch?v=1234"],
+            "categories": {},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
+        responses.add(
+            responses.GET,
+            "https://api.snapcraft.io/api/v1/snaps/sections",
+            json=[],
+            status=200,
+        )
 
         response = self.client.get(self.endpoint_url)
 
@@ -181,3 +209,41 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_template_used("publisher/listing.html")
 
         self.assert_context("video_urls", ["https://youtube.com/watch?v=1234"])
+
+    @responses.activate
+    def test_failed_categories_api(self):
+        payload = {
+            "snap_id": "id",
+            "snap_name": self.snap_name,
+            "title": "Snap title",
+            "summary": "This is a summary",
+            "description": "This is a description",
+            "media": [],
+            "publisher": {"display-name": "The publisher", "username": "toto"},
+            "private": True,
+            "channel_maps_list": [{"map": [{"info": "info"}]}],
+            "contact": "contact adress",
+            "website": "website_url",
+            "public_metrics_enabled": True,
+            "public_metrics_blacklist": True,
+            "license": "license",
+            "video_urls": ["https://youtube.com/watch?v=1234"],
+            "categories": {},
+        }
+
+        responses.add(responses.GET, self.api_url, json=payload, status=200)
+        responses.add(
+            responses.GET,
+            "https://api.snapcraft.io/api/v1/snaps/sections",
+            json=[],
+            status=500,
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+
+        assert response.status_code == 200
+        self.assert_template_used("publisher/listing.html")
+
+        self.assert_context("categories", [])

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -66,12 +66,12 @@ class StoreApi:
     headers = {"X-Ubuntu-Series": "16"}
     headers_v2 = {"Snap-Device-Series": "16"}
 
-    def __init__(self, store=None, testing=False):
+    def __init__(self, store=None, testing=False, cache=True):
         if store:
             self.headers.update({"X-Ubuntu-Store": store})
             self.headers_v2.update({"Snap-Device-Store": store})
 
-        if testing:
+        if testing or not cache:
             self.session = api.requests.Session()
         else:
             self.session = api.requests.CachedSession()

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -229,6 +229,7 @@ def filter_changes_data(changes):
         "blacklist_countries",
         "license",
         "video_urls",
+        "categories",
     ]
 
     return {key: changes[key] for key in whitelist if key in changes}


### PR DESCRIPTION
# Summary

- Add categories to listing page
- Add possibility to push category to metadata
- Add parameter to `StoreApi` `cache=Bool` too allow to cache or not the calls
- Listing page gets its own instance of StoreApi not cached to get list of categories

# QA

- `./run`
- In template `listing.html` add line:
```
    {{ categories }}
    {{ snap_categories }}
```
- http://0.0.0.0:8004/toto/listing
- Make sure it has the right categories and that the template gets the list of categories
- Try with different snaps
- Try to modify a snap with an error (description with zero width space: https://unicode-table.com/en/200B/ ) 
- When the listing page reloads you should get the same (categories and snap category)