### PR TITLE
Only show revision version selector in available revisions panel

### DIFF
--- a/static/js/publisher/release/revisionsList.js
+++ b/static/js/publisher/release/revisionsList.js
@@ -259,31 +259,32 @@ class RevisionsList extends Component {
             .
           </Notification>
         )}
-        {selectedVersionRevisions.length > 0 && (
-          <div className="p-releases-confirm">
-            <b>{selectedRevision.version}</b> is available in{" "}
-            <span className="p-tooltip">
-              <span className="p-help">
-                {selectedVersionRevisionsArchs.length} other architecture
-                {selectedVersionRevisionsArchs.length > 1 ? "s" : ""}
+        {!isReleaseHistory &&
+          selectedVersionRevisions.length > 0 && (
+            <div className="p-releases-confirm">
+              <b>{selectedRevision.version}</b> is available in{" "}
+              <span className="p-tooltip">
+                <span className="p-help">
+                  {selectedVersionRevisionsArchs.length} other architecture
+                  {selectedVersionRevisionsArchs.length > 1 ? "s" : ""}
+                </span>
+                <span className="p-tooltip__message" role="tooltip">
+                  {selectedVersionRevisionsArchs.join(", ")}
+                </span>
               </span>
-              <span className="p-tooltip__message" role="tooltip">
-                {selectedVersionRevisionsArchs.join(", ")}
-              </span>
-            </span>
-            <div className="p-releases-confirm__buttons">
-              <button
-                className="p-button--positive is-inline u-no-margin--bottom"
-                onClick={this.selectVersionClick.bind(this, [
-                  selectedRevision,
-                  ...selectedVersionRevisions
-                ])}
-              >
-                {"Select in all architectures"}
-              </button>
+              <div className="p-releases-confirm__buttons">
+                <button
+                  className="p-button--positive is-inline u-no-margin--bottom"
+                  onClick={this.selectVersionClick.bind(this, [
+                    selectedRevision,
+                    ...selectedVersionRevisions
+                  ])}
+                >
+                  {"Select in all architectures"}
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
         <table className="p-revisions-list">
           <thead>
             <tr>


### PR DESCRIPTION
Fixes an issue where same version selector was shown in history panel of channels, when it should be only visible with available revisions.

Reported by @therealjuan via IRC:

![selector-bug](https://user-images.githubusercontent.com/83575/51256919-d62c3e00-19a6-11e9-8771-ef687dc83847.png)


### Code review

Diff looks bigger because of indent whitespace changes. Review with 'hide whitespace' setting to reveal true diff:

<img width="291" alt="screenshot 2019-01-17 at 09 09 38" src="https://user-images.githubusercontent.com/83575/51304197-c1e45180-1a37-11e9-9b19-5fd74a0b4065.png">

### QA
- ./run or demo
- go to Release page of any snap with multiple architectures
- open available revisions and select some revision (where same version is available in other architectures)
- a box should appear telling that same version is available in other architectures
- open history panel of some channel (beta, etc) of the same architecture
- a box about same version should not be visible there
