### PR TITLE
Autoselect available revisions

### DIFF
--- a/static/js/publisher/release/actions/availableRevisionsSelect.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.js
@@ -1,8 +1,30 @@
+import { getArchsFromRevisionsMap } from "../releasesState";
+import { selectRevision } from "./channelMap";
+import { getSelectedAvailableRevisionsForArch } from "../selectors";
+
 export const SET_AVAILABLE_REVISIONS_SELECT = "SET_AVAILABLE_REVISIONS_SELECT";
 
 export function setAvailableRevisionsSelect(value) {
   return {
     type: SET_AVAILABLE_REVISIONS_SELECT,
     payload: { value }
+  };
+}
+
+export function selectAvailableRevisions(value) {
+  return (dispatch, getState) => {
+    dispatch(setAvailableRevisionsSelect(value));
+
+    // for each architecture
+    const archs = getArchsFromRevisionsMap(getState().revisions);
+    // get latest revision to select
+    archs.forEach(arch => {
+      const revisions = getSelectedAvailableRevisionsForArch(getState(), arch);
+
+      const revisionToSelect = revisions[0];
+      if (revisionToSelect) {
+        dispatch(selectRevision(revisionToSelect));
+      }
+    });
   };
 }

--- a/static/js/publisher/release/actions/availableRevisionsSelect.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.js
@@ -1,6 +1,10 @@
-import { getArchitectures } from "../selectors";
+import { AVAILABLE_REVISIONS_SELECT_RECENT } from "../constants";
 import { selectRevision, clearSelectedRevisions } from "./channelMap";
-import { getSelectedAvailableRevisionsForArch } from "../selectors";
+import {
+  getArchitectures,
+  getSelectedAvailableRevisions,
+  getSelectedAvailableRevisionsForArch
+} from "../selectors";
 
 export const SET_AVAILABLE_REVISIONS_SELECT = "SET_AVAILABLE_REVISIONS_SELECT";
 
