### PR TITLE
Close unclosed tag on details page

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -46,27 +46,27 @@
 {% block content %}
   <div class="p-strip--light is-shallow snapcraft-banner-background">
     <div class="row">
-        <div class="p-snap-heading">
-          {% if icon_url %}
-            <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
-          {% else %}
-            <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
-          {% endif %}
-          <div class="p-snap-heading__title">
-            <h1 class="p-heading--two p-snap-heading__name">{{ snap_title }}</h1>
-            <p class="p-snap-heading__publisher">
-              by {{ display_name(publisher, username) }}
-              {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
-              <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
-                <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
-                <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
-              </span>
-              {% endif %}
-              {% if is_users_snap %}
-                <a href="/{{ package_name }}/listing">Edit</a>
-              {% endif %}
-            </p>
-          </div>
+      <div class="p-snap-heading">
+        {% if icon_url %}
+          <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" />
+        {% else %}
+          <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" />
+        {% endif %}
+        <div class="p-snap-heading__title">
+          <h1 class="p-heading--two p-snap-heading__name">{{ snap_title }}</h1>
+          <p class="p-snap-heading__publisher">
+            by {{ display_name(publisher, username) }}
+            {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
+            <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
+              <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
+            </span>
+            {% endif %}
+            {% if is_users_snap %}
+              <a href="/{{ package_name }}/listing">Edit</a>
+            {% endif %}
+          </p>
+        </div>
 
       {% if not webapp_config['STORE_QUERY'] %}
         <div class="p-snap-install-buttons">
@@ -187,6 +187,7 @@
         </div>
       </div>
       <div class="row u-equal-height" data-js="blog-article-list" data-snap="{{ package_name }}">
+      </div>
     </div>
   </div>
 
@@ -244,14 +245,22 @@
   {# templates #}
   {% set article_title = {'rendered': '${title}'} %}
   {% set article = {'slug': '${slug}', 'title': article_title} %}
-  <script type="text/template" id="blog-article-template">{% include 'partials/blog-card--minimal.html' %}</script>
+  <script type="text/template" id="blog-article-template">
+    {% include 'partials/blog-card--minimal.html' %}
+  </script>
 
   {% set video = {'type': 'youtube', 'url': '${url}', 'id': '${id}'} %}
-  <script type="text/template" id="video-youtube-template">{% include 'partials/_video.html' %}</script>
+  <script type="text/template" id="video-youtube-template">
+    {% include 'partials/_video.html' %}
+  </script>
   {% set video = {'type': 'vimeo', 'url': '${url}', 'id': '${id}'} %}
-  <script type="text/template" id="video-vimeo-template">{% include 'partials/_video.html' %}</script>
+  <script type="text/template" id="video-vimeo-template">
+    {% include 'partials/_video.html' %}
+  </script>
   {% set video = {'type': 'asciinema', 'url': '${url}', 'id': '${id}'} %}
-  <script type="text/template" id="video-asciinema-template">{% include 'partials/_video.html' %}</script>
+  <script type="text/template" id="video-asciinema-template">
+    {% include 'partials/_video.html' %}
+  </script>
 
 {% endblock %}
 


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1494

This was causing some metrics and the footer to be omitted from the page.

## QA
- Pull the branch
- `./run`
- Visit https://snapcraft.io/core
- Open http://0.0.0.0:8004/core in another tab
- Make sure the footer and metrics are displayed on the local version