### PR TITLE
Highlight selected revisions in same colour as pending revisions

### DIFF
--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -42,19 +42,10 @@ class RevisionsList extends Component {
       : new Date(revision.created_at);
     const isSelected = this.props.selectedRevisions.includes(revision.revision);
 
-    // disable revisions from the same architecture that already selected
-    // but only if checkboxes are visible (not in channel history)
-    const isDisabled =
-      isSelectable &&
-      !isSelected &&
-      revision.architectures.some(arch =>
-        this.props.selectedArchitectures.includes(arch)
-      );
-
     const id = `revision-check-${revision.revision}`;
-    const className = `${isDisabled ? "is-disabled" : ""} ${
-      isSelectable ? "is-clickable" : ""
-    } ${isPending ? "is-pending" : ""}`;
+    const className = `${isSelectable ? "is-clickable" : ""} ${
+      isPending || isSelected ? "is-pending" : ""
+    }`;
 
     return (
       <tr

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -184,24 +184,16 @@
       padding-left: 2rem;
     }
 
-    .is-disabled {
-      opacity: .5;
-
-      .p-tooltip__message {
-        display: none;
-      }
-    }
-
     .is-clickable {
       cursor: pointer;
 
       &:hover {
         background-color: $color-light;
-
       }
     }
 
-    .is-pending {
+    .is-pending,
+    .is-pending:hover {
       background: $color-highlighted;
     }
   }


### PR DESCRIPTION
Fixes #1498 

Use the same highlight style for selected revisions as for pending revisions.
Also removes now unnecessary disabled style.

### QA

- ./run or  https://snapcraft-io-canonical-websites-pr-1505.run.demo.haus/
- go to Releases page for any snap
- open a panel with available revisions
- click on any revision to select it
- it should appear with orange background

<img width="1030" alt="screenshot 2019-01-10 at 12 24 58" src="https://user-images.githubusercontent.com/83575/50965749-2e5ccf00-14d3-11e9-8c68-31e957c31140.png">
