### PR TITLE
Convert all dates to readable format on backend

### DIFF
--- a/static/js/public/snap-details/channelMap.js
+++ b/static/js/public/snap-details/channelMap.js
@@ -1,4 +1,3 @@
-import distanceInWords from "date-fns/distance_in_words_strict";
 import SnapEvents from "../../libs/events";
 import { triggerEvent } from "../../base/ga";
 
@@ -432,9 +431,7 @@ class ChannelMap {
           trackName,
           trackInfo["risk"],
           trackInfo["version"],
-          distanceInWords(new Date(), new Date(trackInfo["created-at"]), {
-            addSuffix: true
-          }),
+          trackInfo["created-at"],
           trackInfo["confinement"]
         ]);
       });

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -22,7 +22,7 @@ class StoreLogicTest(unittest.TestCase):
                     "track": "track",
                     "risk": "risk",
                 },
-                "created-at": "date",
+                "created-at": "2019-01-12T16:48:41.821037+00:00",
                 "confinement": "confinement",
                 "download": {"size": "size"},
                 "version": "version",
@@ -35,7 +35,7 @@ class StoreLogicTest(unittest.TestCase):
                 "track": [
                     {
                         "channel": "channel",
-                        "created-at": "date",
+                        "created-at": "Jan 12 2019",
                         "confinement": "confinement",
                         "size": "size",
                         "risk": "risk",
@@ -56,7 +56,7 @@ class StoreLogicTest(unittest.TestCase):
                     "track": "track",
                     "risk": "risk",
                 },
-                "created-at": "date",
+                "created-at": "2019-01-12T16:48:41.821037+00:00",
                 "confinement": "confinement",
                 "download": {"size": "size"},
                 "version": "version",
@@ -68,7 +68,7 @@ class StoreLogicTest(unittest.TestCase):
                     "track": "track1",
                     "risk": "risk",
                 },
-                "created-at": "date",
+                "created-at": "2019-01-12T16:48:41.821037+00:00",
                 "confinement": "confinement",
                 "download": {"size": "size"},
                 "version": "version",
@@ -80,7 +80,7 @@ class StoreLogicTest(unittest.TestCase):
                 "track": [
                     {
                         "channel": "channel",
-                        "created-at": "date",
+                        "created-at": "Jan 12 2019",
                         "confinement": "confinement",
                         "size": "size",
                         "risk": "risk",
@@ -90,7 +90,7 @@ class StoreLogicTest(unittest.TestCase):
                 "track1": [
                     {
                         "channel": "channel",
-                        "created-at": "date",
+                        "created-at": "Jan 12 2019",
                         "confinement": "confinement",
                         "size": "size",
                         "risk": "risk",
@@ -111,7 +111,7 @@ class StoreLogicTest(unittest.TestCase):
                     "track": "track",
                     "risk": "risk",
                 },
-                "created-at": "date",
+                "created-at": "2019-01-12T16:48:41.821037+00:00",
                 "confinement": "confinement",
                 "download": {"size": "size"},
                 "version": "version",
@@ -123,7 +123,7 @@ class StoreLogicTest(unittest.TestCase):
                     "track": "track",
                     "risk": "risk",
                 },
-                "created-at": "date",
+                "created-at": "2019-01-12T16:48:41.821037+00:00",
                 "confinement": "confinement",
                 "download": {"size": "size"},
                 "version": "version",
@@ -136,7 +136,7 @@ class StoreLogicTest(unittest.TestCase):
                 "track": [
                     {
                         "channel": "channel",
-                        "created-at": "date",
+                        "created-at": "Jan 12 2019",
                         "confinement": "confinement",
                         "size": "size",
                         "risk": "risk",
@@ -148,7 +148,7 @@ class StoreLogicTest(unittest.TestCase):
                 "track": [
                     {
                         "channel": "channel",
-                        "created-at": "date",
+                        "created-at": "Jan 12 2019",
                         "confinement": "confinement",
                         "size": "size",
                         "risk": "risk",

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -1,5 +1,7 @@
 from urllib.parse import parse_qs, urlparse
 
+from dateutil import parser
+
 
 def get_searched_snaps(search_results):
     """Get search snaps from API response
@@ -130,7 +132,7 @@ def convert_channel_maps(channel_map):
             channel_map_restruct[arch][track] = []
 
         info = {
-            "created-at": channel.get("created-at"),
+            "created-at": convert_date(channel.get("created-at")),
             "version": channel.get("version"),
             "channel": channel.get("channel").get("name"),
             "risk": channel.get("channel").get("risk"),
@@ -140,6 +142,19 @@ def convert_channel_maps(channel_map):
         channel_map_restruct[arch][track].append(info)
 
     return channel_map_restruct
+
+
+def convert_date(date_to_convert):
+    """Convert date to human readable format: Month Day Year
+
+    Format of date to convert: 2019-01-12T16:48:41.821037+00:00
+    Output: Jan 12 2019
+
+    :param date_to_convert: Date to convert
+    :returns: Readable date
+    """
+    date_parsed = parser.parse(date_to_convert)
+    return date_parsed.strftime("%b %d %Y")
 
 
 def get_categories(categories_json):

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -8,7 +8,6 @@ import humanize
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
 import webapp.store.logic as logic
-from dateutil import parser
 from webapp.api.exceptions import (
     ApiCircuitBreaker,
     ApiConnectionError,
@@ -409,7 +408,7 @@ def store_blueprint(store_query=None, testing=False):
             "confinement": confinement,
             # Transformed API data
             "filesize": humanize.naturalsize(binary_filesize),
-            "last_updated": (humanize.naturaldate(parser.parse(last_updated))),
+            "last_updated": logic.convert_date(last_updated),
             "last_updated_raw": last_updated,
             # Data from metrics API
             "countries": (


### PR DESCRIPTION
# Summary

Fixes https://github.com/CanonicalLtd/snap-squad/issues/855
Convert all dates to human readable format in store pages: 

```
    Format of date to convert: 2019-01-12T16:48:41.821037+00:00
    Output: Jan 12 2019
```

# QA

- `./run`
- http://127.0.0.1:8004/nextcloud
- Make sure all dates (even on the channel map popup) are in the format: Month Day Year