### PR TITLE
Removed London event banner from homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,23 +119,6 @@
   <hr />
 </div>
 
-<section class="p-strip" style="">
-  <div class="row">
-    <div class="col-6">
-      <h3 class="p-heading--two">Learn how to publish in the universal Linux App Store in London</h3>
-      <p style="">An evening workshop with Ubuntu engineers at Canonical's head offices in London. Make your apps accessible to an audience of millions.</p>
-      <p><a class="p-button--neutral p-link--external" target="_blank" href="https://www.eventbrite.co.uk/e/learn-how-to-publish-in-the-universal-linux-app-store-tickets-52939558645?utm-medium=discovery&amp;utm-campaign=social&amp;utm-content=attendeeshare&amp;aff=escb&amp;utm-source=cp&amp;utm-term=listing#tickets" style="">Register now</a></p>
-    </div>
-    <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/4f462928-original.jpg" alt="Learn how to publish in the universal Linux App Store in London" style="">
-    </div>
-  </div>
-</section>
-
-<div class="row">
-  <hr />
-</div>
-
 <div class="p-strip">
   <div class="row">
     <div class="col-6">


### PR DESCRIPTION
## QA Steps

1. Pull the branch or open up the demo url
2. Go to the homepage
3. Check there is no banner about a London event in the homepage
4. #winning