### PR TITLE
 Markdown support for snap description

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask-WTF==0.14.2
 humanize==0.5.1
 Markdown==3.0.1
 prometheus_client==0.3.1
+mistune==0.8.4
 pybreaker==0.4.4
 pycountry==17.9.23
 pymacaroons==0.12.0

--- a/static/js/publisher/market/markdown.js
+++ b/static/js/publisher/market/markdown.js
@@ -5,5 +5,10 @@ export default function() {
   markdownLink.addEventListener("click", e => {
     e.preventDefault();
     markdownInfo.classList.toggle("u-hide");
+    if (markdownInfo.classList.contains("u-hide")) {
+      markdownLink.innerHTML = markdownLink.innerHTML.replace("Hide", "Show");
+    } else {
+      markdownLink.innerHTML = markdownLink.innerHTML.replace("Show", "Hide");
+    }
   });
 }

--- a/static/js/publisher/market/markdown.js
+++ b/static/js/publisher/market/markdown.js
@@ -2,12 +2,8 @@ export default function() {
   const markdownLink = document.querySelector(".js-toggle-markdown");
   const markdownInfo = document.querySelector(".js-markdown");
 
-  markdownLink.addEventListener("click", function(e) {
+  markdownLink.addEventListener("click", e => {
     e.preventDefault();
-    if (markdownInfo.classList.contains("u-hide")) {
-      markdownInfo.classList.remove("u-hide");
-    } else {
-      markdownInfo.classList.add("u-hide");
-    }
+    markdownInfo.classList.toggle("u-hide");
   });
 }

--- a/static/js/publisher/market/markdown.js
+++ b/static/js/publisher/market/markdown.js
@@ -1,0 +1,13 @@
+export default function() {
+  const markdownLink = document.querySelector(".js-toggle-markdown");
+  const markdownInfo = document.querySelector(".js-markdown");
+
+  markdownLink.addEventListener("click", function(e) {
+    e.preventDefault();
+    if (markdownInfo.classList.contains("u-hide")) {
+      markdownInfo.classList.remove("u-hide");
+    } else {
+      markdownInfo.classList.add("u-hide");
+    }
+  });
+}

--- a/static/js/publisher/market/markdown.js
+++ b/static/js/publisher/market/markdown.js
@@ -6,9 +6,9 @@ export default function() {
     e.preventDefault();
     markdownInfo.classList.toggle("u-hide");
     if (markdownInfo.classList.contains("u-hide")) {
-      markdownLink.innerHTML = markdownLink.innerHTML.replace("Hide", "Show");
+      markdownLink.innerHTML = "Show supported markdown syntax";
     } else {
-      markdownLink.innerHTML = markdownLink.innerHTML.replace("Show", "Hide");
+      markdownLink.innerHTML = "Hide supported markdown syntax";
     }
   });
 }

--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -5,6 +5,7 @@ import { initMultiselect } from "./form/multiselect";
 import { enableInput, changeHandler } from "./settings";
 import { publicise } from "./publicise";
 import { initCategories } from "./market/categories";
+import markdownToggle from "./market/markdown";
 
 const settings = { enableInput, changeHandler };
 
@@ -15,5 +16,6 @@ export {
   initMultiselect,
   settings,
   publicise,
-  initCategories
+  initCategories,
+  markdownToggle
 };

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -268,7 +268,7 @@
                   <b>Bold:</b> <code>**Foo**</code>
                 </small></p>
                 <p><small>
-                  <b>Links:</b> <code>https://foo.bar</code>
+                  <b>URLs:</b> <code>https://foo.bar</code>
                 </small></p>
                 <p><small>
                   <b>Lists:</b> <code>* Foo</code>
@@ -279,7 +279,7 @@
                   <b>Italics:</b> <code>__Foo__</code>
                 </small></p>
                 <p><small>
