### PR TITLE
Show bigger promote button

### DIFF
--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -52,14 +52,12 @@ export default class PromoteMenu extends Component {
       targetChannel => targetChannel.isDisabled
     );
 
-    const icon = <span className="p-text-icon">⤴</span>;
-
     return (
       <ContextualMenu
         className="p-releases-channel__promote p-icon-button"
         appearance="neutral"
         isDisabled={isDisabled}
-        label={icon}
+        label="Promote"
         title="Promote to other channels"
         ref={this.setMenuRef}
       >

--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -92,9 +92,6 @@ class ReleasesTableCell extends Component {
       <Fragment>
         {isUnassigned ? (
           <Fragment>
-            <span className="p-release-data__icon">
-              <i className="p-icon--plus" />
-            </span>
             <span className="p-release-data__info">
               <span className="p-release-data__title">Add revision</span>
               <span className="p-release-data__meta">

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -214,31 +214,30 @@ class ReleasesTable extends Component {
   render() {
     const { archs } = this.props;
     const filteredArch = this.props.filters && this.props.filters.arch;
+
+    const className = `p-releases-table ${
+      this.props.isHistoryOpen && this.props.filters ? "has-active" : ""
+    }`;
+
     return (
-      <Fragment>
-        <div className="row">
-          <div
-            className={`p-releases-table ${
-              this.props.isHistoryOpen && this.props.filters ? "has-active" : ""
-            }`}
-          >
-            <div className="p-releases-table__row p-releases-table__row--heading">
-              <div className="p-releases-channel" />
-              {archs.map(arch => (
-                <div
-                  className={`p-releases-table__cell p-releases-table__arch ${
-                    filteredArch === arch ? "is-active" : ""
-                  }`}
-                  key={`${arch}`}
-                >
-                  {arch}
-                </div>
-              ))}
-            </div>
-            {this.renderRows()}
+      <div className="row">
+        <div className={className}>
+          <div className="p-releases-table__row p-releases-table__row--heading">
+            <div className="p-releases-channel" />
+            {archs.map(arch => (
+              <div
+                className={`p-releases-table__cell p-releases-table__arch ${
+                  filteredArch === arch ? "is-active" : ""
+                }`}
+                key={`${arch}`}
+              >
+                {arch}
+              </div>
+            ))}
           </div>
+          {this.renderRows()}
         </div>
-      </Fragment>
+      </div>
     );
   }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -46,23 +46,22 @@
     flex-shrink: 0;
     justify-content: flex-end;
     margin-top: ($sp-unit - .1rem);
-    width: 78px; // to fit 2 icon buttons exactly
+    width: 125px; // to fit 2 icon buttons exactly
   }
 
   // align first (promote) button to left
   .p-releases-channel__promote {
     margin-right: auto;
   }
+
   // channel cell
 
   .p-releases-channel {
     align-items: flex-start;
     display: flex;
     flex-shrink: 0;
-    margin-right: $grid-gutter-width / 2;
-    // TODO:
-    // width: 222px; // fixed width col-3
-    width: 230px; // temporary width until we merge menus into one
+    margin-right: 5px;
+    width: 260px;
 
     .has-active & {
       opacity: .5;


### PR DESCRIPTION
Fixes #1504

Showing bigger Promote button (with label instead of the icon)

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1506.run.demo.haus/
- go to Releases page of snap any snap
- promote button should be bigger with "Promote" label instead of the icon

<img width="1018" alt="screenshot 2019-01-11 at 15 46 29" src="https://user-images.githubusercontent.com/83575/51041237-bf0dda80-15b9-11e9-8ccf-0544e5e7289a.png">
