### PR TITLE
Select revisions with same version in other archs

### DIFF
--- a/static/js/publisher/release/actions/availableRevisionsSelect.js
+++ b/static/js/publisher/release/actions/availableRevisionsSelect.js
@@ -2,8 +2,8 @@ import { AVAILABLE_REVISIONS_SELECT_RECENT } from "../constants";
 import { selectRevision, clearSelectedRevisions } from "./channelMap";
 import {
   getArchitectures,
-  getSelectedAvailableRevisions,
-  getSelectedAvailableRevisionsForArch
+  getFilteredAvailableRevisions,
+  getFilteredAvailableRevisionsForArch
 } from "../selectors";
 
 export const SET_AVAILABLE_REVISIONS_SELECT = "SET_AVAILABLE_REVISIONS_SELECT";
@@ -28,7 +28,7 @@ export function selectAvailableRevisions(value) {
 
     // for Recent select only revisions from most recent uploaded version
     if (value === AVAILABLE_REVISIONS_SELECT_RECENT) {
-      const recentRevisions = getSelectedAvailableRevisions(state);
+      const recentRevisions = getFilteredAvailableRevisions(state);
 
       if (recentRevisions.length > 0) {
         // find most recent version
@@ -40,7 +40,7 @@ export function selectAvailableRevisions(value) {
 
     // get latest revision to select
     archs.forEach(arch => {
-      const revisions = getSelectedAvailableRevisionsForArch(state, arch);
+      const revisions = getFilteredAvailableRevisionsForArch(state, arch);
 
       const revisionToSelect = revisions.filter(revisionsFilter)[0];
       if (revisionToSelect) {

--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -72,7 +72,7 @@ class ReleasesConfirm extends Component {
               {isLoading ? "Loading..." : "Apply"}
             </button>
             <button
-              className="p-button--neutral u-no-margin--bottom"
+              className="p-button--neutral u-no-margin--bottom u-no-margin--right"
               onClick={this.onRevertClick.bind(this)}
             >
               Cancel

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -11,7 +11,7 @@ import { undoRelease } from "../actions/pendingReleases";
 
 import {
   getPendingChannelMap,
-  getSelectedAvailableRevisionsForArch
+  getFilteredAvailableRevisionsForArch
 } from "../selectors";
 
 function getChannelName(track, risk) {
@@ -213,7 +213,7 @@ const mapStateToProps = state => {
     pendingCloses: state.pendingCloses,
     pendingChannelMap: getPendingChannelMap(state),
     getAvailableCount: arch =>
-      getSelectedAvailableRevisionsForArch(state, arch).length
+      getFilteredAvailableRevisionsForArch(state, arch).length
   };
 };
 

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -31,6 +31,10 @@ class RevisionsList extends Component {
     this.props.toggleRevision(revision);
   }
 
+  selectVersionClick(revisions) {
+    revisions.forEach(revision => this.props.toggleRevision(revision));
+  }
+
   renderRow(revision, isSelectable, showAllColumns, isPending) {
     const revisionDate = revision.release
       ? new Date(revision.release.when)
@@ -270,6 +274,17 @@ class RevisionsList extends Component {
                 {selectedVersionRevisionsArchs.join(", ")}
               </span>
             </span>
+            <div className="p-releases-confirm__buttons">
+              <button
+                className="p-button--positive is-inline u-no-margin--bottom"
+                onClick={this.selectVersionClick.bind(
+                  this,
+                  selectedVersionRevisions
+                )}
+              >
+                {"Select in all architectures"}
+              </button>
+            </div>
           </div>
         )}
         <table className="p-revisions-list">

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -19,8 +19,8 @@ import {
   getFilteredReleaseHistory,
   getSelectedRevisions,
   getSelectedArchitectures,
-  getSelectedAvailableRevisions,
-  getSelectedAvailableRevisionsForArch
+  getFilteredAvailableRevisions,
+  getFilteredAvailableRevisionsForArch
 } from "./selectors";
 
 import { getPendingRelease } from "./releasesState";
@@ -118,9 +118,9 @@ class RevisionsList extends Component {
     let {
       availableRevisionsSelect,
       showAllColumns,
-      selectedAvailableRevisions
+      filteredAvailableRevisions
     } = this.props;
-    let filteredRevisions = selectedAvailableRevisions;
+    let filteredRevisions = filteredAvailableRevisions;
     let title = "Latest revisions";
     let filters = this.props.filters;
     let isReleaseHistory = false;
@@ -128,7 +128,7 @@ class RevisionsList extends Component {
 
     if (filters && filters.arch) {
       if (filters.risk === AVAILABLE) {
-        filteredRevisions = this.props.getSelectedAvailableRevisionsForArch(
+        filteredRevisions = this.props.getFilteredAvailableRevisionsForArch(
           filters.arch
         );
 
@@ -267,8 +267,8 @@ RevisionsList.propTypes = {
   filteredReleaseHistory: PropTypes.array,
   selectedRevisions: PropTypes.array.isRequired,
   selectedArchitectures: PropTypes.array.isRequired,
-  selectedAvailableRevisions: PropTypes.array.isRequired,
-  getSelectedAvailableRevisionsForArch: PropTypes.func.isRequired,
+  filteredAvailableRevisions: PropTypes.array.isRequired,
+  getFilteredAvailableRevisionsForArch: PropTypes.func.isRequired,
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
@@ -289,9 +289,9 @@ const mapStateToProps = state => {
     selectedRevisions: getSelectedRevisions(state),
     filteredReleaseHistory: getFilteredReleaseHistory(state),
     selectedArchitectures: getSelectedArchitectures(state),
-    selectedAvailableRevisions: getSelectedAvailableRevisions(state),
-    getSelectedAvailableRevisionsForArch: arch =>
-      getSelectedAvailableRevisionsForArch(state, arch)
+    filteredAvailableRevisions: getFilteredAvailableRevisions(state),
+    getFilteredAvailableRevisionsForArch: arch =>
+      getFilteredAvailableRevisionsForArch(state, arch)
   };
 };
 

--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -14,7 +14,7 @@ import {
 } from "./constants";
 
 import { closeHistory } from "./actions/history";
-import { toggleRevision } from "./actions/channelMap";
+import { toggleRevision, clearSelectedRevisions } from "./actions/channelMap";
 import {
   getFilteredReleaseHistory,
   getSelectedRevision,
@@ -32,6 +32,7 @@ class RevisionsList extends Component {
   }
 
   selectVersionClick(revisions) {
+    this.props.clearSelectedRevisions();
     revisions.forEach(revision => this.props.toggleRevision(revision));
   }
 
@@ -217,6 +218,11 @@ class RevisionsList extends Component {
             this.props.selectedRevisions.indexOf(revision.revision) === -1
         );
 
+        // filter out current architecture
+        selectedVersionRevisions = selectedVersionRevisions.filter(
+          revision => revision.architectures.indexOf(filters.arch) === -1
+        );
+
         // recalculate list of architectures from current list of revisions
         selectedVersionRevisionsArchs = [];
 
@@ -277,10 +283,10 @@ class RevisionsList extends Component {
             <div className="p-releases-confirm__buttons">
               <button
                 className="p-button--positive is-inline u-no-margin--bottom"
-                onClick={this.selectVersionClick.bind(
-                  this,
-                  selectedVersionRevisions
-                )}
+                onClick={this.selectVersionClick.bind(this, [
+                  selectedRevision,
+                  ...selectedVersionRevisions
+                ])}
               >
                 {"Select in all architectures"}
               </button>
@@ -351,6 +357,7 @@ RevisionsList.propTypes = {
 
   // actions
   closeHistoryPanel: PropTypes.func.isRequired,
+  clearSelectedRevisions: PropTypes.func.isRequired,
   toggleRevision: PropTypes.func.isRequired
 };
 
@@ -378,6 +385,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     closeHistoryPanel: () => dispatch(closeHistory()),
+    clearSelectedRevisions: () => dispatch(clearSelectedRevisions()),
     toggleRevision: revision => dispatch(toggleRevision(revision))
   };
 };

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -132,15 +132,15 @@ export function getAvailableRevisionsBySelection(state, value) {
 }
 
 // return list of revisions based on current availableRevisionsSelect value
-export function getSelectedAvailableRevisions(state) {
+export function getFilteredAvailableRevisions(state) {
   const { availableRevisionsSelect } = state;
   return getAvailableRevisionsBySelection(state, availableRevisionsSelect);
 }
 
 // return list of revisions based on current availableRevisionsSelect value
 // filtered by arch (can't be memoized)
-export function getSelectedAvailableRevisionsForArch(state, arch) {
-  return getSelectedAvailableRevisions(state).filter(revision =>
+export function getFilteredAvailableRevisionsForArch(state, arch) {
+  return getFilteredAvailableRevisions(state).filter(revision =>
     revision.architectures.includes(arch)
   );
 }

--- a/static/js/publisher/release/selectors/index.js
+++ b/static/js/publisher/release/selectors/index.js
@@ -49,15 +49,20 @@ export function getFilteredReleaseHistory(state) {
 
 // returns list of selected revisions, to know which ones to render selected
 export function getSelectedRevisions(state) {
-  let selectedRevisions = [];
-
   if (state.channelMap[AVAILABLE]) {
-    selectedRevisions = Object.values(state.channelMap[AVAILABLE]).map(
+    return Object.values(state.channelMap[AVAILABLE]).map(
       revision => revision.revision
     );
   }
 
-  return selectedRevisions;
+  return [];
+}
+
+// return selected revision for given architecture
+export function getSelectedRevision(state, arch) {
+  if (state.channelMap[AVAILABLE]) {
+    return state.channelMap[AVAILABLE][arch];
+  }
 }
 
 // returns list of selected architectures

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -10,8 +10,8 @@ import {
   getSelectedArchitectures,
   getPendingChannelMap,
   hasDevmodeRevisions,
-  getSelectedAvailableRevisions,
-  getSelectedAvailableRevisionsForArch,
+  getFilteredAvailableRevisions,
+  getFilteredAvailableRevisionsForArch,
   getArchitectures
 } from "./index";
 
@@ -323,7 +323,7 @@ describe("getPendingChannelMap", () => {
   });
 });
 
-describe("getSelectedAvailableRevisions", () => {
+describe("getFilteredAvailableRevisions", () => {
   const initialState = reducers(undefined, {});
 
   const dayAgo = new Date();
@@ -353,7 +353,7 @@ describe("getSelectedAvailableRevisions", () => {
 
   describe("when there are no revisions", () => {
     it("should return empty list", () => {
-      expect(getSelectedAvailableRevisions(initialState)).toEqual([]);
+      expect(getFilteredAvailableRevisions(initialState)).toEqual([]);
     });
   });
 
@@ -365,7 +365,7 @@ describe("getSelectedAvailableRevisions", () => {
       };
 
       it("should return all revisions by default", () => {
-        expect(getSelectedAvailableRevisions(stateWithAllSelected)).toEqual([
+        expect(getFilteredAvailableRevisions(stateWithAllSelected)).toEqual([
           stateWithAllSelected.revisions[3],
           stateWithAllSelected.revisions[2],
           stateWithAllSelected.revisions[1]
@@ -381,7 +381,7 @@ describe("getSelectedAvailableRevisions", () => {
 
       it("should return only unreleased revisions", () => {
         expect(
-          getSelectedAvailableRevisions(stateWithUnreleasedSelected)
+          getFilteredAvailableRevisions(stateWithUnreleasedSelected)
         ).toEqual([
           stateWithUnreleasedSelected.revisions[2],
           stateWithUnreleasedSelected.revisions[1]
@@ -396,7 +396,7 @@ describe("getSelectedAvailableRevisions", () => {
       };
 
       it("should return unreleased revisions not older then a week", () => {
-        expect(getSelectedAvailableRevisions(stateWithRecentSelected)).toEqual([
+        expect(getFilteredAvailableRevisions(stateWithRecentSelected)).toEqual([
           stateWithRecentSelected.revisions[1]
         ]);
       });
@@ -404,7 +404,7 @@ describe("getSelectedAvailableRevisions", () => {
   });
 });
 
-describe("getSelectedAvailableRevisionsByArch", () => {
+describe("getFilteredAvailableRevisionsByArch", () => {
   const arch = "test64";
   const initialState = reducers(undefined, {});
   const stateWithRevisions = {
@@ -423,7 +423,7 @@ describe("getSelectedAvailableRevisionsByArch", () => {
 
   describe("when there are no revisions", () => {
     it("should return empty list", () => {
-      expect(getSelectedAvailableRevisionsForArch(initialState, arch)).toEqual(
+      expect(getFilteredAvailableRevisionsForArch(initialState, arch)).toEqual(
         []
       );
     });
@@ -437,7 +437,7 @@ describe("getSelectedAvailableRevisionsByArch", () => {
 
     it("should return selected revisions by for given architecture", () => {
       expect(
-        getSelectedAvailableRevisionsForArch(stateWithAllSelected, arch)
+        getFilteredAvailableRevisionsForArch(stateWithAllSelected, arch)
       ).toEqual([
         stateWithAllSelected.revisions[3],
         stateWithAllSelected.revisions[1]

--- a/static/js/publisher/release/selectors/selectors.test.js
+++ b/static/js/publisher/release/selectors/selectors.test.js
@@ -6,6 +6,7 @@ import {
 } from "../constants";
 import {
   getFilteredReleaseHistory,
+  getSelectedRevision,
   getSelectedRevisions,
   getSelectedArchitectures,
   getPendingChannelMap,
@@ -170,6 +171,30 @@ describe("getSelectedRevisions", () => {
 
   it("should return list of selected revision ids", () => {
     expect(getSelectedRevisions(stateWithSelectedRevisions)).toEqual([1, 2]);
+  });
+});
+
+describe("getSelectedRevision", () => {
+  const initialState = reducers(undefined, {});
+
+  const stateWithSelectedRevisions = {
+    ...initialState,
+    channelMap: {
+      [AVAILABLE]: {
+        abc42: { revision: 1, version: "1" },
+        test64: { revision: 2, version: "2" }
+      }
+    }
+  };
+
+  it("should be empty for initial state", () => {
+    expect(getSelectedRevision(initialState, "test64")).toBeUndefined();
+  });
+
+  it("should return revision selected in given arch", () => {
+    expect(getSelectedRevision(stateWithSelectedRevisions, "test64")).toEqual(
+      stateWithSelectedRevisions.channelMap[AVAILABLE]["test64"]
+    );
   });
 });
 

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -12,7 +12,7 @@
 
   .p-releases-confirm__buttons {
     position: absolute;
-    right: 0;
+    right: 1em;
     top: 10px;
   }
 


### PR DESCRIPTION
Fixes #1472

Adds possibility to select revisions with same version as currently selected in other architectures.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1502.run.demo.haus/
- go to releases of any snap with multiple architectures
- open panel with available revisions
- check any revision that is also available in other architectures
- box should appear with information about same version in other architectures
- click on a button to select all revisions with same version in other archs

<img width="783" alt="screenshot 2019-01-09 at 12 47 30" src="https://user-images.githubusercontent.com/83575/50897572-d0fe4a80-140c-11e9-9e75-75c243ad5492.png">
