### PR TITLE
Properly propagate click event from table cell (to close dropdowns)

### DIFF
--- a/static/js/publisher/release/components/releasesTableCell.js
+++ b/static/js/publisher/release/components/releasesTableCell.js
@@ -19,11 +19,8 @@ function getChannelName(track, risk) {
 }
 
 class ReleasesTableCell extends Component {
-  handleReleaseCellClick(arch, risk, track, event) {
+  handleReleaseCellClick(arch, risk, track) {
     this.props.toggleHistoryPanel({ arch, risk, track });
-
-    event.preventDefault();
-    event.stopPropagation();
   }
 
   undoClick(revision, track, risk, event) {


### PR DESCRIPTION
Fixes #1499 

Fixes the issue when Promote dropdown was not closed when clicking on releases table cell.

### QA

- ./run or demo
- go to Releases page of any snap
- click on a Promote button to open dropdown
- click on any release table cell (to open history panel for given channel/arch)
- Promote dropdown should close when history panel is opened