@@ -16,13 +20,25 @@ export function selectAvailableRevisions(value) {
     dispatch(setAvailableRevisionsSelect(value));
     dispatch(clearSelectedRevisions());
 
+    const state = getState();
+
     // for each architecture
     const archs = getArchitectures(getState());
+    let revisionsFilter = () => true;
+
+    // for Recent select only revisions from most recent uploaded version
+    if (value === AVAILABLE_REVISIONS_SELECT_RECENT) {
+      // find most recent version
+      const recentVersion = getSelectedAvailableRevisions(state)[0].version;
+      // filter most recent revision with given version
+      revisionsFilter = revision => revision.version === recentVersion;
+    }
+
     // get latest revision to select
     archs.forEach(arch => {
-      const revisions = getSelectedAvailableRevisionsForArch(getState(), arch);
+      const revisions = getSelectedAvailableRevisionsForArch(state, arch);
 
-      const revisionToSelect = revisions[0];
+      const revisionToSelect = revisions.filter(revisionsFilter)[0];
       if (revisionToSelect) {
         dispatch(selectRevision(revisionToSelect));
       }

--- a/static/js/publisher/release/actions/availableRevisionsSelect.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.js
@@ -23,15 +23,19 @@ export function selectAvailableRevisions(value) {
     const state = getState();
 
     // for each architecture
-    const archs = getArchitectures(getState());
+    const archs = getArchitectures(state);
     let revisionsFilter = () => true;
 
     // for Recent select only revisions from most recent uploaded version
     if (value === AVAILABLE_REVISIONS_SELECT_RECENT) {
-      // find most recent version
-      const recentVersion = getSelectedAvailableRevisions(state)[0].version;
-      // filter most recent revision with given version
-      revisionsFilter = revision => revision.version === recentVersion;
+      const recentRevisions = getSelectedAvailableRevisions(state);
+
+      if (recentRevisions.length > 0) {
+        // find most recent version
+        const recentVersion = recentRevisions[0].version;
+        // filter most recent revision with given version
+        revisionsFilter = revision => revision.version === recentVersion;
+      }
     }
 
     // get latest revision to select

--- a/static/js/publisher/release/actions/availableRevisionsSelect.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.js
@@ -1,4 +1,4 @@
-import { getArchsFromRevisionsMap } from "../releasesState";
+import { getArchitectures } from "../selectors";
 import { selectRevision, clearSelectedRevisions } from "./channelMap";
 import { getSelectedAvailableRevisionsForArch } from "../selectors";
 
@@ -17,7 +17,7 @@ export function selectAvailableRevisions(value) {
     dispatch(clearSelectedRevisions());
 
     // for each architecture
-    const archs = getArchsFromRevisionsMap(getState().revisions);
+    const archs = getArchitectures(getState());
     // get latest revision to select
     archs.forEach(arch => {
       const revisions = getSelectedAvailableRevisionsForArch(getState(), arch);

--- a/static/js/publisher/release/actions/availableRevisionsSelect.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.js
@@ -1,5 +1,5 @@
 import { getArchsFromRevisionsMap } from "../releasesState";
-import { selectRevision } from "./channelMap";
+import { selectRevision, clearSelectedRevisions } from "./channelMap";
 import { getSelectedAvailableRevisionsForArch } from "../selectors";
 
 export const SET_AVAILABLE_REVISIONS_SELECT = "SET_AVAILABLE_REVISIONS_SELECT";
@@ -14,6 +14,7 @@ export function setAvailableRevisionsSelect(value) {
 export function selectAvailableRevisions(value) {
   return (dispatch, getState) => {
     dispatch(setAvailableRevisionsSelect(value));
+    dispatch(clearSelectedRevisions());
 
     // for each architecture
     const archs = getArchsFromRevisionsMap(getState().revisions);

--- a/static/js/publisher/release/actions/availableRevisionsSelect.test.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.test.js
@@ -1,7 +1,15 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+const mockStore = configureMockStore([thunk]);
+
 import {
   SET_AVAILABLE_REVISIONS_SELECT,
-  setAvailableRevisionsSelect
+  setAvailableRevisionsSelect,
+  selectAvailableRevisions
 } from "./availableRevisionsSelect";
+import { selectRevision } from "./channelMap";
+import { AVAILABLE_REVISIONS_SELECT_UNRELEASED } from "../constants";
 
 describe("availableRevisionsSelect actions", () => {
   describe("setAvailableRevisionsSelect", () => {
@@ -15,6 +23,44 @@ describe("availableRevisionsSelect actions", () => {
 
     it("should supply a payload with a value to set", () => {
       expect(setAvailableRevisionsSelect(value).payload.value).toEqual(value);
+    });
+  });
+
+  describe("selectAvailableRevisions", () => {
+    const value = "test";
+    const revisions = {
+      1: { revision: 1, architectures: ["test64", "amd42"] },
+      2: { revision: 2, architectures: ["test64"] },
+      3: { revision: 3, architectures: ["abc42"], channels: ["test/edge"] }
+    };
+    let store;
+
+    beforeEach(() => {
+      store = mockStore({
+        // mock store state is not modified by actions
+        // so this is the value we expect after the actions are dispatched
+        availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_UNRELEASED,
+        revisions
+      });
+
+      store.dispatch(selectAvailableRevisions(value));
+    });
+
+    it("should dispatch SET_AVAILABLE_REVISIONS_SELECT action", () => {
+      expect(store.getActions()).toContainEqual(
+        setAvailableRevisionsSelect(value)
+      );
+    });
+
+    it("should dispatch SELECT_REVISION action for latest revision from every selected architecture", () => {
+      expect(store.getActions()).toContainEqual(selectRevision(revisions[1]));
+      expect(store.getActions()).toContainEqual(selectRevision(revisions[2]));
+    });
+
+    it("should not dispatch SELECT_REVISION action for not selected revisions", () => {
+      expect(store.getActions()).not.toContainEqual(
+        selectRevision(revisions[3])
+      );
     });
   });
 });

--- a/static/js/publisher/release/actions/availableRevisionsSelect.test.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.test.js
@@ -8,7 +8,7 @@ import {
   setAvailableRevisionsSelect,
   selectAvailableRevisions
 } from "./availableRevisionsSelect";
-import { selectRevision } from "./channelMap";
+import { selectRevision, clearSelectedRevisions } from "./channelMap";
 import { AVAILABLE_REVISIONS_SELECT_UNRELEASED } from "../constants";
 
 describe("availableRevisionsSelect actions", () => {
@@ -50,6 +50,10 @@ describe("availableRevisionsSelect actions", () => {
       expect(store.getActions()).toContainEqual(
         setAvailableRevisionsSelect(value)
       );
+    });
+
+    it("should dispatch CLEAR_SELECTED_REVISIONS action", () => {
+      expect(store.getActions()).toContainEqual(clearSelectedRevisions());
     });
 
     it("should dispatch SELECT_REVISION action for latest revision from every selected architecture", () => {

--- a/static/js/publisher/release/actions/availableRevisionsSelect.test.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.test.js
@@ -8,7 +8,11 @@ import {
   setAvailableRevisionsSelect,
   selectAvailableRevisions
 } from "./availableRevisionsSelect";
-import { selectRevision, clearSelectedRevisions } from "./channelMap";
+import {
+  SELECT_REVISION,
+  selectRevision,
+  clearSelectedRevisions
+} from "./channelMap";
 import {
   AVAILABLE_REVISIONS_SELECT_RECENT,
   AVAILABLE_REVISIONS_SELECT_UNRELEASED
@@ -73,47 +77,77 @@ describe("availableRevisionsSelect actions", () => {
     describe("when 'Recent' are selected", () => {
       const value = AVAILABLE_REVISIONS_SELECT_RECENT;
 
-      const revisions = {
-        1: {
-          revision: 1,
-          version: "1.test",
-          architectures: ["arch1"],
-          created_at: new Date()
-        },
-        2: {
-          revision: 2,
-          version: "2.test",
-          architectures: ["arch2"],
-          created_at: new Date()
-        },
-        3: {
-          revision: 3,
-          version: "1.test",
-          architectures: ["arch3"],
-          created_at: new Date()
-        }
-      };
+      describe("when there are no revisions", () => {
+        const revisions = {};
 
-      beforeEach(() => {
-        store = mockStore({
-          // mock store state is not modified by actions
-          // so this is the value we expect after the actions are dispatched
-          availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_RECENT,
-          revisions
+        it("should not dispatch any SELECT_REVISION actions", () => {
+          store = mockStore({
+            // mock store state is not modified by actions
+            // so this is the value we expect after the actions are dispatched
+            availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_RECENT,
+            revisions
+          });
+          store.dispatch(selectAvailableRevisions(value));
+
+          const actions = store.getActions();
+
+          expect(actions).not.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                type: SELECT_REVISION
+              })
+            ])
+          );
+        });
+      });
+
+      describe("when there are revisions in the state", () => {
+        const revisions = {
+          1: {
+            revision: 1,
+            version: "1.test",
+            architectures: ["arch1"],
+            created_at: new Date()
+          },
+          2: {
+            revision: 2,
+            version: "2.test",
+            architectures: ["arch2"],
+            created_at: new Date()
+          },
+          3: {
+            revision: 3,
+            version: "1.test",
+            architectures: ["arch3"],
+            created_at: new Date()
+          }
+        };
+
+        beforeEach(() => {
+          store = mockStore({
+            // mock store state is not modified by actions
+            // so this is the value we expect after the actions are dispatched
+            availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_RECENT,
+            revisions
+          });
+
+          store.dispatch(selectAvailableRevisions(value));
         });
 
-        store.dispatch(selectAvailableRevisions(value));
-      });
+        it("should dispatch SELECT_REVISION action for latest revisions with most recent version", () => {
+          expect(store.getActions()).toContainEqual(
+            selectRevision(revisions[1])
+          );
+          expect(store.getActions()).toContainEqual(
+            selectRevision(revisions[3])
+          );
+        });
 
-      it("should dispatch SELECT_REVISION action for latest revisions with most recent version", () => {
-        expect(store.getActions()).toContainEqual(selectRevision(revisions[1]));
-        expect(store.getActions()).toContainEqual(selectRevision(revisions[3]));
-      });
-
-      it("should dispatch SELECT_REVISION action for latest revisions with other versions", () => {
-        expect(store.getActions()).not.toContainEqual(
-          selectRevision(revisions[2])
-        );
+        it("should dispatch SELECT_REVISION action for latest revisions with other versions", () => {
+          expect(store.getActions()).not.toContainEqual(
+            selectRevision(revisions[2])
+          );
+        });
       });
     });
   });

--- a/static/js/publisher/release/actions/availableRevisionsSelect.test.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.test.js
@@ -9,7 +9,10 @@ import {
   selectAvailableRevisions
 } from "./availableRevisionsSelect";
 import { selectRevision, clearSelectedRevisions } from "./channelMap";
-import { AVAILABLE_REVISIONS_SELECT_UNRELEASED } from "../constants";
+import {
+  AVAILABLE_REVISIONS_SELECT_RECENT,
+  AVAILABLE_REVISIONS_SELECT_UNRELEASED
+} from "../constants";
 
 describe("availableRevisionsSelect actions", () => {
   describe("setAvailableRevisionsSelect", () => {
@@ -65,6 +68,53 @@ describe("availableRevisionsSelect actions", () => {
       expect(store.getActions()).not.toContainEqual(
         selectRevision(revisions[3])
       );
+    });
+
+    describe("when 'Recent' are selected", () => {
+      const value = AVAILABLE_REVISIONS_SELECT_RECENT;
+
+      const revisions = {
+        1: {
+          revision: 1,
+          version: "1.test",
+          architectures: ["arch1"],
+          created_at: new Date()
+        },
+        2: {
+          revision: 2,
+          version: "2.test",
+          architectures: ["arch2"],
+          created_at: new Date()
+        },
+        3: {
+          revision: 3,
+          version: "1.test",
+          architectures: ["arch3"],
+          created_at: new Date()
+        }
+      };
+
+      beforeEach(() => {
+        store = mockStore({
+          // mock store state is not modified by actions
+          // so this is the value we expect after the actions are dispatched
+          availableRevisionsSelect: AVAILABLE_REVISIONS_SELECT_RECENT,
+          revisions
+        });
+
+        store.dispatch(selectAvailableRevisions(value));
+      });
+
+      it("should dispatch SELECT_REVISION action for latest revisions with most recent version", () => {
+        expect(store.getActions()).toContainEqual(selectRevision(revisions[1]));
+        expect(store.getActions()).toContainEqual(selectRevision(revisions[3]));
+      });
+
+      it("should dispatch SELECT_REVISION action for latest revisions with other versions", () => {
+        expect(store.getActions()).not.toContainEqual(
+          selectRevision(revisions[2])
+        );
+      });
     });
   });
 });

--- a/static/js/publisher/release/actions/channelMap.js
+++ b/static/js/publisher/release/actions/channelMap.js
@@ -1,5 +1,6 @@
 export const INIT_CHANNEL_MAP = "INIT_CHANNEL_MAP";
 export const SELECT_REVISION = "SELECT_REVISION";
+export const CLEAR_SELECTED_REVISIONS = "CLEAR_SELECTED_REVISIONS";
 export const RELEASE_REVISION_SUCCESS = "RELEASE_REVISION_SUCCESS";
 export const CLOSE_CHANNEL_SUCCESS = "CLOSE_CHANNEL_SUCCESS";
 
@@ -21,6 +22,12 @@ export function toggleRevision(revision) {
   return {
     type: SELECT_REVISION,
     payload: { revision, toggle: true }
+  };
+}
+
+export function clearSelectedRevisions() {
+  return {
+    type: CLEAR_SELECTED_REVISIONS
   };
 }
 

--- a/static/js/publisher/release/actions/channelMap.js
+++ b/static/js/publisher/release/actions/channelMap.js
@@ -13,7 +13,14 @@ export function initChannelMap(channelMap) {
 export function selectRevision(revision) {
   return {
     type: SELECT_REVISION,
-    payload: { revision }
+    payload: { revision, toggle: false }
+  };
+}
+
+export function toggleRevision(revision) {
+  return {
+    type: SELECT_REVISION,
+    payload: { revision, toggle: true }
   };
 }
 

--- a/static/js/publisher/release/actions/channelMap.test.js
+++ b/static/js/publisher/release/actions/channelMap.test.js
@@ -5,6 +5,7 @@ import {
   CLOSE_CHANNEL_SUCCESS,
   initChannelMap,
   selectRevision,
+  toggleRevision,
   releaseRevisionSuccess,
   closeChannelSuccess
 } from "./channelMap";
@@ -38,8 +39,26 @@ describe("channelMap actions", () => {
       expect(selectRevision(revision).type).toBe(SELECT_REVISION);
     });
 
-    it("should supply a payload with channel map data", () => {
+    it("should supply a payload with revision data", () => {
       expect(selectRevision(revision).payload.revision).toEqual(revision);
+    });
+
+    it("should supply a payload with toggle set to false", () => {
+      expect(selectRevision(revision).payload.toggle).toBe(false);
+    });
+  });
+
+  describe("toggleRevision", () => {
+    it("should create an action to select revision", () => {
+      expect(toggleRevision(revision).type).toBe(SELECT_REVISION);
+    });
+
+    it("should supply a payload with revision data", () => {
+      expect(toggleRevision(revision).payload.revision).toEqual(revision);
+    });
+
+    it("should supply a payload with toggle set to false", () => {
+      expect(toggleRevision(revision).payload.toggle).toBe(true);
     });
   });
 

--- a/static/js/publisher/release/actions/channelMap.test.js
+++ b/static/js/publisher/release/actions/channelMap.test.js
@@ -1,11 +1,13 @@
 import {
   INIT_CHANNEL_MAP,
   SELECT_REVISION,
+  CLEAR_SELECTED_REVISIONS,
   RELEASE_REVISION_SUCCESS,
   CLOSE_CHANNEL_SUCCESS,
   initChannelMap,
   selectRevision,
   toggleRevision,
+  clearSelectedRevisions,
   releaseRevisionSuccess,
   closeChannelSuccess
 } from "./channelMap";
@@ -59,6 +61,12 @@ describe("channelMap actions", () => {
 
     it("should supply a payload with toggle set to false", () => {
       expect(toggleRevision(revision).payload.toggle).toBe(true);
+    });
+  });
+
+  describe("clearSelectedRevisions", () => {
+    it("should create an action to clear selected revisions", () => {
+      expect(clearSelectedRevisions().type).toBe(CLEAR_SELECTED_REVISIONS);
     });
   });
 

--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -39,13 +39,17 @@ export class AvailableRevisionsMenu extends Component {
 
   renderItem(item) {
     const count = this.props.getFilteredCount(item);
+    const isDisabled = count === 0;
+    const className = `p-contextual-menu__link ${
+      isDisabled ? "is-disabled" : ""
+    }`;
 
     return (
       <a
         key={`available-menu-item-${item}`}
-        className="p-contextual-menu__link"
+        className={className}
         href="#"
-        onClick={this.itemClick.bind(this, item)}
+        onClick={!isDisabled ? this.itemClick.bind(this, item) : undefined}
       >
         {menuLabels[item]} <span className="u-float--right">({count})</span>
       </a>

--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import ContextualMenu from "./contextualMenu";
 
 import { selectAvailableRevisions } from "../actions/availableRevisionsSelect";
+import { getAvailableRevisionsBySelection } from "../selectors";
 
 import {
   AVAILABLE_REVISIONS_SELECT_UNRELEASED,
@@ -36,21 +37,27 @@ export class AvailableRevisionsMenu extends Component {
     }
   }
 
+  renderItem(item) {
+    const count = this.props.getFilteredCount(item);
+
+    return (
+      <a
+        key={`available-menu-item-${item}`}
+        className="p-contextual-menu__link"
+        href="#"
+        onClick={this.itemClick.bind(this, item)}
+      >
+        {menuLabels[item]} <span className="u-float--right">({count})</span>
+      </a>
+    );
+  }
+
   renderItems() {
     const items = Object.keys(menuLabels);
 
     return (
       <span className="p-contextual-menu__group">
-        {items.map(item => (
-          <a
-            key={`available-menu-item-${item}`}
-            className="p-contextual-menu__link"
-            href="#"
-            onClick={this.itemClick.bind(this, item)}
-          >
-            {menuLabels[item]}
-          </a>
-        ))}
+        {items.map(this.renderItem.bind(this))}
       </span>
     );
   }
@@ -71,12 +78,15 @@ export class AvailableRevisionsMenu extends Component {
 
 AvailableRevisionsMenu.propTypes = {
   value: PropTypes.string.isRequired,
-  setValue: PropTypes.func.isRequired
+  setValue: PropTypes.func.isRequired,
+  getFilteredCount: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
   return {
-    value: state.availableRevisionsSelect
+    value: state.availableRevisionsSelect,
+    getFilteredCount: value =>
+      getAvailableRevisionsBySelection(state, value).length
   };
 };
 

--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 
 import ContextualMenu from "./contextualMenu";
 
-import { setAvailableRevisionsSelect } from "../actions/availableRevisionsSelect";
+import { selectAvailableRevisions } from "../actions/availableRevisionsSelect";
 
 import {
   AVAILABLE_REVISIONS_SELECT_UNRELEASED,
@@ -78,7 +78,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    setValue: value => dispatch(setAvailableRevisionsSelect(value))
+    setValue: value => dispatch(selectAvailableRevisions(value))
   };
 };
 

--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -24,6 +24,10 @@ export class AvailableRevisionsMenu extends Component {
     this.setMenuRef = menu => (this.menu = menu);
   }
 
+  componentDidMount() {
+    this.props.setValue(AVAILABLE_REVISIONS_SELECT_RECENT);
+  }
+
   itemClick(value, event) {
     this.props.setValue(value);
 

--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -26,7 +26,15 @@ export class AvailableRevisionsMenu extends Component {
   }
 
   componentDidMount() {
-    this.props.setValue(AVAILABLE_REVISIONS_SELECT_RECENT);
+    const { setValue, getFilteredCount } = this.props;
+
+    if (getFilteredCount(AVAILABLE_REVISIONS_SELECT_RECENT) > 0) {
+      setValue(AVAILABLE_REVISIONS_SELECT_RECENT);
+    } else if (getFilteredCount(AVAILABLE_REVISIONS_SELECT_UNRELEASED) > 0) {
+      setValue(AVAILABLE_REVISIONS_SELECT_UNRELEASED);
+    } else {
+      setValue(AVAILABLE_REVISIONS_SELECT_ALL);
+    }
   }
 
   itemClick(value, event) {

--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -58,7 +58,7 @@ export default class PromoteMenu extends Component {
         appearance="neutral"
         isDisabled={isDisabled}
         label="⤴"
-        title="Promote revisions"
+        title="Promote to other channels"
         ref={this.setMenuRef}
       >
         {this.renderItems()}

--- a/static/js/publisher/release/reducers/channelMap.js
+++ b/static/js/publisher/release/reducers/channelMap.js
@@ -2,6 +2,7 @@ import { AVAILABLE } from "../constants";
 import {
   INIT_CHANNEL_MAP,
   SELECT_REVISION,
+  CLEAR_SELECTED_REVISIONS,
   RELEASE_REVISION_SUCCESS,
   CLOSE_CHANNEL_SUCCESS
 } from "../actions/channelMap";
@@ -74,6 +75,11 @@ export default function channelMap(state = {}, action) {
         action.payload.revision,
         action.payload.toggle
       );
+    case CLEAR_SELECTED_REVISIONS:
+      return {
+        ...state,
+        [AVAILABLE]: {}
+      };
     case RELEASE_REVISION_SUCCESS:
       return releaseRevision(
         state,

--- a/static/js/publisher/release/reducers/channelMap.js
+++ b/static/js/publisher/release/reducers/channelMap.js
@@ -6,7 +6,7 @@ import {
   CLOSE_CHANNEL_SUCCESS
 } from "../actions/channelMap";
 
-function selectRevision(state, revision) {
+function selectRevision(state, revision, toggle) {
   // TODO: support multiple archs
   const arch = revision.architectures[0];
 
@@ -16,6 +16,7 @@ function selectRevision(state, revision) {
   };
 
   if (
+    toggle &&
     state[AVAILABLE][arch] &&
     state[AVAILABLE][arch].revision === revision.revision
   ) {
@@ -68,7 +69,11 @@ export default function channelMap(state = {}, action) {
         ...action.payload.channelMap
       };
     case SELECT_REVISION:
-      return selectRevision(state, action.payload.revision);
+      return selectRevision(
+        state,
+        action.payload.revision,
+        action.payload.toggle
+      );
     case RELEASE_REVISION_SUCCESS:
       return releaseRevision(
         state,

--- a/static/js/publisher/release/reducers/channelMap.test.js
+++ b/static/js/publisher/release/reducers/channelMap.test.js
@@ -2,6 +2,7 @@ import channelMap from "./channelMap";
 import {
   INIT_CHANNEL_MAP,
   SELECT_REVISION,
+  CLEAR_SELECTED_REVISIONS,
   RELEASE_REVISION_SUCCESS,
   CLOSE_CHANNEL_SUCCESS
 } from "../actions/channelMap";
@@ -113,6 +114,30 @@ describe("channelMap", () => {
           expect(result[AVAILABLE]["abc42"]).toBeUndefined();
         });
       });
+    });
+  });
+
+  describe("on CLEAR_SELECTED_REVISIONS action", () => {
+    const revision = {
+      revision: 1,
+      version: "1",
+      architectures: ["abc42"]
+    };
+
+    const stateWithSelectedRevision = {
+      [AVAILABLE]: {
+        abc42: revision
+      }
+    };
+
+    const clearSelectedAction = {
+      type: CLEAR_SELECTED_REVISIONS
+    };
+
+    it("should remove all selected revisions from AVAILABLE 'channel'", () => {
+      const result = channelMap(stateWithSelectedRevision, clearSelectedAction);
+
+      expect(result[AVAILABLE]).toEqual({});
     });
   });
 

--- a/static/js/publisher/release/reducers/channelMap.test.js
+++ b/static/js/publisher/release/reducers/channelMap.test.js
@@ -66,17 +66,52 @@ describe("channelMap", () => {
     describe("when revision is already selected", () => {
       const stateWithSelectedRevision = {
         [AVAILABLE]: {
-          abc42: revision
+          abc42: { revision: 2 }
         }
       };
 
-      it("should remove selected revision from AVAILABLE channel", () => {
+      it("should update selected revision", () => {
         const result = channelMap(
           stateWithSelectedRevision,
           selectRevisionAction
         );
 
-        expect(result[AVAILABLE]["abc42"]).toBeUndefined();
+        expect(result[AVAILABLE]["abc42"]).toEqual(revision);
+      });
+    });
+
+    describe("when toggle is set to true", () => {
+      const toggleRevisionAction = {
+        ...selectRevisionAction,
+        payload: {
+          revision,
+          toggle: true
+        }
+      };
+
+      describe("when revision is not yet selected", () => {
+        it("should add selected revision to AVAILABLE channel", () => {
+          const result = channelMap({}, toggleRevisionAction);
+
+          expect(result[AVAILABLE]["abc42"]).toEqual(revision);
+        });
+      });
+
+      describe("when revision is already selected", () => {
+        const stateWithSelectedRevision = {
+          [AVAILABLE]: {
+            abc42: revision
+          }
+        };
+
+        it("should remove selected revision from AVAILABLE channel", () => {
+          const result = channelMap(
+            stateWithSelectedRevision,
+            toggleRevisionAction
+          );
+
+          expect(result[AVAILABLE]["abc42"]).toBeUndefined();
+        });
       });
     });
   });

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -20,7 +20,6 @@ import { undoRelease, cancelPendingReleases } from "./actions/pendingReleases";
 import { getPendingChannelMap } from "./selectors";
 
 import {
-  getArchsFromRevisionsMap,
   getTracksFromChannelMap,
   getRevisionsMap,
   initReleasesData,
@@ -52,9 +51,7 @@ class ReleasesController extends Component {
       error: null,
       isLoading: false,
       // list of all available tracks
-      tracks: tracks,
-      // list of architectures released to (or selected to be released to)
-      archs: getArchsFromRevisionsMap(revisionsMap)
+      tracks: tracks
     };
   }
 
@@ -284,7 +281,6 @@ class ReleasesController extends Component {
 
         <ReleasesTable
           // not moved to redux yet
-          archs={this.state.archs}
           currentTrack={this.state.currentTrack}
         />
       </Fragment>

--- a/static/js/publisher/release/releasesState.js
+++ b/static/js/publisher/release/releasesState.js
@@ -91,19 +91,6 @@ function getReleaseDataFromChannelMap(channelMapsList, revisionsMap) {
   return releasedChannels;
 }
 
-// update list of architectures based on revisions uploaded
-function getArchsFromRevisionsMap(revisionsMap) {
-  let archs = [];
-  Object.values(revisionsMap).forEach(revision => {
-    archs = archs.concat(revision.architectures);
-  });
-
-  // make archs unique and sorted
-  archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
-
-  return archs.sort();
-}
-
 // for channel without release get next (less risk) channel with a release
 function getTrackingChannel(releasedChannels, track, risk, arch) {
   let tracking = null;
@@ -166,7 +153,6 @@ function getPendingRelease(pendingReleases, arch, channel) {
 export {
   getPendingRelease,
   getUnassignedRevisions,
-  getArchsFromRevisionsMap,
   getTracksFromChannelMap,
   getTrackingChannel,
   getRevisionsMap,

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -9,7 +9,7 @@ import {
   BETA,
   EDGE
 } from "./constants";
-import { getPendingChannelMap } from "./selectors";
+import { getArchitectures, getPendingChannelMap } from "./selectors";
 import { isInDevmode } from "./devmodeIcon";
 import ChannelMenu from "./components/channelMenu";
 import PromoteMenu from "./components/promoteMenu";
@@ -248,6 +248,7 @@ ReleasesTable.propTypes = {
   channelMap: PropTypes.object.isRequired,
   pendingCloses: PropTypes.array.isRequired,
 
+  archs: PropTypes.array.isRequired,
   pendingChannelMap: PropTypes.object,
 
   // actions
@@ -255,7 +256,6 @@ ReleasesTable.propTypes = {
   promoteChannel: PropTypes.func.isRequired,
 
   // state (non redux)
-  archs: PropTypes.array.isRequired,
   currentTrack: PropTypes.string.isRequired
 };
 
@@ -265,6 +265,7 @@ const mapStateToProps = state => {
     isHistoryOpen: state.history.isOpen,
     channelMap: state.channelMap,
     pendingCloses: state.pendingCloses,
+    archs: getArchitectures(state),
     pendingChannelMap: getPendingChannelMap(state)
   };
 };

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -14,7 +14,7 @@ import {
 } from "./constants";
 
 import { closeHistory } from "./actions/history";
-import { selectRevision } from "./actions/channelMap";
+import { toggleRevision } from "./actions/channelMap";
 import {
   getFilteredReleaseHistory,
   getSelectedRevisions,
@@ -27,7 +27,7 @@ import { getPendingRelease } from "./releasesState";
 
 class RevisionsList extends Component {
   revisionSelectChange(revision) {
-    this.props.selectRevision(revision);
+    this.props.toggleRevision(revision);
   }
 
   renderRow(revision, isSelectable, showAllColumns, isPending) {
@@ -272,7 +272,7 @@ RevisionsList.propTypes = {
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
-  selectRevision: PropTypes.func.isRequired
+  toggleRevision: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => {
@@ -298,7 +298,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     closeHistoryPanel: () => dispatch(closeHistory()),
-    selectRevision: revision => dispatch(selectRevision(revision))
+    toggleRevision: revision => dispatch(toggleRevision(revision))
   };
 };
 

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -99,32 +99,38 @@ export function getPendingChannelMap(state) {
   return pendingChannelMap;
 }
 
+// get all revisions ordered from newest (based on revsion id)
+export function getAllRevisions(state) {
+  return Object.values(state.revisions).reverse();
+}
+
+// get all revisions not released to any channel yet
+export function getUnreleasedRevisions(state) {
+  return getAllRevisions(state).filter(
+    revision => !revision.channels || revision.channels.length === 0
+  );
+}
+
+// get unreleased revisions not older then 7 days
+export function getRecentRevisions(state) {
+  const interval = 1000 * 60 * 60 * 24 * 7; // 7 days
+  return getUnreleasedRevisions(state).filter(
+    r => Date.now() - new Date(r.created_at).getTime() < interval
+  );
+}
+
 // return list of revisions based on current availableRevisionsSelect value
 export function getSelectedAvailableRevisions(state) {
-  const { revisions, availableRevisionsSelect } = state;
+  const { availableRevisionsSelect } = state;
 
-  // get all revisions ordered from newest (based on revsion id)
-  let availableRevisions = Object.values(revisions).reverse();
-
-  if (
-    availableRevisionsSelect === AVAILABLE_REVISIONS_SELECT_UNRELEASED ||
-    availableRevisionsSelect === AVAILABLE_REVISIONS_SELECT_RECENT
-  ) {
-    // filter revisions not released to any channel yet
-    availableRevisions = availableRevisions.filter(
-      revision => !revision.channels || revision.channels.length === 0
-    );
+  switch (availableRevisionsSelect) {
+    case AVAILABLE_REVISIONS_SELECT_RECENT:
+      return getRecentRevisions(state);
+    case AVAILABLE_REVISIONS_SELECT_UNRELEASED:
+      return getUnreleasedRevisions(state);
+    default:
+      return getAllRevisions(state);
   }
-
-  if (availableRevisionsSelect === AVAILABLE_REVISIONS_SELECT_RECENT) {
-    const interval = 1000 * 60 * 60 * 24 * 7; // 7 days
-    // filter revisions not older then 7 days
-    availableRevisions = availableRevisions.filter(
-      r => Date.now() - new Date(r.created_at).getTime() < interval
-    );
-  }
-
-  return availableRevisions;
 }
 
 // return list of revisions based on current availableRevisionsSelect value

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -119,11 +119,9 @@ export function getRecentRevisions(state) {
   );
 }
 
-// return list of revisions based on current availableRevisionsSelect value
-export function getSelectedAvailableRevisions(state) {
-  const { availableRevisionsSelect } = state;
-
-  switch (availableRevisionsSelect) {
+// return list of revisions based on given selection value
+export function getAvailableRevisionsBySelection(state, value) {
+  switch (value) {
     case AVAILABLE_REVISIONS_SELECT_RECENT:
       return getRecentRevisions(state);
     case AVAILABLE_REVISIONS_SELECT_UNRELEASED:
@@ -131,6 +129,12 @@ export function getSelectedAvailableRevisions(state) {
     default:
       return getAllRevisions(state);
   }
+}
+
+// return list of revisions based on current availableRevisionsSelect value
+export function getSelectedAvailableRevisions(state) {
+  const { availableRevisionsSelect } = state;
+  return getAvailableRevisionsBySelection(state, availableRevisionsSelect);
 }
 
 // return list of revisions based on current availableRevisionsSelect value

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -140,3 +140,17 @@ export function getSelectedAvailableRevisionsForArch(state, arch) {
     revision.architectures.includes(arch)
   );
 }
+
+// get list of architectures of uploaded revisions
+export function getArchitectures(state) {
+  let archs = [];
+
+  getAllRevisions(state).forEach(revision => {
+    archs = archs.concat(revision.architectures);
+  });
+
+  // make archs unique and sorted
+  archs = archs.filter((item, i, ar) => ar.indexOf(item) === i);
+
+  return archs.sort();
+}

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -11,7 +11,8 @@ import {
   getPendingChannelMap,
   hasDevmodeRevisions,
   getSelectedAvailableRevisions,
-  getSelectedAvailableRevisionsForArch
+  getSelectedAvailableRevisionsForArch,
+  getArchitectures
 } from "./index";
 
 import reducers from "../reducers";
@@ -442,5 +443,25 @@ describe("getSelectedAvailableRevisionsByArch", () => {
         stateWithAllSelected.revisions[1]
       ]);
     });
+  });
+});
+
+describe("getArchitectures", () => {
+  const initialState = reducers(undefined, {});
+  const stateWithRevisions = {
+    ...initialState,
+    revisions: {
+      1: { revision: 1, architectures: ["test64"] },
+      2: { revision: 2, architectures: ["amd42", "abc64"] },
+      3: { revision: 3, architectures: ["test64", "amd42"] }
+    }
+  };
+
+  it("should return alphabetical list of all architectures", () => {
+    expect(getArchitectures(stateWithRevisions)).toEqual([
+      "abc64",
+      "amd42",
+      "test64"
+    ]);
   });
 });


### PR DESCRIPTION
Part of #1473

Autoselects latest revisions when available revisions dropdown value is changed

### QA
- run or demo
- go to Releases page of any snap
- 'Recent' available revisions should be selected by default (if there are any)
- if there are any recent revisions they will be selected by default (show in the table as 'orange')
- Recent option should select revisions only from one most recent version (not from all architectures)
- If there are no revisions in Recent or Unreleased these options should be disabled
- change Recent to 'Unreleased' or 'All'
- selected revisions should be updated based on the choice (note that for Recent and Unrelased selection will be the same, because Recent is subset of Unreleased)

Couple test snaps:
- snap with some recent revisions (not in all architectures): [nextcloud](https://snapcraft-io-canonical-websites-pr-1485.run.demo.haus/nextcloud/releases)
- snap with some unreleased revisions: [skype](https://snapcraft-io-canonical-websites-pr-1485.run.demo.haus/skype/releases)
- snap with just 'All' revisions (all are released): [slack](https://snapcraft-io-canonical-websites-pr-1485.run.demo.haus/slack/releases)

<img width="1044" alt="screen shot 2018-12-21 at 14 57 50" src="https://user-images.githubusercontent.com/83575/50345969-22fc3080-0531-11e9-9f30-7d61e32daab4.png">
