### PR TITLE
Add browser tooltip to promote button

### DIFF
--- a/static/js/publisher/release/components/contextualMenu.js
+++ b/static/js/publisher/release/components/contextualMenu.js
@@ -48,7 +48,7 @@ export default class ContextualMenu extends Component {
   }
 
   render() {
-    const { appearance, isDisabled, position } = this.props;
+    const { appearance, isDisabled, position, title } = this.props;
     const menuClass = "p-contextual-menu" + (position ? `--${position}` : "");
     const buttonClass = `p-button${appearance ? `--${appearance}` : ""}`;
     const className = [
@@ -62,6 +62,7 @@ export default class ContextualMenu extends Component {
     return (
       <button
         className={className}
+        title={title}
         onClick={isDisabled ? null : this.dropdownButtonClick.bind(this)}
       >
         {this.renderIcon()}
@@ -76,6 +77,7 @@ export default class ContextualMenu extends Component {
 ContextualMenu.propTypes = {
   isDisabled: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  title: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   position: PropTypes.oneOf(["left", "center"]), // right is by default

--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -58,6 +58,7 @@ export default class PromoteMenu extends Component {
         appearance="neutral"
         isDisabled={isDisabled}
         label="⤴"
+        title="Promote revisions"
         ref={this.setMenuRef}
       >
         {this.renderItems()}


### PR DESCRIPTION
Vanilla tooltip doesn't work well with contextual menu, so we at least add browser `title` tooltip to make button more clear.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1487.run.demo.haus/
- go to Releases page of any snap
- hover over promote button [⤴]
- browser tooltip with a title should appear

<img width="569" alt="screen shot 2018-12-21 at 12 45 46" src="https://user-images.githubusercontent.com/83575/50341407-f0493c80-051e-11e9-8450-4d2b7bf44ca9.png">
