### PR TITLE
Order new categories in store page

### DIFF
--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -242,20 +242,16 @@ class StoreLogicTest(unittest.TestCase):
                 "clickindex:sections": [
                     {"name": "featured"},
                     {"name": "test"},
-                    {"name": "developers"},
+                    {"name": "development"},
                 ]
             }
         }
         category_list = logic.get_categories(categories)
-        self.assertEqual(
-            category_list,
-            [
-                {"name": "Developers", "slug": "developers"},
-                {"name": "Games", "slug": "games"},
-                {"name": "Social networking", "slug": "social-networking"},
-                {"name": "Test", "slug": "test"},
-            ],
+        self.assertTrue(
+            {"name": "Development", "slug": "development"} in category_list
         )
+        self.assertTrue({"name": "Games", "slug": "games"} in category_list)
+        self.assertTrue({"name": "Test", "slug": "test"} in category_list)
 
     def test_get_video_embed_code(self):
         youtube_url = "https://youtube.com/watch?v=123"

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -186,7 +186,20 @@ def get_categories(categories_json):
     :param categories_json: The returned json
     :returns: A list of categories
     """
-    categories_list = ["developers", "games", "social-networking"]
+    categories_list = [
+        "development",
+        "games",
+        "social",
+        "productivity",
+        "utilities",
+        "photo-and-video",
+        "server-and-cloud",
+        "security",
+        "devices-and-iot",
+        "music-and-audio",
+        "entertainment",
+        "art-and-design",
+    ]
     blacklist = ["featured"]
     categories = []
 


### PR DESCRIPTION
# Summary

Fixes  canonical-websites/snapcraft.io#1529
New order for categories in store pages

# QA

- `./run`
- http://127.0.0.1:8004/store
- Make sure order matches this order:

```
Featured
Development
Games
Social
Productivity
Utilities
Photo & Video
Server and cloud
Security
Devices & IoT
Music & Audio
...
```