### PR TITLE
Make contextual menus work in Firefox

### DIFF
--- a/static/js/publisher/release/components/contextualMenu.js
+++ b/static/js/publisher/release/components/contextualMenu.js
@@ -60,7 +60,7 @@ export default class ContextualMenu extends Component {
     ].join(" ");
 
     return (
-      <button
+      <span
         className={className}
         title={title}
         onClick={isDisabled ? null : this.dropdownButtonClick.bind(this)}
@@ -69,7 +69,7 @@ export default class ContextualMenu extends Component {
         <span className="p-contextual-menu__dropdown" aria-hidden="true">
           {this.props.children}
         </span>
-      </button>
+      </span>
     );
   }
 }


### PR DESCRIPTION
Vanilla contextual menu is not clickable in Firefox if its configured on 
a button, so we change it back to span.

### QA
- ./run or demo
- go to Releases page in Firefox
- click on contextual menus (available revisions select, promote button, channel menu with close channel)
- make sure menus are clickable, react to hover, etc