### PR TITLE
Remove duplicated images uploaded

### DIFF
--- a/tests/publisher/snaps/tests_post_binary_metadata.py
+++ b/tests/publisher/snaps/tests_post_binary_metadata.py
@@ -302,3 +302,153 @@ class PostBinaryMetadataListingPage(BaseTestCases.EndpointLoggedIn):
 
         assert response.status_code == 302
         assert response.location == self._get_location()
+
+    @responses.activate
+    def test_upload_duplicated_screenshot(self):
+        responses.reset()
+
+        current_screenshots = []
+        responses.add(
+            responses.GET, self.api_url, json=current_screenshots, status=200
+        )
+        responses.add(responses.PUT, self.api_url, json={}, status=200)
+
+        changes = {
+            "images": [
+                {
+                    "file": {},
+                    "url": "blob:this_is_a_blob",
+                    "name": "blue.png",
+                    "type": "icon",
+                    "status": "new",
+                },
+                {
+                    "file": {},
+                    "url": "blob:this_is_a_blob",
+                    "name": "blue.png",
+                    "type": "icon",
+                    "status": "new",
+                },
+            ]
+        }
+
+        data = dict(
+            screenshots=[(io.BytesIO(b"my file contents"), "blue.png")],
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+
+        response = self.client.post(
+            self.endpoint_url, content_type="multipart/form-data", data=data
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual("GET", called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        called = responses.calls[1]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual("PUT", called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        self.assertIn(b'"key": "blue.png"', called.request.body)
+        self.assertIn(b'"type": "screenshot"', called.request.body)
+        self.assertIn(b'"filename": "blue.png"', called.request.body)
+        hash_screenshot = (
+            '"hash": '
+            '"114d70ba7d04c76d8c217c970f99682025c89b1a6ffe91eb9045653b4b954eb9'
+        )
+        self.assertIn(
+            bytes(hash_screenshot, encoding="utf-8"), called.request.body
+        )
+
+        assert called.request.body.count(b'"key": "blue.png"') == 1
+        assert response.status_code == 302
+        assert response.location == self._get_location()
+
+    @responses.activate
+    def test_upload_screenshot_with_duplicates_current_ones(self):
+        responses.reset()
+
+        current_screenshots = [
+            {
+                "url": "URL",
+                "hash": "HASH",
+                "type": "screenshot",
+                "filename": "red.png",
+            },
+            {
+                "url": "URL",
+                "hash": "HASH",
+                "type": "screenshot",
+                "filename": "red.png",
+            },
+        ]
+        responses.add(
+            responses.GET, self.api_url, json=current_screenshots, status=200
+        )
+        responses.add(responses.PUT, self.api_url, json={}, status=200)
+
+        changes = {
+            "images": [
+                {
+                    "file": {},
+                    "url": "blob:this_is_a_blob",
+                    "name": "blue.png",
+                    "type": "icon",
+                    "status": "new",
+                },
+                {"url": "URL", "type": "screenshot", "status": "uploaded"},
+            ]
+        }
+
+        data = dict(
+            screenshots=[(io.BytesIO(b"my file contents"), "blue.png")],
+            snap_id=self.snap_id,
+            changes=json.dumps(changes),
+        )
+
+        response = self.client.post(
+            self.endpoint_url, content_type="multipart/form-data", data=data
+        )
+
+        self.assertEqual(2, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual("GET", called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        called = responses.calls[1]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual("PUT", called.request.method)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        self.assertIn(b'"key": "blue.png"', called.request.body)
+        self.assertIn(b'"type": "screenshot"', called.request.body)
+        self.assertIn(b'"filename": "blue.png"', called.request.body)
+        hash_screenshot = (
+            '"hash": '
+            '"114d70ba7d04c76d8c217c970f99682025c89b1a6ffe91eb9045653b4b954eb9'
+        )
+        self.assertIn(
+            bytes(hash_screenshot, encoding="utf-8"), called.request.body
+        )
+
+        self.assertIn(b'"url": "URL"', called.request.body)
+        self.assertIn(b'"hash": "HASH"', called.request.body)
+        self.assertIn(b'"type": "screenshot"', called.request.body)
+        self.assertIn(b'"filename": "red.png"', called.request.body)
+
+        assert called.request.body.count(b'"url": "URL"') == 1
+        assert response.status_code == 302
+        assert response.location == self._get_location()

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -180,8 +180,12 @@ def build_changed_images(
     images_json = None
     for changed_screenshot in changed_screenshots:
         for current_screenshot in current_screenshots:
-            if changed_screenshot["url"] == current_screenshot["url"]:
+            if (
+                changed_screenshot["url"] == current_screenshot["url"]
+                and current_screenshot not in info
+            ):
                 info.append(current_screenshot)
+                break
 
     # Add new icon
     if icon is not None:
@@ -197,8 +201,10 @@ def build_changed_images(
             )
 
             if is_same:
-                info.append(build_image_info(new_screenshot, "screenshot"))
-                images_files.append(new_screenshot)
+                image_built = build_image_info(new_screenshot, "screenshot")
+                if image_built not in info:
+                    info.append(image_built)
+                    images_files.append(new_screenshot)
 
     images_json = {"info": dumps(info)}
 


### PR DESCRIPTION
# Summary

Fixes #1526 
When uploading some checks weren't done well:

- When checking for current screenshots and the screenshots that we publish, if there was a duplicate the screenshot was added 4 times -> fixed
- if bug in the frontend the user was able to publish a image more than one time -> fixed

Added tests to test those behaviours

# QA

- `./run`
- Make sure you can still upload images from listing page
