### PR TITLE
Move snap listing edit link to notification

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -62,9 +62,6 @@
               <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
             </span>
             {% endif %}
-            {% if is_users_snap %}
-              <a href="/{{ package_name }}/listing">Edit</a>
-            {% endif %}
           </p>
         </div>
 
@@ -99,6 +96,15 @@
       {% endif %}
         </div>
     </div>
+    {% if is_users_snap %}
+      <div class="row">
+        <div class="p-notification--information">
+          <p class="p-notification__response">
+            Ensure your snap stay always relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
+          </p>
+        </div>
+      </div>
+    {% endif %}
   </div>
 
   {% if not webapp_config['STORE_QUERY'] %}


### PR DESCRIPTION
Fixes #1453

Moves snap details edit link into a notification

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1540.run.demo.haus/
- sign in and go to snap details page of snap you published
- notification should be visible with link to edit listing page

<img width="1035" alt="screenshot 2019-01-30 at 12 33 46" src="https://user-images.githubusercontent.com/83575/51979616-e1469a00-248d-11e9-966b-2fe9d9e0becd.png">
