### PR TITLE
Better messaging for JSON parse errors

### DIFF
--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -26,6 +26,9 @@ import {
   getReleaseDataFromChannelMap
 } from "./releasesState";
 
+const ERROR_MESSAGE =
+  "There was an error while processing your request, please try again later.";
+
 class ReleasesController extends Component {
   constructor(props) {
     super(props);
@@ -82,7 +85,11 @@ class ReleasesController extends Component {
       },
       redirect: "follow",
       referrer: "no-referrer"
-    }).then(response => response.json());
+    })
+      .then(response => response.json())
+      .catch(() => {
+        throw new Error(ERROR_MESSAGE);
+      });
   }
 
   fetchRelease(revision, channels) {
@@ -100,7 +107,11 @@ class ReleasesController extends Component {
       redirect: "follow",
       referrer: "no-referrer",
       body: JSON.stringify({ revision, channels, name: this.props.snapName })
-    }).then(response => response.json());
+    })
+      .then(response => response.json())
+      .catch(() => {
+        throw new Error(ERROR_MESSAGE);
+      });
   }
 
   fetchClose(channels) {
@@ -118,7 +129,11 @@ class ReleasesController extends Component {
       redirect: "follow",
       referrer: "no-referrer",
       body: JSON.stringify({ channels })
-    }).then(response => response.json());
+    })
+      .then(response => response.json())
+      .catch(() => {
+        throw new Error(ERROR_MESSAGE);
+      });
   }
 
   // TODO: move inside of this function out
@@ -164,9 +179,7 @@ class ReleasesController extends Component {
   }
 
   handleReleaseError(error) {
-    let message =
-      error.message ||
-      "Error while performing the release. Please try again later.";
+    let message = error.message || ERROR_MESSAGE;
 
     // try to find error messages in response json
     // which may be an array or errors or object with errors property


### PR DESCRIPTION
Fixes #1171

When the HTML error is returned by API instead of the JSON we now show a more user friendly error message (not exposing internal JSON parsing error).

### QA

To properly QA it you need to run it locally and mock an error from API.
To do this for example throw `raise Exception('Test error')` into `publisher/snaps/view.py#post_release` (line ~587).

- ./run
- go to Releases page of any snap
- select some revisions to promote to some channel
- click 'Apply' button to save the changes
- if error response was properly mocked error thought be thrown by server and an error massage should appear

<img width="1041" alt="screenshot 2019-01-16 at 14 00 13" src="https://user-images.githubusercontent.com/83575/51250615-37e4ac00-1997-11e9-8aef-ff0dabe55b55.png">
