### PR TITLE
Disable continue button if no OS selected

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -34,6 +34,7 @@ function install(language) {
         if (!document.querySelector(".js-linux-manual")) {
           const continueBtn = document.querySelector(".js-continue");
           if (continueBtn) {
+            continueBtn.classList.remove("is--disabled");
             continueBtn.href = `/first-snap/${language}/${selectedOs}/package`;
           }
         }

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -45,7 +45,7 @@
 
     <div class="row">
       <p class="u-float--left">Next, we'll package an example snap.</p>
-      <a class="p-button--positive u-float--right js-continue">Continue</a>
+      <a class="p-button--positive u-float--right js-continue is--disabled">Continue</a>
     </div>
 
   </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1324

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/first-snap/python
- The continue button should be disabled, until an OS is picked