### PR TITLE
Show available stores on snap registration page

### DIFF
--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -70,7 +70,23 @@ Register new Snap name
   <form method="POST" action="/account/register-snap" class="u-no-margin--top">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
-   <div class="row">
+    {% if available_stores %}
+      <div class="row">
+        <div class="col-4 push-2">
+          <label for="snap-store">Store</label>
+          <div class="p-form-validation__field">
+            <select name="store" id="snap-store">
+              <option value="ubuntu" checked="checked">Global</option>
+              {% for store in available_stores %}
+                <option value="{{ store.id }}">{{ store.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    <div class="row">
       <div class="col-8 push-2">
         <div class="p-form-validation">
           <label for="snap-name">Snap name</label>

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -12,14 +12,35 @@ class GetRegisterNamePage(BaseTestCases.BaseAppTesting):
     def setUp(self):
         endpoint_url = "/register-snap"
         super().setUp(snap_name=None, api_url=None, endpoint_url=endpoint_url)
+        self.user_url = "https://dashboard.snapcraft.io/dev/api/account"
 
     @responses.activate
     def test_register_name_logged_in(self):
         self._log_in(self.client)
+
+        user_payload = {"error_list": [], "stores": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=200
+        )
+
         response = self.client.get(self.endpoint_url)
 
         assert response.status_code == 200
         self.assert_template_used("publisher/register-snap.html")
+
+    @responses.activate
+    def test_register_name_user_api_error(self):
+        self._log_in(self.client)
+
+        user_payload = {"error_list": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=502
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert response.status_code == 502
+        self.assert_template_used("50X.html")
 
 
 class GetReserveNamePage(BaseTestCases.BaseAppTesting):
@@ -29,10 +50,17 @@ class GetReserveNamePage(BaseTestCases.BaseAppTesting):
             "?snap_name=test-snap&is_private=False&conflict=True"
         )
         super().setUp(snap_name=None, api_url=None, endpoint_url=endpoint_url)
+        self.user_url = "https://dashboard.snapcraft.io/dev/api/account"
 
     @responses.activate
     def test_reserve_name_logged_in(self):
         self._log_in(self.client)
+
+        user_payload = {"error_list": [], "stores": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=200
+        )
+
         response = self.client.get(self.endpoint_url)
 
         assert response.status_code == 200
@@ -66,6 +94,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
             method_endpoint="POST",
             data=data,
         )
+        self.user_url = "https://dashboard.snapcraft.io/dev/api/account"
 
     @responses.activate
     def test_post_no_data(self):
@@ -153,6 +182,11 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         payload = {"error_list": [{"code": "error-code"}]}
         responses.add(responses.POST, self.api_url, json=payload, status=400)
 
+        user_payload = {"error_list": [], "stores": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=200
+        )
+
         self.client.post(self.endpoint_url, data=self.data)
 
         self.assert_template_used("publisher/register-snap.html")
@@ -162,6 +196,11 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
     def test_name_already_registered(self):
         payload = {"error_list": [{"code": "already_registered"}]}
         responses.add(responses.POST, self.api_url, json=payload, status=409)
+
+        user_payload = {"error_list": [], "stores": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=200
+        )
 
         response = self.client.post(self.endpoint_url, data=self.data)
 
@@ -174,6 +213,11 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
     def test_claim_dispute(self):
         payload = {"error_list": [{"code": "already_claimed"}]}
         responses.add(responses.POST, self.api_url, json=payload, status=409)
+
+        user_payload = {"error_list": [], "stores": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=200
+        )
 
         response = self.client.post(self.endpoint_url, data=self.data)
 

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -223,3 +223,18 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
 
         assert response.status_code == 302
         self.assertEqual(response.location, "http://localhost/account/details")
+
+    @responses.activate
+    def test_post_error_user_error(self):
+        payload = {"error_list": [{"code": "oops"}]}
+        responses.add(responses.POST, self.api_url, json=payload, status=409)
+
+        user_payload = {"error_list": [], "stores": []}
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=502
+        )
+
+        response = self.client.post(self.endpoint_url, data=self.data)
+
+        assert response.status_code == 502
+        self.assert_template_used("50X.html")

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -69,6 +69,39 @@ class GetReserveNamePage(BaseTestCases.BaseAppTesting):
         self.assert_context("is_private", False)
         self.assert_context("conflict", True)
 
