### PR TITLE
Self-serve categories

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -114,14 +114,15 @@ function initForm(config, initialState, errors) {
   let state = JSON.parse(JSON.stringify(initialState));
 
   const stateInput = document.createElement("input");
-  stateInput.type = "hidden";
   stateInput.name = "state";
+  stateInput.value = "";
 
   formEl.appendChild(stateInput);
 
   const diffInput = document.createElement("input");
   diffInput.type = "hidden";
   diffInput.name = "changes";
+  diffInput.value = "";
 
   formEl.appendChild(diffInput);
 

--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -114,6 +114,7 @@ function initForm(config, initialState, errors) {
   let state = JSON.parse(JSON.stringify(initialState));
 
   const stateInput = document.createElement("input");
+  stateInput.type = "hidden";
   stateInput.name = "state";
   stateInput.value = "";
 

--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -205,7 +205,7 @@ function initForm(config, initialState, errors) {
     if (formEl["license"]) {
       license(formEl);
     }
-    if (formEl["primary_category"]) {
+    if (formEl.elements["primary_category"]) {
       categories(formEl);
     }
 

--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -3,6 +3,7 @@ import { updateState, diffState } from "./state";
 import { publicMetrics } from "./market/publicMetrics";
 import { whitelistBlacklist } from "./market/whitelistBlacklist";
 import { initLicenses, license } from "./market/license";
+import { categories } from "./market/categories";
 
 // https://gist.github.com/dperini/729294
 // Luke 07-06-2018 made the protocol optional
@@ -202,6 +203,9 @@ function initForm(config, initialState, errors) {
     }
     if (formEl["license"]) {
       license(formEl);
+    }
+    if (formEl["primary_category"]) {
+      categories(formEl);
     }
 
     let formData = new FormData(formEl);

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -40,11 +40,15 @@ describe("initForm", () => {
   let submitButton;
   let revertButton;
   let titleInput;
+  let summaryInput;
+  let descriptionInput;
+  let websiteInput;
+  let contactInput;
   let primaryCategoryInput;
   let secondaryCategoryInput;
   let categoriesInput;
 
-  function setupForm(config) {
+  function setupForm(config, initialState) {
     form = document.createElement("form");
     form.id = config.form;
 
@@ -58,7 +62,14 @@ describe("initForm", () => {
     titleInput = document.createElement("input");
     titleInput.type = "text";
     titleInput.name = "title";
-    titleInput.value = "test";
+    titleInput.value = initialState.title;
+    titleInput.required = "true";
+    titleInput.maxlength = "64";
+
+    categoriesInput = document.createElement("input");
+    categoriesInput.type = "text";
+    categoriesInput.name = "categories";
+    categoriesInput.value = initialState.categories;
 
     primaryCategoryInput = document.createElement("input");
     primaryCategoryInput.type = "text";
@@ -70,10 +81,30 @@ describe("initForm", () => {
     secondaryCategoryInput.name = "secondary_category";
     secondaryCategoryInput.value = "";
 
-    categoriesInput = document.createElement("input");
-    categoriesInput.type = "text";
-    categoriesInput.name = "categories";
-    categoriesInput.value = "";
+    summaryInput = document.createElement("input");
+    summaryInput.type = "text";
+    summaryInput.name = "summary";
+    summaryInput.value = initialState.summary;
+    summaryInput.required = "true";
+    summaryInput.maxlength = "128";
+
+    descriptionInput = document.createElement("textarea");
+    descriptionInput.name = "description";
+    descriptionInput.rows = "10";
+    descriptionInput.required = "true";
+    descriptionInput.innerText = initialState.description;
+
+    websiteInput = document.createElement("input");
+    websiteInput.type = "url";
+    websiteInput.name = "website";
+    websiteInput.maxlength = "256";
+    websiteInput.value = initialState.website;
+
+    contactInput = document.createElement("input");
+    contactInput.type = "url";
+    contactInput.name = "contact";
+    contactInput.value = initialState.contact;
+    contactInput.maxlength = "256";
 
     form.appendChild(submitButton);
     form.appendChild(revertButton);
@@ -81,13 +112,7 @@ describe("initForm", () => {
 
     document.body.appendChild(form);
 
-    market.initForm(
-      config,
-      {
-        title: "test"
-      },
-      undefined
-    );
+    market.initForm(config, initialState, undefined);
   }
 
   describe("simple", () => {
@@ -95,8 +120,17 @@ describe("initForm", () => {
       form: "market-form"
     };
 
+    const initialState = {
+      title: "test",
+      categories: "",
+      summary: "Summary",
+      description: "Description",
+      website: "https://example.com",
+      contact: "mailto:test@example.com"
+    };
+
     beforeEach(() => {
-      setupForm(config);
+      setupForm(config, initialState);
     });
 
     afterEach(() => {
@@ -148,16 +182,16 @@ describe("initForm", () => {
         form.dispatchEvent(new Event("submit"));
       });
 
-      test("state is updated", () => {
+      test("state and diff are updated", () => {
         const stateInput = document.querySelector("[name='state']");
         expect(stateInput.value).toEqual(
-          JSON.stringify({
-            title: "test2"
-          })
+          JSON.stringify(
+            Object.assign(initialState, {
+              title: "test2"
+            })
+          )
         );
-      });
 
-      test("diff is updated", () => {
         const diffInput = document.querySelector("[name='changes']");
         expect(diffInput.value).toEqual(
           JSON.stringify({

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -34,3 +34,137 @@ describe("initSnapIconEdit", () => {
     expect(icon.src).toBe("test-url");
   });
 });
+
+describe("initForm", () => {
+  let form;
+  let submitButton;
+  let revertButton;
+  let titleInput;
+  let primaryCategoryInput;
+  let secondaryCategoryInput;
+  let categoriesInput;
+
+  function setupForm(config) {
+    form = document.createElement("form");
+    form.id = config.form;
+
+    submitButton = document.createElement("button");
+    submitButton.classList.add("js-form-submit");
+
+    revertButton = document.createElement("a");
+    revertButton.classList.add("js-form-revert");
+    revertButton.href = "/test";
+
+    titleInput = document.createElement("input");
+    titleInput.type = "text";
+    titleInput.name = "title";
+    titleInput.value = "test";
+
+    primaryCategoryInput = document.createElement("input");
+    primaryCategoryInput.type = "text";
+    primaryCategoryInput.name = "primary_category";
+    primaryCategoryInput.value = "";
+
+    secondaryCategoryInput = document.createElement("input");
+    secondaryCategoryInput.type = "text";
+    secondaryCategoryInput.name = "secondary_category";
+    secondaryCategoryInput.value = "";
+
+    categoriesInput = document.createElement("input");
+    categoriesInput.type = "text";
+    categoriesInput.name = "categories";
+    categoriesInput.value = "";
+
+    form.appendChild(submitButton);
+    form.appendChild(revertButton);
+    form.appendChild(titleInput);
+
+    document.body.appendChild(form);
+
+    market.initForm(
+      config,
+      {
+        title: "test"
+      },
+      undefined
+    );
+  }
+
+  describe("simple", () => {
+    const config = {
+      form: "market-form"
+    };
+
+    beforeEach(() => {
+      setupForm(config);
+    });
+
+    afterEach(() => {
+      form.parentNode.removeChild(form);
+    });
+
+    test("creates state input", () => {
+      const stateInput = document.querySelector("[name='state']");
+      expect(stateInput.value).toEqual("");
+    });
+
+    test("creates diff input", () => {
+      const diffInput = document.querySelector("[name='changes']");
+      expect(diffInput.value).toEqual("");
+    });
+
+    test("disables the submit button", () => {
+      expect(submitButton.getAttribute("disabled")).toEqual("");
+    });
+
+    test("disables the revert button", () => {
+      expect(revertButton.classList.contains("is-disabled")).toEqual(true);
+      expect(revertButton.href).toEqual("javascript:void(0);");
+    });
+
+    describe("on title change", () => {
+      beforeEach(() => {
+        titleInput.click();
+        titleInput.value = "test2";
+        titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
+      test("save is enabled", () => {
+        expect(submitButton.getAttribute("disabled")).toBeNull();
+      });
+
+      test("revert is enabled", () => {
+        expect(revertButton.classList.contains("is-disabled")).toEqual(false);
+        expect(revertButton.href).toEqual("/test");
+      });
+    });
+
+    describe("on submit", () => {
+      beforeEach(() => {
+        titleInput.click();
+        titleInput.value = "test2";
+        titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+        form.dispatchEvent(new Event("submit"));
+      });
+
+      test("state is updated", () => {
+        const stateInput = document.querySelector("[name='state']");
+        expect(stateInput.value).toEqual(
+          JSON.stringify({
+            title: "test2"
+          })
+        );
+      });
+
+      test("diff is updated", () => {
+        const diffInput = document.querySelector("[name='changes']");
+        expect(diffInput.value).toEqual(
+          JSON.stringify({
+            title: "test2"
+          })
+        );
+      });
+    });
+  });
+});

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -1,4 +1,5 @@
 import * as market from "./form";
+import * as categories from "./market/categories";
 
 describe("initSnapIconEdit", () => {
   let input;
@@ -48,6 +49,8 @@ describe("initForm", () => {
   let secondaryCategoryInput;
   let categoriesInput;
 
+  const categoriesList = ["", "test1", "test2"];
+
   function setupForm(config, initialState) {
     form = document.createElement("form");
     form.id = config.form;
@@ -71,15 +74,31 @@ describe("initForm", () => {
     categoriesInput.name = "categories";
     categoriesInput.value = initialState.categories;
 
-    primaryCategoryInput = document.createElement("input");
-    primaryCategoryInput.type = "text";
+    primaryCategoryInput = document.createElement("select");
     primaryCategoryInput.name = "primary_category";
     primaryCategoryInput.value = "";
 
-    secondaryCategoryInput = document.createElement("input");
-    secondaryCategoryInput.type = "text";
+    categoriesList.forEach((category, index) => {
+      const option = document.createElement("option");
+      option.value = category;
+      if (index === 0) {
+        option.selected = "selected";
+      }
+      primaryCategoryInput.appendChild(option);
+    });
+
+    secondaryCategoryInput = document.createElement("select");
     secondaryCategoryInput.name = "secondary_category";
     secondaryCategoryInput.value = "";
+
+    categoriesList.forEach((category, index) => {
+      const option = document.createElement("option");
+      option.value = category;
+      if (index === 0) {
+        option.selected = "selected";
+      }
+      secondaryCategoryInput.appendChild(option);
+    });
 
     summaryInput = document.createElement("input");
     summaryInput.type = "text";
@@ -92,7 +111,7 @@ describe("initForm", () => {
     descriptionInput.name = "description";
     descriptionInput.rows = "10";
     descriptionInput.required = "true";
-    descriptionInput.innerText = initialState.description;
+    descriptionInput.value = initialState.description;
 
     websiteInput = document.createElement("input");
     websiteInput.type = "url";
@@ -109,9 +128,17 @@ describe("initForm", () => {
     form.appendChild(submitButton);
     form.appendChild(revertButton);
     form.appendChild(titleInput);
+    form.appendChild(categoriesInput);
+    form.appendChild(primaryCategoryInput);
+    form.appendChild(secondaryCategoryInput);
+    form.appendChild(summaryInput);
+    form.appendChild(descriptionInput);
+    form.appendChild(websiteInput);
+    form.appendChild(contactInput);
 
     document.body.appendChild(form);
 
+    categories.categories = jest.fn();
     market.initForm(config, initialState, undefined);
   }
 
@@ -122,7 +149,7 @@ describe("initForm", () => {
 
     const initialState = {
       title: "test",
-      categories: "",
+      categories: [],
       summary: "Summary",
       description: "Description",
       website: "https://example.com",
@@ -198,6 +225,45 @@ describe("initForm", () => {
             title: "test2"
           })
         );
+      });
+    });
+  });
+
+  describe("categories", () => {
+    const config = {
+      form: "market-form"
+    };
+
+    const initialState = {
+      title: "test",
+      categories: "",
+      summary: "Summary",
+      description: "Description",
+      website: "https://example.com",
+      contact: "mailto:test@example.com"
+    };
+
+    beforeEach(() => {
+      setupForm(config, initialState);
+    });
+
+    afterEach(() => {
+      form.parentNode.removeChild(form);
+    });
+
+    describe("on submit", () => {
+      beforeEach(() => {
+        primaryCategoryInput.click();
+        primaryCategoryInput.options[0].removeAttribute("selected");
+        primaryCategoryInput.options[1].selected = "selected";
+        primaryCategoryInput.dispatchEvent(
+          new Event("change", { bubbles: true })
+        );
+
+        form.dispatchEvent(new Event("submit"));
+      });
+      test("categories is called", () => {
+        expect(categories.categories.mock.calls.length).toEqual(1);
       });
     });
   });

--- a/static/js/publisher/market/categories.js
+++ b/static/js/publisher/market/categories.js
@@ -1,0 +1,89 @@
+function categories(form) {
+  let categoriesList = [];
+  if (form["primary_category"]) {
+    categoriesList.push(form["primary_category"].value);
+  }
+  if (form["secondary_category"]) {
+    categoriesList.push(form["secondary_category"].value);
+  }
+  form["categories"].value = categoriesList.join(", ");
+}
+
+function initCategories() {
+  const categoryHelpTextEl = document.querySelector(
+    ".js-categories-category1-help-text"
+  );
+  const categorySecondaryAddEl = document.querySelector(
+    ".js-categories-category2-add"
+  );
+  const categorySecondaryPickerEl = document.querySelector(
+    ".js-categories-category2-picker"
+  );
+  const categorySecondaryAddLink = document.querySelector(
+    ".js-categories-category2-add-link"
+  );
+  const secondaryCategoryRemove = document.querySelector(
+    ".js-categories-category2-remove"
+  );
+
+  const primaryCategorySelectEl = document.querySelector(
+    "[name='primary_category']"
+  );
+  const secondaryCategorySelectEl = document.querySelector(
+    "[name='secondary_category']"
+  );
+
+  const setSecondaryOptions = () => {
+    const primaryValue = primaryCategorySelectEl.value;
+    const secondaryValue = secondaryCategorySelectEl.value;
+    for (let i = 0; i < secondaryCategorySelectEl.options.length; i++) {
+      const option = secondaryCategorySelectEl.options[i];
+      if (option.value === primaryValue) {
+        option.setAttribute("disabled", "disabled");
+        if (secondaryValue === primaryValue) {
+          resetSecondaryCategory();
+        }
+      } else {
+        option.removeAttribute("disabled");
+      }
+    }
+  };
+
+  const resetSecondaryCategory = () => {
+    secondaryCategorySelectEl.value = "";
+    secondaryCategorySelectEl.dispatchEvent(
+      new Event("change", { bubbles: true })
+    );
+  };
+
+  primaryCategorySelectEl.addEventListener("change", () => {
+    const value = primaryCategorySelectEl.value;
+    if (value.trim() !== "") {
+      categoryHelpTextEl.classList.add("u-hide");
+      if (secondaryCategorySelectEl.value === "") {
+        categorySecondaryAddEl.classList.remove("u-hide");
+        categorySecondaryPickerEl.classList.add("u-hide");
+      }
+    } else {
+      categoryHelpTextEl.classList.remove("u-hide");
+      categorySecondaryAddEl.classList.add("u-hide");
+      categorySecondaryPickerEl.classList.add("u-hide");
+      resetSecondaryCategory();
+    }
+    setSecondaryOptions();
+  });
+
+  categorySecondaryAddLink.addEventListener("click", () => {
+    categorySecondaryAddEl.classList.add("u-hide");
+    categorySecondaryPickerEl.classList.remove("u-hide");
+    setSecondaryOptions();
+  });
+
+  secondaryCategoryRemove.addEventListener("click", () => {
+    resetSecondaryCategory();
+    categorySecondaryPickerEl.classList.add("u-hide");
+    categorySecondaryAddEl.classList.remove("u-hide");
+  });
+}
+
+export { categories, initCategories };

--- a/static/js/publisher/market/categories.js
+++ b/static/js/publisher/market/categories.js
@@ -1,12 +1,12 @@
 function categories(form) {
   let categoriesList = [];
-  if (form["primary_category"]) {
-    categoriesList.push(form["primary_category"].value);
+  if (form.elements["primary_category"]) {
+    categoriesList.push(form.elements["primary_category"].value);
   }
-  if (form["secondary_category"]) {
-    categoriesList.push(form["secondary_category"].value);
+  if (form.elements["secondary_category"]) {
+    categoriesList.push(form.elements["secondary_category"].value);
   }
-  form["categories"].value = categoriesList.join(", ");
+  form.elements["categories"].value = categoriesList.join(", ");
 }
 
 function initCategories() {
@@ -68,7 +68,6 @@ function initCategories() {
       categoryHelpTextEl.classList.remove("u-hide");
       categorySecondaryAddEl.classList.add("u-hide");
       categorySecondaryPickerEl.classList.add("u-hide");
-      resetSecondaryCategory();
     }
     setSecondaryOptions();
   });

--- a/static/js/publisher/market/categories.test.js
+++ b/static/js/publisher/market/categories.test.js
@@ -1,0 +1,222 @@
+import * as categories from "./categories";
+
+describe("categories", () => {
+  let form;
+  let cat1Input;
+  let cat2Input;
+  let catsInput;
+
+  beforeEach(() => {
+    form = document.createElement("form");
+
+    cat1Input = document.createElement("input");
+    cat1Input.name = "primary_category";
+    cat1Input.type = "text";
+    cat1Input.value = "";
+
+    cat2Input = document.createElement("input");
+    cat2Input.name = "secondary_category";
+    cat2Input.type = "text";
+    cat2Input.value = "";
+
+    catsInput = document.createElement("input");
+    catsInput.name = "categories";
+    catsInput.type = "text";
+    catsInput.value = "";
+
+    form.appendChild(cat1Input);
+    form.appendChild(cat2Input);
+    form.appendChild(catsInput);
+
+    document.body.appendChild(form);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(form);
+  });
+
+  test("given a primary category, return that value", () => {
+    cat1Input.value = "test";
+    categories.categories(form);
+    expect(catsInput.value).toEqual("test, ");
+  });
+
+  test("given a primary and secondary category, return those values", () => {
+    cat1Input.value = "test";
+    cat2Input.value = "test2";
+    categories.categories(form);
+    expect(catsInput.value).toEqual("test, test2");
+  });
+});
+
+describe("initCategories", () => {
+  let holder;
+  let categoryHelpTextEl;
+  let categorySecondaryAddEl;
+  let categorySecondaryPickerEl;
+  let categorySecondaryAddLink;
+  let secondaryCategoryRemove;
+  let primaryCategorySelectEl;
+  let secondaryCategorySelectEl;
+
+  const categoryOptions = ["", "test1", "test2", "test3"];
+
+  let cb;
+
+  beforeEach(() => {
+    categoryHelpTextEl = document.createElement("div");
+    categoryHelpTextEl.className = "js-categories-category1-help-text";
+
+    categorySecondaryAddEl = document.createElement("div");
+    categorySecondaryAddEl.className = "js-categories-category2-add";
+
+    categorySecondaryPickerEl = document.createElement("div");
+    categorySecondaryPickerEl.className = "js-categories-category2-picker";
+
+    categorySecondaryAddLink = document.createElement("div");
+    categorySecondaryAddLink.className = "js-categories-category2-add-link";
+
+    secondaryCategoryRemove = document.createElement("div");
+    secondaryCategoryRemove.className = "js-categories-category2-remove";
+
+    primaryCategorySelectEl = document.createElement("select");
+    primaryCategorySelectEl.name = "primary_category";
+    primaryCategorySelectEl.value = "";
+
+    secondaryCategorySelectEl = document.createElement("select");
+    secondaryCategorySelectEl.name = "secondary_category";
+    secondaryCategorySelectEl.value = "";
+
+    categoryOptions.forEach((category, index) => {
+      const option1 = document.createElement("option");
+      const option2 = document.createElement("option");
+      option1.value = category;
+      option2.value = category;
+      if (index === 0) {
+        option1.selected = "selected";
+        option2.selected = "selected";
+      }
+      primaryCategorySelectEl.appendChild(option1);
+      secondaryCategorySelectEl.appendChild(option2);
+    });
+
+    cb = jest.fn();
+    secondaryCategorySelectEl.addEventListener("change", cb);
+
+    holder = document.createElement("div");
+    holder.appendChild(categoryHelpTextEl);
+    holder.appendChild(categorySecondaryAddEl);
+    holder.appendChild(categorySecondaryPickerEl);
+    holder.appendChild(categorySecondaryAddLink);
+    holder.appendChild(secondaryCategoryRemove);
+    holder.appendChild(primaryCategorySelectEl);
+    holder.appendChild(secondaryCategorySelectEl);
+    document.body.appendChild(holder);
+
+    categories.initCategories();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(holder);
+  });
+
+  describe("changing primary category without a secondary category", () => {
+    beforeEach(() => {
+      primaryCategorySelectEl.options[0].removeAttribute("selected");
+      primaryCategorySelectEl.options[1].selected = "selected";
+      primaryCategorySelectEl.dispatchEvent(new Event("change"));
+    });
+
+    test("hides the help text", () => {
+      expect(categoryHelpTextEl.classList.contains("u-hide")).toEqual(true);
+    });
+
+    test("shows the secondary add prompty", () => {
+      expect(categorySecondaryAddEl.classList.contains("u-hide")).toEqual(
+        false
+      );
+    });
+
+    test("hides the secondary category selector", () => {
+      expect(categorySecondaryPickerEl.classList.contains("u-hide")).toEqual(
+        true
+      );
+    });
+
+    test("secondary selector option is disabled", () => {
+      expect(secondaryCategorySelectEl.options[1].disabled).toEqual(true);
+    });
+  });
+
+  describe("removing primary category", () => {
+    beforeEach(() => {
+      primaryCategorySelectEl.options[1].removeAttribute("selected");
+      primaryCategorySelectEl.options[0].selected = "selected";
+      primaryCategorySelectEl.dispatchEvent(new Event("change"));
+    });
+
+    test("shows the help text", () => {
+      expect(categoryHelpTextEl.classList.contains("u-hide")).toEqual(false);
+    });
+
+    test("hides the secondary add prompt", () => {
+      expect(categorySecondaryAddEl.classList.contains("u-hide")).toEqual(true);
+    });
+
+    test("hides the secondary category selector", () => {
+      expect(categorySecondaryPickerEl.classList.contains("u-hide")).toEqual(
+        true
+      );
+    });
+
+    test("secondary selector option is disabled", () => {
+      expect(secondaryCategorySelectEl.options[0].disabled).toEqual(true);
+    });
+
+    test("expect secondary category change event to be triggered", () => {
+      expect(cb.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe("add second category", () => {
+    beforeEach(() => {
+      categorySecondaryAddLink.dispatchEvent(new Event("click"));
+    });
+
+    test("hides the secondary add prompt", () => {
+      expect(categorySecondaryAddEl.classList.contains("u-hide")).toEqual(true);
+    });
+
+    test("shows the secondary category selector", () => {
+      expect(categorySecondaryPickerEl.classList.contains("u-hide")).toEqual(
+        false
+      );
+    });
+
+    test("secondary selector option is disabled", () => {
+      expect(secondaryCategorySelectEl.options[0].disabled).toEqual(true);
+    });
+  });
+
+  describe("remove secondary category", () => {
+    beforeEach(() => {
+      secondaryCategoryRemove.dispatchEvent(new Event("click"));
+    });
+
+    test("shows the secondary add prompt", () => {
+      expect(categorySecondaryAddEl.classList.contains("u-hide")).toEqual(
+        false
+      );
+    });
+
+    test("hides the secondary category selector", () => {
+      expect(categorySecondaryPickerEl.classList.contains("u-hide")).toEqual(
+        true
+      );
+    });
+
+    test("expect secondary category change event to be triggered", () => {
+      expect(cb.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -4,7 +4,16 @@ import * as market from "./form";
 import { initMultiselect } from "./form/multiselect";
 import { enableInput, changeHandler } from "./settings";
 import { publicise } from "./publicise";
+import { initCategories } from "./market/categories";
 
 const settings = { enableInput, changeHandler };
 
-export { metrics, selector, market, initMultiselect, settings, publicise };
+export {
+  metrics,
+  selector,
+  market,
+  initMultiselect,
+  settings,
+  publicise,
+  initCategories
+};

--- a/static/js/publisher/state.js
+++ b/static/js/publisher/state.js
@@ -25,7 +25,8 @@ function commaSeperatedStringToArray(str) {
       .join("")
       .trim() !== ""
   ) {
-    return str.split(", ");
+    const split = str.split(", ");
+    return split.filter(item => item !== "");
   } else {
     return [];
   }

--- a/static/js/publisher/state.js
+++ b/static/js/publisher/state.js
@@ -103,4 +103,4 @@ function diffState(initialState, state) {
   return Object.keys(diff).length > 0 ? diff : null;
 }
 
-export { updateState, diffState };
+export { updateState, diffState, commaSeperatedStringToArray };

--- a/static/js/publisher/state.js
+++ b/static/js/publisher/state.js
@@ -13,11 +13,18 @@ const allowedKeys = [
   "whitelist_countries",
   "blacklist_countries",
   "video_urls",
-  "license"
+  "license",
+  "categories"
 ];
 
 function commaSeperatedStringToArray(str) {
-  if (str !== "") {
+  if (
+    str !== "" &&
+    str
+      .split(",")
+      .join("")
+      .trim() !== ""
+  ) {
     return str.split(", ");
   } else {
     return [];
@@ -27,6 +34,7 @@ function commaSeperatedStringToArray(str) {
 const transform = {
   whitelist_countries: commaSeperatedStringToArray,
   blacklist_countries: commaSeperatedStringToArray,
+  categories: commaSeperatedStringToArray,
   private: value => value === "private",
   public_metrics_enabled: value => value === "on"
 };

--- a/static/js/publisher/state.test.js
+++ b/static/js/publisher/state.test.js
@@ -164,4 +164,9 @@ describe("commaSeperatedStringToArray", () => {
       "test2"
     ]);
   });
+
+  test("should return a single element array if multiple values and 1 is blank", () => {
+    expect(commaSeperatedStringToArray("test, ")).toEqual(["test"]);
+    expect(commaSeperatedStringToArray(", test")).toEqual(["test"]);
+  });
 });

--- a/static/js/publisher/state.test.js
+++ b/static/js/publisher/state.test.js
@@ -1,4 +1,4 @@
-import { updateState, diffState } from "./state";
+import { updateState, diffState, commaSeperatedStringToArray } from "./state";
 
 describe("updateState", () => {
   let state;
@@ -142,5 +142,26 @@ describe("diffState", () => {
         )
       ).toBeNull();
     });
+  });
+});
+
+describe("commaSeperatedStringToArray", () => {
+  test("should return empty array if single value is blank", () => {
+    expect(commaSeperatedStringToArray("")).toEqual([]);
+  });
+
+  test("should return empty array if all values are blank", () => {
+    expect(commaSeperatedStringToArray(", ")).toEqual([]);
+  });
+
+  test("should return an array if single value is not blank", () => {
+    expect(commaSeperatedStringToArray("test")).toEqual(["test"]);
+  });
+
+  test("should return an array if multiple values are not blank", () => {
+    expect(commaSeperatedStringToArray("test, test2")).toEqual([
+      "test",
+      "test2"
+    ]);
   });
 });

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -145,7 +145,8 @@
             <label>Category:</label>
           </div>
           <div class="col-4">
-            <input type="hidden" name="categories" value="{{ snap_categories.items }}" />
+            <input type="hidden" name="categories"
+                   value="{% if snap_categories.categories[0] %}{% for category in snap_categories.categories %}{% if loop.index > 1 %}, {% endif %}{{ category.name }}{% endfor %}{% endif %}" />
             <select
               name="primary_category"
               {% if snap_categories.categories[0] %}
@@ -492,6 +493,7 @@
       description: {{ description|tojson }},
       website: {{ website|tojson }},
       contact: {{ contact|tojson }},
+      categories: "{% if snap_categories.categories[0] %}{% for category in snap_categories.categories %}{% if loop.index > 1 %}, {% endif %}{{ category.name }}{% endfor %}{% endif %}",
       images: [
         {% if icon_url %}
           { url: {{ icon_url|tojson }}, type: "icon", status: "uploaded" },

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -162,6 +162,7 @@
                   {% endif %}
                 >{{ category.name }}</option>
               {% endfor %}
+              <option value="None">None</option>
             </select>
           </div>
         </div>
@@ -177,16 +178,16 @@
 
         <div class="js-categories-category2-add row{% if not snap_categories.categories[0] or snap_categories.categories[1] %} u-hide{% endif %}">
           <div class="col-8 push-2">
-            <p><a class="js-categories-category2-add-link">+ Add secondary category</a></p>
+            <p><a class="js-categories-category2-add-link">+ Add another category</a></p>
             <p class="p-form-help-text">
-              If your snap fits into multiple categories you can select a secondary.
+              If your snap fits into multiple categories you can select another.
             </p>
           </div>
         </div>
 
         <div class="js-categories-category2-picker row{% if not snap_categories.categories[1] %} u-hide{% endif %}">
           <div class="col-2">
-            <label>Secondary category:</label>
+            <label>Second category:</label>
           </div>
           <div class="col-4">
             <select

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -142,6 +142,91 @@
 
         <div class="row">
           <div class="col-2">
+            <label>Category:</label>
+          </div>
+          <div class="col-4">
+            <input type="hidden" name="categories" value="{{ snap_categories.items }}" />
+            <select
+              name="primary_category"
+              {% if snap_categories.categories[0] %}
+                value="{{ snap_categories.categories[0].name }}"
+              {% endif %}
+              {% if snap_categories.locked %} disabled="disabled"{% endif %}
+            >
+              <option value="">Select category</option>
+              {% for category in categories %}
+                <option
+                  value="{{ category.slug }}"
+                  {% if snap_categories.categories[0] and (snap_categories.categories[0].name == category.slug) %}
+                    selected="selected"
+                  {% endif %}
+                >{{ category.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+
+        <div class="js-categories-category1-help-text row{% if snap_categories.categories[0] %} u-hide{% endif %}">
+          <div class="col-8 push-2">
+            <p class="p-form-help-text">
+              Include a category and your snap will be better ranked within the Snap Store.
+              It will also allow users to discover your snap via browsing the available categories.
+            </p>
+          </div>
+        </div>
+
+        <div class="js-categories-category2-add row{% if not snap_categories.categories[0] or snap_categories.categories[1] %} u-hide{% endif %}">
+          <div class="col-8 push-2">
+            <p><a class="js-categories-category2-add-link">+ Add secondary category</a></p>
+            <p class="p-form-help-text">
+              If your snap fits into multiple categories you can select a secondary.
+            </p>
+          </div>
+        </div>
+
+        <div class="js-categories-category2-picker row{% if not snap_categories.categories[1] %} u-hide{% endif %}">
+          <div class="col-2">
+            <label>Secondary category:</label>
+          </div>
+          <div class="col-4">
+            <select
+              name="secondary_category"
+              {% if snap_categories.categories[1] %}
+              value="{{ snap_categories.categories[1].name }}"
+              {% endif %}
+              {% if snap_categories.locked %} disabled="disabled"{% endif %}
+            >
+              <option value="">Select category</option>
+              {% for category in categories %}
+                <option
+                  value="{{ category.slug }}"
+                  {% if snap_categories.categories[1] and (snap_categories.categories[1].name == category.slug) %}
+                  selected="selected"
+                  {% endif %}
+                  {% if snap_categories.categories[0] and category.slug == snap_categories.categories[0].name %}
+                  disabled="disabled"
+                  {% endif %}
+                >{{ category.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="col-2">
+            <p>
+              <a class="js-categories-category2-remove">
+                <i class="p-icon--delete"></i>
+              </a>
+            </p>
+          </div>
+        </div>
+
+        <div class="p-strip is-shallow">
+          <div class="row">
+            <hr class="u-no-margin--bottom" />
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-2">
             <label>Summary: </label>
           </div>
           <div class="col-8">
@@ -424,6 +509,8 @@
       null
     {% endif %}
     );
+
+    snapcraft.publisher.initCategories();
   });
 </script>
 {% endblock %}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -163,7 +163,7 @@
                   {% endif %}
                 >{{ category.name }}</option>
               {% endfor %}
-              <option value="None">None</option>
+              <option value="">None</option>
             </select>
           </div>
         </div>

--- a/tests/publisher/snaps/tests_listing.py
+++ b/tests/publisher/snaps/tests_listing.py
@@ -58,7 +58,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": False,
             "license": "License",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -114,7 +114,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -152,7 +152,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -190,7 +190,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": ["https://youtube.com/watch?v=1234"],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -228,7 +228,7 @@ class GetListingPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "public_metrics_blacklist": True,
             "license": "license",
             "video_urls": ["https://youtube.com/watch?v=1234"],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_post_listing.py
+++ b/tests/publisher/snaps/tests_post_listing.py
@@ -132,7 +132,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "public_metrics_blacklist": True,
             "license": "test OR testing",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -217,7 +217,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "public_metrics_blacklist": True,
             "license": "test OR testing",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -317,7 +317,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "public_metrics_blacklist": True,
             "license": "test OR testing",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -381,7 +381,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             "public_metrics_blacklist": True,
             "license": "test OR testing",
             "video_urls": [],
-            "categories": {},
+            "categories": {"items": []},
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -255,3 +255,18 @@ def invalid_field_errors(errors):
             other_errors.append(error)
 
     return field_errors, other_errors
+
+
+def replace_reserved_categories_key(categories):
+    """The API returns `items` which is a reserved word in jinja2.
+    This method renames that key for snap_categories.
+
+    :param categories: Dict of categories
+
+    :return: Dict of categories"""
+    snap_categories = categories
+    snap_categories["categories"] = snap_categories["items"]
+
+    del snap_categories["items"]
+
+    return snap_categories

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -265,11 +265,15 @@ def get_listing_snap(snap_name):
 
     categories = get_categories(categories_results)
 
+    snap_categories = logic.replace_reserved_categories_key(
+        snap_details["categories"]
+    )
+
     context = {
         "snap_id": snap_details["snap_id"],
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
-        "snap_categories": snap_details["categories"],
+        "snap_categories": snap_categories,
         "summary": snap_details["summary"],
         "description": snap_details["description"],
         "icon_url": icon_urls[0] if icon_urls else None,
@@ -424,11 +428,15 @@ def post_listing_snap(snap_name):
 
             categories = get_categories(categories_results)
 
+            snap_categories = logic.replace_reserved_categories_key(
+                snap_details["categories"]
+            )
+
             context = {
                 # read-only values from details API
                 "snap_id": snap_details["snap_id"],
                 "snap_name": snap_details["snap_name"],
-                "snap_categories": snap_details["categories"],
+                "snap_categories": snap_categories,
                 "icon_url": icon_urls[0] if icon_urls else None,
                 "publisher_name": snap_details["publisher"]["display-name"],
                 "username": snap_details["publisher"]["username"],


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1458

## Done
- Added select boxes and interaction as described in https://docs.google.com/document/d/1Teovi34AVAkHtFdO9agsILqS96QVmaDqZ9DMKyFs48U/edit
- Updated the backend to transform the snap categories to avoid reserved jinja2 key

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snaps
- Select a snap
- You should see a new `Category:` section
- Play around with the categories, adding categories and secondary categories
- You should not be able to select the same category for both the primary and secondary categories
- When you're happy click "Save"
- Visit http://0.0.0.0:8004/search?category=<category_name> for the category(s) you selected
- If you go to the last page you should see your snap (may require patience and refreshes)
- **WHEN DONE, REMOVE THE CATEGORIES FROM TEST SNAPS AS THEY WILL DISPLAY ON PRODUCTION**