### PR TITLE
Updated contextual menu icon to bin icon

### DIFF
--- a/static/js/publisher/release/components/contextualMenu.js
+++ b/static/js/publisher/release/components/contextualMenu.js
@@ -44,7 +44,7 @@ export default class ContextualMenu extends Component {
   }
 
   renderIcon() {
-    return this.props.label || <i className="p-icon--contextual-menu" />;
+    return this.props.label || <i className="p-icon--delete" />;
   }
 
   render() {


### PR DESCRIPTION
[Initial fix for 1486](https://github.com/canonical-websites/snapcraft.io/issues/1486)

1. Pull the branch or open demo service
2. Open releases page for any published snap
3. Notice on opened channels there should be Promote and Close channel icons
4. Close channel is currently represented with a bin