### PR TITLE
Disabled promote menu tooltip

### DIFF
--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -18,23 +18,35 @@ export default class PromoteMenu extends Component {
   }
 
   renderItem(targetChannel) {
-    const { channel, isDisabled } = targetChannel;
+    const { channel, isDisabled, reason } = targetChannel;
     const className = [
       "p-contextual-menu__link is-indented",
       isDisabled ? "is-disabled" : ""
     ].join(" ");
 
     return (
-      <a
-        className={className}
-        href="#"
+      <span
         key={`promote-to-${channel}`}
-        onClick={
-          isDisabled ? null : this.promoteToChannelClick.bind(this, channel)
-        }
+        className="p-tooltip p-tooltip--btm-center"
       >
-        {channel}
-      </a>
+        <span
+          className={className}
+          onClick={
+            isDisabled ? null : this.promoteToChannelClick.bind(this, channel)
+          }
+        >
+          {channel}
+        </span>
+        {reason && (
+          <span
+            className="p-tooltip__message u-align--center"
+            role="tooltip"
+            id={`promote-to-${channel}-devmode`}
+          >
+            {reason}
+          </span>
+        )}
+      </span>
     );
   }
 

--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -64,9 +64,11 @@ export default class PromoteMenu extends Component {
       targetChannel => targetChannel.isDisabled
     );
 
