### PR TITLE
Change channel menu into close channel button

### DIFF
--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -11,7 +11,6 @@ import {
 } from "./constants";
 import { getArchitectures, getPendingChannelMap } from "./selectors";
 import { isInDevmode } from "./devmodeIcon";
-import ChannelMenu from "./components/channelMenu";
 import PromoteMenu from "./components/promoteMenu";
 import AvailableRevisionsMenu from "./components/availableRevisionsMenu";
 import HistoryPanel from "./historyPanel";
@@ -152,10 +151,13 @@ class ReleasesTable extends Component {
                 />
               )}
               {canBeClosed && (
-                <ChannelMenu
-                  channel={channel}
-                  closeChannel={this.onCloseChannel.bind(this, channel)}
-                />
+                <button
+                  className="p-button--base p-icon-button u-no-margin"
+                  onClick={this.onCloseChannel.bind(this, channel)}
+                  title={`Close channel ${channel}`}
+                >
+                  <i className="p-icon--delete" />
+                </button>
               )}
             </span>
           </div>

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -220,6 +220,13 @@
       margin-right: .25rem;
     }
 
+    // workaround for misaligned Vanilla icon
+    // https://github.com/vanilla-framework/vanilla-framework/issues/2085
+    & .p-icon--delete {
+      left: -1px;
+      top: -3px;
+    }
+
     // don't grow these buttons to 100% width on mobile
     @media (max-width: $breakpoint-small) {
       width: auto;


### PR DESCRIPTION
Fixes #1486

### QA
- ./run on https://snapcraft-io-canonical-websites-pr-1492.run.demo.haus
- go to Releases page
- in place of channel menu there should be a bin icon button
- clicking on a button should mark channel to be closed
- click around, promote some releases, close channel, make sure everything works


<img width="578" alt="screen shot 2018-12-21 at 17 09 17" src="https://user-images.githubusercontent.com/83575/50351681-3a441980-0543-11e9-9b33-a7b44072351b.png">
