### PR TITLE
Show descriptions in available revisions menu dropdown

### DIFF
--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -14,9 +14,18 @@ import {
 } from "../constants";
 
 const menuLabels = {
-  [AVAILABLE_REVISIONS_SELECT_RECENT]: "Recent",
-  [AVAILABLE_REVISIONS_SELECT_UNRELEASED]: "Unreleased",
-  [AVAILABLE_REVISIONS_SELECT_ALL]: "All"
+  [AVAILABLE_REVISIONS_SELECT_RECENT]: {
+    label: "Recent",
+    description: "Revisions from past week not released to any channel"
+  },
+  [AVAILABLE_REVISIONS_SELECT_UNRELEASED]: {
+    label: "Unreleased",
+    description: "Revisions not released to any channel"
+  },
+  [AVAILABLE_REVISIONS_SELECT_ALL]: {
+    label: "All",
+    description: "All uploaded revisions"
+  }
 };
 
 export class AvailableRevisionsMenu extends Component {
@@ -59,7 +68,11 @@ export class AvailableRevisionsMenu extends Component {
         href="#"
         onClick={!isDisabled ? this.itemClick.bind(this, item) : undefined}
       >
-        {menuLabels[item]} <span className="u-float--right">({count})</span>
+        {menuLabels[item].label}{" "}
+        <span className="u-float--right">({count})</span>
+        <span className="p-contextual-menu__description">
+          {menuLabels[item].description}
+        </span>
       </a>
     );
   }
@@ -77,10 +90,11 @@ export class AvailableRevisionsMenu extends Component {
   render() {
     return (
       <ContextualMenu
-        label={menuLabels[this.props.value]}
+        label={menuLabels[this.props.value].label}
         className="p-select-button"
         ref={this.setMenuRef}
         position="left"
+        isWide={true}
       >
         {this.renderItems()}
       </ContextualMenu>

--- a/static/js/publisher/release/components/availableRevisionsMenu.js
+++ b/static/js/publisher/release/components/availableRevisionsMenu.js
@@ -16,15 +16,15 @@ import {
 const menuLabels = {
   [AVAILABLE_REVISIONS_SELECT_RECENT]: {
     label: "Recent",
-    description: "Revisions from past week not released to any channel"
+    description:
+      "Revisions from past week not released in any channel with most recent version"
   },
   [AVAILABLE_REVISIONS_SELECT_UNRELEASED]: {
     label: "Unreleased",
     description: "Revisions not released to any channel"
   },
   [AVAILABLE_REVISIONS_SELECT_ALL]: {
-    label: "All",
-    description: "All uploaded revisions"
+    label: "All revisions"
   }
 };
 
@@ -47,6 +47,11 @@ export class AvailableRevisionsMenu extends Component {
   }
 
   itemClick(value, event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+    event.nativeEvent.preventDefault();
+
     this.props.setValue(value);
 
     if (this.menu) {
@@ -62,18 +67,19 @@ export class AvailableRevisionsMenu extends Component {
     }`;
 
     return (
-      <a
+      <span
         key={`available-menu-item-${item}`}
         className={className}
-        href="#"
         onClick={!isDisabled ? this.itemClick.bind(this, item) : undefined}
       >
         {menuLabels[item].label}{" "}
         <span className="u-float--right">({count})</span>
-        <span className="p-contextual-menu__description">
-          {menuLabels[item].description}
-        </span>
-      </a>
+        {menuLabels[item].description && (
+          <span className="p-contextual-menu__description">
+            {menuLabels[item].description}
+          </span>
+        )}
+      </span>
     );
   }
 

--- a/static/js/publisher/release/components/contextualMenu.js
+++ b/static/js/publisher/release/components/contextualMenu.js
@@ -48,7 +48,7 @@ export default class ContextualMenu extends Component {
   }
 
   render() {
-    const { appearance, isDisabled, position, title } = this.props;
+    const { appearance, isDisabled, position, title, isWide } = this.props;
     const menuClass = "p-contextual-menu" + (position ? `--${position}` : "");
     const buttonClass = `p-button${appearance ? `--${appearance}` : ""}`;
     const className = [
@@ -66,7 +66,10 @@ export default class ContextualMenu extends Component {
         onClick={isDisabled ? null : this.dropdownButtonClick.bind(this)}
       >
         {this.renderIcon()}
-        <span className="p-contextual-menu__dropdown" aria-hidden="true">
+        <span
+          className={`p-contextual-menu__dropdown ${isWide ? "is-wide" : ""}`}
+          aria-hidden="true"
+        >
           {this.props.children}
         </span>
       </span>
@@ -80,6 +83,7 @@ ContextualMenu.propTypes = {
   title: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  isWide: PropTypes.bool,
   position: PropTypes.oneOf(["left", "center"]), // right is by default
   appearance: PropTypes.oneOf(["base", "neutral"])
 };

--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -52,12 +52,14 @@ export default class PromoteMenu extends Component {
       targetChannel => targetChannel.isDisabled
     );
 
+    const icon = <span className="p-text-icon">⤴</span>;
+
     return (
       <ContextualMenu
         className="p-releases-channel__promote p-icon-button"
         appearance="neutral"
         isDisabled={isDisabled}
-        label="⤴"
+        label={icon}
         title="Promote to other channels"
         ref={this.setMenuRef}
       >

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -239,15 +239,6 @@
     }
   }
 
-  .p-contextual-menu__item {
-    @extend .p-contextual-menu__link; // sass-lint:disable-line placeholder-in-extend
-
-    &:hover {
-      background: transparent;
-      cursor: default;
-    }
-  }
-
   .p-contextual-menu__dropdown.is-wide {
     min-width: 16rem;
   }
@@ -267,6 +258,16 @@
     color: $color-mid-dark;
     cursor: not-allowed;
     opacity: .5;
+  }
+
+  .p-contextual-menu__item {
+    @extend .p-contextual-menu__link; // sass-lint:disable-line placeholder-in-extend
+    color: $color-dark;
+
+    &:hover {
+      background: transparent;
+      cursor: default;
+    }
   }
 
   .p-contextual-menu__description {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -248,7 +248,12 @@
     }
   }
 
+  .p-contextual-menu__dropdown.is-wide {
+    min-width: 16rem;
+  }
+
   .p-contextual-menu__link {
+    color: $color-link;
     padding-bottom: $sp-x-small;
     padding-top: $sp-x-small;
   }
@@ -262,6 +267,16 @@
     color: $color-mid-dark;
     cursor: not-allowed;
     opacity: .5;
+  }
+
+  .p-contextual-menu__description {
+    color: $color-dark;
+    display: block;
+    font-size: .8rem;
+    line-height: 1.4;
+    margin-bottom: $sp-x-small;
+    margin-top: $sp-x-small;
+    white-space: normal;
   }
 
   .p-tooltip__group {

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -226,6 +226,11 @@
     }
   }
 
+  .p-text-icon {
+    display: inline-block;
+    width: 14px;
+  }
+
   .p-action-button {
     background: none;
     border: 0;


### PR DESCRIPTION
Fixes #1473

Adds descriptions to "Available revisions" dropdown menu

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1497.run.demo.haus/
- go to Releases page 
- Open 'Available' menu
- descriptions should be visible

<img width="792" alt="screenshot 2019-01-08 at 12 18 31" src="https://user-images.githubusercontent.com/83575/50827720-8d89da80-133f-11e9-820e-73a0aec1d6b4.png">