-    const tooltip = isDisabled
-      ? this.props.targetChannels[0].reason
-      : undefined;
+    // if tooltip is provided, use it
+    // otherwise if all items are disabled use the tooltip from disabled channel
+    const tooltip =
+      this.props.tooltip ||
+      (isDisabled ? this.props.targetChannels[0].reason : undefined);
 
     const className = `p-releases-channel__promote ${
       tooltip ? "p-tooltip p-tooltip--btm-center" : ""
@@ -94,6 +96,7 @@ export default class PromoteMenu extends Component {
 }
 
 PromoteMenu.propTypes = {
+  tooltip: PropTypes.string,
   targetChannels: PropTypes.array.isRequired,
   promoteToChannel: PropTypes.func.isRequired
 };

--- a/static/js/publisher/release/components/promoteMenu.js
+++ b/static/js/publisher/release/components/promoteMenu.js
@@ -64,17 +64,31 @@ export default class PromoteMenu extends Component {
       targetChannel => targetChannel.isDisabled
     );
 
+    const tooltip = isDisabled
+      ? this.props.targetChannels[0].reason
+      : undefined;
+
+    const className = `p-releases-channel__promote ${
+      tooltip ? "p-tooltip p-tooltip--btm-center" : ""
+    }`;
+
     return (
-      <ContextualMenu
-        className="p-releases-channel__promote p-icon-button"
-        appearance="neutral"
-        isDisabled={isDisabled}
-        label="Promote"
-        title="Promote to other channels"
-        ref={this.setMenuRef}
-      >
-        {this.renderItems()}
-      </ContextualMenu>
+      <span className={className}>
+        <ContextualMenu
+          className="p-icon-button"
+          appearance="neutral"
+          isDisabled={isDisabled}
+          label="Promote"
+          ref={this.setMenuRef}
+        >
+          {this.renderItems()}
+        </ContextualMenu>
+        {tooltip && (
+          <span className="p-tooltip__message u-align--center" role="tooltip">
+            {tooltip}
+          </span>
+        )}
+      </span>
     );
   }
 }

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -30,8 +30,7 @@ const disabledBecauseDevmode = (
   </Fragment>
 );
 
-const disabledBecauseReleased =
-  "Same revisions are already released to this channel.";
+const disabledBecauseReleased = "The same revisions are already promoted.";
 
 class ReleasesTable extends Component {
   renderRevisionCell(track, risk, arch) {

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -23,6 +23,16 @@ function getChannelName(track, risk) {
   return risk === AVAILABLE ? risk : `${track}/${risk}`;
 }
 
+const disabledBecauseDevmode = (
+  <Fragment>
+    Revisions with devmode confinement or devel grade <br />
+    cannot be released to stable or candidate channels.
+  </Fragment>
+);
+
+const disabledBecauseReleased =
+  "Same revisions are already released to this channel.";
+
 class ReleasesTable extends Component {
   renderRevisionCell(track, risk, arch) {
     return (
@@ -108,7 +118,9 @@ class ReleasesTable extends Component {
         // is in devmode
         if (hasDevmodeRevisions) {
           targetChannels[0].isDisabled = true;
+          targetChannels[0].reason = disabledBecauseDevmode;
           targetChannels[1].isDisabled = true;
+          targetChannels[1].reason = disabledBecauseDevmode;
         }
       }
 
@@ -116,6 +128,7 @@ class ReleasesTable extends Component {
       targetChannels.forEach(targetChannel => {
         if (this.compareChannels(channel, targetChannel.channel)) {
           targetChannel.isDisabled = true;
+          targetChannel.reason = disabledBecauseReleased;
         }
       });
 

--- a/static/js/publisher/release/releasesTable.js
+++ b/static/js/publisher/release/releasesTable.js
@@ -32,6 +32,8 @@ const disabledBecauseDevmode = (
 
 const disabledBecauseReleased = "The same revisions are already promoted.";
 
+const disabledBecauseNotSelected = "Select some revisions to promote them.";
+
 class ReleasesTable extends Component {
   renderRevisionCell(track, risk, arch) {
     return (
@@ -82,6 +84,7 @@ class ReleasesTable extends Component {
 
     let canBePromoted = true;
     let canBeClosed = true;
+    let promoteTooltip;
 
     if (risk === STABLE) {
       canBePromoted = false;
@@ -97,6 +100,14 @@ class ReleasesTable extends Component {
     ) {
       canBePromoted = false;
       canBeClosed = false;
+    }
+
+    if (
+      channel === AVAILABLE &&
+      (!pendingChannelMap[channel] ||
+        Object.keys(pendingChannelMap[channel]).length === 0)
+    ) {
+      promoteTooltip = disabledBecauseNotSelected;
     }
 
     let targetChannels = [];
@@ -158,6 +169,7 @@ class ReleasesTable extends Component {
             <span className="p-releases-table__menus">
               {canBePromoted && (
                 <PromoteMenu
+                  tooltip={promoteTooltip}
                   targetChannels={targetChannels}
                   promoteToChannel={this.onPromoteToChannel.bind(this, channel)}
                 />

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -242,6 +242,14 @@
     }
   }
 
+  .p-contextual-menu__dropdown {
+    overflow: visible; // allow tooltips inside menu
+
+    .p-tooltip {
+      display: block;
+    }
+  }
+
   .p-contextual-menu__dropdown.is-wide {
     min-width: 16rem;
   }


### PR DESCRIPTION
Fixes #1342 

Adds tooltip to disabled promote menu items and to promote menu button itself when it's disabled (when all items are disabled).

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1509.run.demo.haus/
- go to Releases page of any snap (with some devmode revisions)
- select any devmode revision, try to promote it
- hover over disabled channel name in Promote menu
- tooltip should appear saying that devmode revisions can't be released to stable or candidate
- if channel has the same revisions as other channel it will be disabled in promote menu with a tooltip saying that same revisions are already promoted
- if all channels are disabled, Promote button will be disabled with a tooltip showing the reason

<img width="887" alt="screenshot 2019-01-14 at 16 30 41" src="https://user-images.githubusercontent.com/83575/51122423-22964300-181a-11e9-8d43-4f73c715bd98.png">

<img width="887" alt="screenshot 2019-01-14 at 16 30 08" src="https://user-images.githubusercontent.com/83575/51122421-22964300-181a-11e9-80ea-cc3802aa10c9.png">
<img width="887" alt="screenshot 2019-01-14 at 16 30 18" src="https://user-images.githubusercontent.com/83575/51122422-22964300-181a-11e9-89ae-42ac48e0e057.png">