+    @responses.activate
+    def test_reserve_name_with_stores(self):
+        self._log_in(self.client)
+
+        user_payload = {
+            "error_list": [],
+            "stores": [
+                {
+                    "id": "ubuntu",
+                    "name": "Global",
+                    "roles": ["access", "read"],
+                },
+                {"id": "ubuntu2", "name": "Global2", "roles": ["read"]},
+                {
+                    "id": "testing123",
+                    "name": "Test Store",
+                    "roles": ["access"],
+                },
+            ],
+        }
+
+        responses.add(
+            responses.GET, self.user_url, json=user_payload, status=200
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert response.status_code == 200
+        self.assert_context(
+            "available_stores",
+            [{"id": "testing123", "name": "Test Store", "roles": ["access"]}],
+        )
+
 
 class PostRegisterNamePageNotAuth(BaseTestCases.EndpointLoggedOut):
     def setUp(self):

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -270,3 +270,20 @@ def replace_reserved_categories_key(categories):
     del snap_categories["items"]
 
     return snap_categories
+
+
+def filter_available_stores(stores):
+    """Available stores that aren't publicly available
+
+    :param stores: List of stores as per the account endpoint
+
+    :return: List of stores
+    """
+    public_stores = ["ubuntu", "LimeNET", "LimeSDR", "orange-pi"]
+
+    available_stores = []
+    for store in stores:
+        if "access" in store["roles"] and store["id"] not in public_stores:
+            available_stores.append(store)
+
+    return available_stores

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -639,6 +639,10 @@ def redirect_get_register_name():
 @publisher_snaps.route("/register-snap")
 @login_required
 def get_register_name():
+    user = api.get_account(flask.session)
+
+    available_stores = logic.filter_available_stores(user["stores"])
+
     snap_name = flask.request.args.get("snap_name", default="", type=str)
     is_private_str = flask.request.args.get(
         "is_private", default="False", type=str
@@ -665,6 +669,7 @@ def get_register_name():
         "is_private": is_private,
         "conflict": conflict,
         "already_owned": already_owned,
+        "available_stores": available_stores,
     }
     return flask.render_template("publisher/register-snap.html", **context)
 
@@ -695,6 +700,10 @@ def post_register_name():
             registrant_comment=registrant_comment,
         )
     except ApiResponseErrorList as api_response_error_list:
+        user = api.get_account(flask.session)
+
+        available_stores = logic.filter_available_stores(user["stores"])
+
         if api_response_error_list.status_code == 409:
             for error in api_response_error_list.errors:
                 if error["code"] == "already_claimed":
@@ -723,6 +732,7 @@ def post_register_name():
         context = {
             "snap_name": snap_name,
             "is_private": is_private,
+            "available_stores": available_stores,
             "errors": api_response_error_list.errors,
         }
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -639,15 +639,14 @@ def redirect_get_register_name():
 @publisher_snaps.route("/register-snap")
 @login_required
 def get_register_name():
-    user = api.get_account(flask.session)
+    try:
+        user = api.get_account(flask.session)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
 
     available_stores = logic.filter_available_stores(user["stores"])
 
     snap_name = flask.request.args.get("snap_name", default="", type=str)
-    is_private_str = flask.request.args.get(
-        "is_private", default="False", type=str
-    )
-    is_private = is_private_str == "True"
 
     conflict_str = flask.request.args.get(
         "conflict", default="False", type=str
@@ -700,7 +699,10 @@ def post_register_name():
             registrant_comment=registrant_comment,
         )
     except ApiResponseErrorList as api_response_error_list:
-        user = api.get_account(flask.session)
+        try:
+            user = api.get_account(flask.session)
+        except ApiError as api_error:
+            return _handle_errors(api_error)
 
         available_stores = logic.filter_available_stores(user["stores"])
 


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/840
Fixes https://github.com/canonicalltd/snap-squad/issues/841
Fixes https://github.com/canonicalltd/snap-squad/issues/842

# QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/register-snap
- If you don't have access to any stores, you should see the original page
- If you do have stores, you should see a dropdown that contains the available store, including the Global store

## Screenshots
### No stores
![screenshot_2019-01-14 snapcraft - snaps are universal linux packages 1](https://user-images.githubusercontent.com/479384/51117644-4cde0580-1806-11e9-832a-4e56d2048a8f.png)

### Stores
![screenshot_2019-01-14 snapcraft - snaps are universal linux packages](https://user-images.githubusercontent.com/479384/51117643-4cde0580-1806-11e9-9ffe-e7dad8b788d1.png)