-                  <b>Links with titles:</b> <code>[foo bar](https://foo.bar)</code>
+                  <b>Links:</b> <code>[foo bar](https://foo.bar)</code>
                 </small></p>
                 <p><small>
                   <b>Code:</b> Text blocks inside <code>`</code> or <code>```</code> pairs

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -265,24 +265,24 @@
             <div class="row js-markdown u-hide">
               <div class="col-4">
                 <p><small>
-                  <b>Code:</b> Text blocks inside <code>`</code> or <code>```</code> pairs
+                  <b>Bold:</b> <code>**Foo**</code>
+                </small></p>
+                <p><small>
+                  <b>Links:</b> <code>https://foo.bar</code>
                 </small></p>
                 <p><small>
                   <b>Lists:</b> <code>* Foo</code>
                 </small></p>
-                <p><small>
-                  <b>Italics:</b> <code>__Foo__</code>
-                </small></p>
               </div>
               <div class="col-4">
                 <p><small>
-                  <b>Bold:</b> <code>**Foo**</code>
+                  <b>Italics:</b> <code>__Foo__</code>
                 </small></p>
                 <p><small>
-                  <b>Literal URLs:</b> <code>https://foo.bar</code>
+                  <b>Links with titles:</b> <code>[foo bar](https://foo.bar)</code>
                 </small></p>
                 <p><small>
-                  <b>URLs with title:</b> <code>[foo bar](https://foo.bar)</code>
+                  <b>Code:</b> Text blocks inside <code>`</code> or <code>```</code> pairs
                 </small></p>
               </div>
             </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -257,6 +257,33 @@
                 </p>
               {% endif %}
             </div>
+            <p class="p-form-help-text u-no-margin--bottom">
+              <a href="#" class="js-toggle-markdown">Supported markdown syntax</a>
+            </p>
+            <div class="row js-markdown u-hide">
+              <div class="col-4">
+                <p><small>
+                  Code<br />Text blocks inside <code>`</code> or <code>```</code> pairs
+                </small></p>
+                <p><small>
+                  Lists<br /><code>* Foo</code>
+                </small></p>
+                <p><small>
+                  Italics<br /><code>__Foo__</code>
+                </small></p>
+              </div>
+              <div class="col-4">
+                <p><small>
+                  Bold<br /><code>**Foo**</code>
+                </small></p>
+                <p><small>
+                  Literal URLs<br /><code>https://foo.bar</code>
+                </small></p>
+                <p><small>
+                  URLs with title<br /><code>[foo bar](https://foo.bar)</code>
+                </small></p>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -512,6 +539,8 @@
       null
     {% endif %}
     );
+
+    snapcraft.publisher.markdownToggle();
 
     snapcraft.publisher.initCategories();
   });

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -257,30 +257,32 @@
                 </p>
               {% endif %}
             </div>
-            <p class="p-form-help-text u-no-margin--bottom">
-              <a href="#" class="js-toggle-markdown">Supported markdown syntax</a>
+            <p class="u-no-margin--bottom">
+              <small>
+                <a href="" class="js-toggle-markdown">Show supported markdown syntax</a>
+              </small>
             </p>
             <div class="row js-markdown u-hide">
               <div class="col-4">
                 <p><small>
-                  Code<br />Text blocks inside <code>`</code> or <code>```</code> pairs
+                  <b>Code:</b> Text blocks inside <code>`</code> or <code>```</code> pairs
                 </small></p>
                 <p><small>
-                  Lists<br /><code>* Foo</code>
+                  <b>Lists:</b> <code>* Foo</code>
                 </small></p>
                 <p><small>
-                  Italics<br /><code>__Foo__</code>
+                  <b>Italics:</b> <code>__Foo__</code>
                 </small></p>
               </div>
               <div class="col-4">
                 <p><small>
-                  Bold<br /><code>**Foo**</code>
+                  <b>Bold:</b> <code>**Foo**</code>
                 </small></p>
                 <p><small>
-                  Literal URLs<br /><code>https://foo.bar</code>
+                  <b>Literal URLs:</b> <code>https://foo.bar</code>
                 </small></p>
                 <p><small>
-                  URLs with title<br /><code>[foo bar](https://foo.bar)</code>
+                  <b>URLs with title:</b> <code>[foo bar](https://foo.bar)</code>
                 </small></p>
               </div>
             </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -121,7 +121,7 @@
     <div class="row">
       <div class="col-8">
         {% if summary %}<h4>{{ summary }}</h4>{% endif %}
-        <p>{{ description | safe }}</p>
+        <div>{{ description | safe }}</div>
         {% if website %}<p><a href="{{ website }}">Developer website</a></p>{% endif %}
         {% if contact %}
           <p>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -121,7 +121,7 @@
     <div class="row">
       <div class="col-8">
         {% if summary %}<h4>{{ summary }}</h4>{% endif %}
-        <div>{{ description | safe }}</div>
+        {{ description | safe }}
         {% if website %}<p><a href="{{ website }}">Developer website</a></p>{% endif %}
         {% if contact %}
           <p>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -121,9 +121,7 @@
     <div class="row">
       <div class="col-8">
         {% if summary %}<h4>{{ summary }}</h4>{% endif %}
-        {% for paragraph in description_paragraphs %}
-          <p>{{ paragraph | safe }}</p>
-        {% endfor %}
+        <p>{{ description | safe }}</p>
         {% if website %}<p><a href="{{ website }}">Developer website</a></p>{% endif %}
         {% if contact %}
           <p>

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -1,0 +1,135 @@
+import unittest
+
+from webapp.markdown import parse_markdown_description
+
+
+class TestMarkdownParser(unittest.TestCase):
+    """This class tests the custom parser for the snap description. This
+    parser allows only a limited amount of tags. We want a lot of tests for
+    it to make sure on upgrades we don't loose the custom tags that we want
+    to keep.
+
+    List of approved markdown tag allowed:
+
+    * Code (text blocks inside ` or ``` pairs)
+    * Lists (* Foo)
+    * Italics (_foo_)
+    * Bold (**foo**)
+    * Paragraph merging (consecutive lines are joined)
+    * Literal URLs auto-link https://foo.bar
+    * URLs with title [title for the link](https://foo.bar)
+    """
+
+    def test_parse_title(self):
+        """Title conversion shouldn't work
+        """
+        markdown = "# title"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p># title</p>\n"
+
+        assert result == expected_result
+
+    def test_parse_urls(self):
+        """Literal URLs auto-link https://foo.bar
+        """
+        markdown = "https://toto.space"
+        result = parse_markdown_description(markdown)
+        expected_result = (
+            '<p><a href="https://toto.space">https://toto.space</a></p>\n'
+        )
+
+        assert result == expected_result
+
+    def test_parse_urls_title(self):
+        """URLs with title [title for the link](https://foo.bar)
+        """
+        markdown = "[toto](https://toto.space)"
+        result = parse_markdown_description(markdown)
+        expected_result = '<p><a href="https://toto.space">toto</a></p>\n'
+
+        assert result == expected_result
+
+    def test_parse_italics(self):
+        """Italics (_foo_)
+        """
+        markdown = "_text_"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p><em>text</em></p>\n"
+
+        assert result == expected_result
+
+    def test_parse_bold(self):
+        """Bold (**foo**)
+        """
+        markdown = "**text**"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p><strong>text</strong></p>\n"
+
+        assert result == expected_result
+
+    def test_parse_paragraph_merging(self):
+        """Paragraph merging (consecutive lines are joined)
+        """
+        markdown = "this is\n a paragraph"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p>this is\n a paragraph</p>\n"
+
+        assert result == expected_result
+
+    def test_parse_paragraph(self):
+        """Paragraphs
+        """
+        markdown = "paragraph 1\n\n paragraph 2"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p>paragraph 1</p>\n<p>paragraph 2</p>\n"
+
+        assert result == expected_result
+
+    def test_parse_text(self):
+        """Text conversion works
+        """
+        markdown = "text"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p>text</p>\n"
+
+        assert result == expected_result
+
+    def test_parse_code_block(self):
+        """Code (text blocks inside ` or ``` pairs)
+        """
+        markdown = "```code block```"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p><code>code block</code></p>\n"
+
+        assert result == expected_result
+
+    def test_parse_code_line(self):
+        """Code (text blocks inside ` or ``` pairs)
+        """
+        markdown = "`code line`"
+        result = parse_markdown_description(markdown)
+        expected_result = "<p><code>code line</code></p>\n"
+
+        assert result == expected_result
+
+    def test_parse_list(self):
+        """Lists (* Foo)
+        """
+        markdown = "* item \n* item \n* item \n"
+        result = parse_markdown_description(markdown)
+        expected_result = (
+            "<ul>\n<li>item </li>\n<li>item </li>\n<li>item </li>\n</ul>\n"
+        )
+
+        assert result == expected_result
+
+    def test_parse_list_ordered(self):
+        """Lists (* Foo)
+        """
+        markdown = "1. item \n2. item \n3. item \n"
+        result = parse_markdown_description(markdown)
+        expected_result = (
+            "<ol>\n<li>item </li>\n<li>item </li>\n<li>item </li>\n</ol>\n"
+        )
+
+        assert result == expected_result

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -6,7 +6,7 @@ from webapp.markdown import parse_markdown_description
 class TestMarkdownParser(unittest.TestCase):
     """This class tests the custom parser for the snap description. This
     parser allows only a limited amount of tags. We want a lot of tests for
-    it to make sure on upgrades we don't loose the custom tags that we want
+    it to make sure on upgrades we don't lose the custom tags that we want
     to keep.
 
     List of approved markdown tag allowed:

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -144,3 +144,12 @@ class TestMarkdownParser(unittest.TestCase):
         )
 
         assert result == expected_result
+
+    def test_parse_image_link(self):
+        """Image link is converted into a simple link
+        """
+        markdown = "![image](link.png)"
+        result = parse_markdown_description(markdown)
+        expected_result = '<p>!<a href="link.png">image</a></p>\n'
+
+        assert result == expected_result

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -123,6 +123,17 @@ class TestMarkdownParser(unittest.TestCase):
 
         assert result == expected_result
 
+    def test_parse_list_special_char(self):
+        """Lists (• Foo)
+        """
+        markdown = "• item \n• item \n• item \n"
+        result = parse_markdown_description(markdown)
+        expected_result = (
+            "<ul>\n<li>item </li>\n<li>item </li>\n<li>item </li>\n</ul>\n"
+        )
+
+        assert result == expected_result
+
     def test_parse_list_ordered(self):
         """Lists (* Foo)
         """

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -1,4 +1,11 @@
-from mistune import BlockGrammar, BlockLexer, Markdown, _pure_pattern
+from mistune import (
+    BlockGrammar,
+    BlockLexer,
+    Renderer,
+    Markdown,
+    _pure_pattern,
+    InlineLexer,
+)
 import re
 
 
@@ -50,8 +57,18 @@ class DescriptionBlock(BlockLexer):
     list_rules = ("block_code", "list_block", "text", "newline")
 
 
+class DescriptionInline(InlineLexer):
+    def _process_link(self, m, link, title=None):
+        line = m.group(0)
+        if line[0] != "!":
+            return super()._process_link(m, link, title)
+
+
+renderer = Renderer()
 parser = Markdown(
-    parse_block_html=True, parse_inline_html=True, block=DescriptionBlock()
+    renderer=renderer,
+    block=DescriptionBlock(),
+    inline=DescriptionInline(renderer=renderer),
 )
 
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -6,6 +6,11 @@ class DescriptionGrammar(BlockGrammar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # This is an extention of the list block rule written in BlockGrammar
+        # of mistune library:
+        # https://github.com/lepture/mistune/blob/master/mistune.py#L120-L141
+        # We want to support the • as a tag for lists in markdown.
+        # To do this this [*+-•] is the list of supported tags
         self.list_block = re.compile(
             r"^( *)(?=[*+-•]|\d+\.)(([*+-•])?(?:\d+\.)?) [\s\S]+?"
             r"(?:"

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -47,6 +47,7 @@ class DescriptionBlock(BlockLexer):
     grammar_class = DescriptionGrammar
 
     default_rules = [
+        "fences",
         "block_code",
         "list_block",
         "paragraph",

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -1,7 +1,38 @@
-from mistune import Markdown, BlockLexer
+from mistune import BlockGrammar, BlockLexer, Markdown, _pure_pattern
+import re
+
+
+class DescriptionGrammar(BlockGrammar):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.list_block = re.compile(
+            r"^( *)(?=[*+-•]|\d+\.)(([*+-•])?(?:\d+\.)?) [\s\S]+?"
+            r"(?:"
+            r"\n+(?=\1?(?:[-*_•] *){3,}(?:\n+|$))"  # hrule
+            r"|\n+(?=%s)"  # def links
+            r"|\n+(?=%s)"  # def footnotes\
+            r"|\n+(?=\1(?(3)\d+\.|[*+-•]) )"  # heterogeneous bullet
+            r"|\n{2,}"
+            r"(?! )"
+            r"(?!\1(?:[*+-•]|\d+\.) )\n*"
+            r"|"
+            r"\s*$)"
+            % (
+                _pure_pattern(super().def_links),
+                _pure_pattern(super().def_footnotes),
+            )
+        )
+        self.list_bullet = re.compile(r"^ *(?:[*+-•]|\d+\.) +")
+        self.list_item = re.compile(
+            r"^(( *)(?:[*+-•]|\d+\.) [^\n]*"
+            r"(?:\n(?!\2(?:[*+-•]|\d+\.) )[^\n]*)*)",
+            flags=re.M,
+        )
 
 
 class DescriptionBlock(BlockLexer):
+    grammar_class = DescriptionGrammar
 
     default_rules = ["block_code", "list_block", "paragraph", "text"]
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -1,0 +1,26 @@
+from mistune import Markdown, BlockLexer
+
+
+class DescriptionBlock(BlockLexer):
+
+    default_rules = ["block_code", "list_block", "paragraph", "text"]
+
+    list_rules = (
+        "block_code",
+        "list_block",
+        "text",
+        "list",
+        "list_item",
+        "paragraph",
+        "autolink",
+        "link",
+    )
+
+
+parser = Markdown(
+    parse_block_html=True, parse_inline_html=True, block=DescriptionBlock()
+)
+
+
+def parse_markdown_description(content):
+    return parser(content)

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -34,9 +34,15 @@ class DescriptionGrammar(BlockGrammar):
 class DescriptionBlock(BlockLexer):
     grammar_class = DescriptionGrammar
 
-    default_rules = ["block_code", "list_block", "paragraph", "text"]
+    default_rules = [
+        "block_code",
+        "list_block",
+        "paragraph",
+        "text",
+        "newline",
+    ]
 
-    list_rules = ("block_code", "list_block", "text")
+    list_rules = ("block_code", "list_block", "text", "newline")
 
 
 parser = Markdown(

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -19,15 +19,15 @@ class DescriptionGrammar(BlockGrammar):
         # We want to support the • as a tag for lists in markdown.
         # To do this this [*+-•] is the list of supported tags
         self.list_block = re.compile(
-            r"^( *)(?=[*+-•]|\d+\.)(([*+-•])?(?:\d+\.)?) [\s\S]+?"
+            r"^( *)(?=[•*+-]|\d+\.)(([•*+-])?(?:\d+\.)?) [\s\S]+?"
             r"(?:"
-            r"\n+(?=\1?(?:[-*_•] *){3,}(?:\n+|$))"  # hrule
+            r"\n+(?=\1?(?:[-*_] *){3,}(?:\n+|$))"  # hrule
             r"|\n+(?=%s)"  # def links
             r"|\n+(?=%s)"  # def footnotes\
-            r"|\n+(?=\1(?(3)\d+\.|[*+-•]) )"  # heterogeneous bullet
+            r"|\n+(?=\1(?(3)\d+\.|[•*+-]) )"  # heterogeneous bullet
             r"|\n{2,}"
             r"(?! )"
-            r"(?!\1(?:[*+-•]|\d+\.) )\n*"
+            r"(?!\1(?:[•*+-]|\d+\.) )\n*"
             r"|"
             r"\s*$)"
             % (
@@ -35,12 +35,12 @@ class DescriptionGrammar(BlockGrammar):
                 _pure_pattern(super().def_footnotes),
             )
         )
-        self.list_bullet = re.compile(r"^ *(?:[*+-•]|\d+\.) +")
         self.list_item = re.compile(
-            r"^(( *)(?:[*+-•]|\d+\.) [^\n]*"
-            r"(?:\n(?!\2(?:[*+-•]|\d+\.) )[^\n]*)*)",
+            r"^(( *)(?:[•*+-]|\d+\.) [^\n]*"
+            r"(?:\n(?!\2(?:[•*+-]|\d+\.) )[^\n]*)*)",
             flags=re.M,
         )
+        self.list_bullet = re.compile(r"^ *(?:[•*+-]|\d+\.) +")
 
 
 class DescriptionBlock(BlockLexer):
@@ -55,7 +55,7 @@ class DescriptionBlock(BlockLexer):
         "newline",
     ]
 
-    list_rules = ("block_code", "list_block", "text", "newline")
+    list_rules = ("fences", "block_code", "list_block", "text", "newline")
 
 
 class DescriptionInline(InlineLexer):

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -5,16 +5,7 @@ class DescriptionBlock(BlockLexer):
 
     default_rules = ["block_code", "list_block", "paragraph", "text"]
 
-    list_rules = (
-        "block_code",
-        "list_block",
-        "text",
-        "list",
-        "list_item",
-        "paragraph",
-        "autolink",
-        "link",
-    )
+    list_rules = ("block_code", "list_block", "text")
 
 
 parser = Markdown(

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -98,40 +98,6 @@ def convert_navigation_url(url, link):
     return url
 
 
-def split_description_into_paragraphs(unformatted_description):
-    """Split a long description into a set of paragraphs. We assume each
-    paragraph is separated by 2 or more line-breaks in the description.
-
-    :param unformatted_description: The paragraph to format
-
-    :returns: The formatted paragraphs
-    """
-    description = unformatted_description.strip()
-    paragraphs = re.compile(r"[\n\r]{2,}").split(description)
-    formatted_paragraphs = []
-
-    # Sanitise paragraphs
-    def external(attrs, new=False):
-        url_parts = urlparse(attrs[(None, "href")])
-        if url_parts.netloc and url_parts.netloc != "snapcraft.io":
-            if (None, "class") not in attrs:
-                attrs[(None, "class")] = "p-link--external"
-            elif "p-link--external" not in attrs[(None, "class")]:
-                attrs[(None, "class")] += " p-link--external"
-        return attrs
-
-    for paragraph in paragraphs:
-        callbacks = bleach.linkifier.DEFAULT_CALLBACKS
-        callbacks.append(external)
-
-        paragraph = escape(paragraph)
-        paragraph = bleach.linkify(paragraph, callbacks=callbacks)
-
-        formatted_paragraphs.append(paragraph.replace("\n", "<br />"))
-
-    return formatted_paragraphs
-
-
 def convert_channel_maps(channel_map):
     """Converts channel maps list to format easier to manipulate
 

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -1,8 +1,4 @@
-import re
-from html import escape
 from urllib.parse import parse_qs, urlparse
-
-import bleach
 
 
 def get_searched_snaps(search_results):

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,21 +1,24 @@
+from math import floor
+from urllib.parse import quote_plus
+
 import flask
+
 import humanize
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
-from webapp.api.store import StoreApi
 import webapp.store.logic as logic
 from dateutil import parser
-from math import floor
 from webapp.api.exceptions import (
+    ApiCircuitBreaker,
+    ApiConnectionError,
     ApiError,
-    ApiTimeoutError,
     ApiResponseDecodeError,
     ApiResponseError,
     ApiResponseErrorList,
-    ApiConnectionError,
-    ApiCircuitBreaker,
+    ApiTimeoutError,
 )
-from urllib.parse import quote_plus
+from webapp.api.store import StoreApi
+from webapp.markdown import parse_markdown_description
 
 
 def store_blueprint(store_query=None, testing=False):
@@ -268,7 +271,7 @@ def store_blueprint(store_query=None, testing=False):
         if not details.get("channel-map"):
             flask.abort(404, "No snap named {}".format(snap_name))
 
-        formatted_paragraphs = logic.split_description_into_paragraphs(
+        formatted_description = parse_markdown_description(
             details["snap"]["description"]
         )
 
@@ -397,7 +400,7 @@ def store_blueprint(store_query=None, testing=False):
             "contact": details["snap"].get("contact"),
             "website": details["snap"].get("website"),
             "summary": details["snap"]["summary"],
-            "description_paragraphs": formatted_paragraphs,
+            "description": formatted_description,
             "channel_map": channel_maps_list,
             "has_stable": logic.has_stable(channel_maps_list),
             "developer_validation": details["snap"]["publisher"]["validation"],

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -3,6 +3,7 @@ from urllib.parse import quote_plus
 
 import flask
 
+import bleach
 import humanize
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
@@ -271,9 +272,8 @@ def store_blueprint(store_query=None, testing=False):
         if not details.get("channel-map"):
             flask.abort(404, "No snap named {}".format(snap_name))
 
-        formatted_description = parse_markdown_description(
-            details["snap"]["description"]
-        )
+        clean_description = bleach.clean(details["snap"]["description"])
+        formatted_description = parse_markdown_description(clean_description)
 
         channel_maps_list = logic.convert_channel_maps(
             details.get("channel-map")


### PR DESCRIPTION
Add markdown support for description

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/listing
- Edit the description with some markdown, support and unsupported
- Save your changes and visit http://0.0.0.0:8004/<snap_name>
- Ensure the markdown looks and works as expected