### PR TITLE
Close nav dropdown on outside click

### DIFF
--- a/static/js/base/dropdown-menu-toggle.js
+++ b/static/js/base/dropdown-menu-toggle.js
@@ -11,26 +11,41 @@
    * </div>
    *
    */
-
   function toggle(toggleCtrl) {
     var toggles = document.querySelectorAll(toggleCtrl);
+
     for (var i = 0, ii = toggles.length; i < ii; i += 1) {
       toggles[i].addEventListener("click", function(evt) {
         evt.preventDefault();
-        var targetMenu = document.getElementById(
-          this.getAttribute("aria-controls")
-        );
+        evt.stopPropagation();
 
-        if (targetMenu) {
-          if (targetMenu.getAttribute("aria-hidden") === "true") {
-            this.setAttribute("aria-expanded", true);
-            targetMenu.setAttribute("aria-hidden", false);
-          } else {
-            this.setAttribute("aria-expanded", false);
-            targetMenu.setAttribute("aria-hidden", true);
-          }
-        }
+        toggleDropdown(this, this.getAttribute("aria-expanded") === "false");
       });
+    }
+
+    document.body.addEventListener("click", function() {
+      for (var i = 0, ii = toggles.length; i < ii; i += 1) {
+        toggles[i].setAttribute("aria-expanded", false);
+
+        toggleDropdown(toggles[i], false);
+      }
+    });
+  }
+
+  // helper function to toggle dropdown
+  function toggleDropdown(toggle, show) {
+    var targetMenu = document.getElementById(
+      toggle.getAttribute("aria-controls")
+    );
+
+    if (targetMenu) {
+      if (show) {
+        toggle.setAttribute("aria-expanded", true);
+        targetMenu.setAttribute("aria-hidden", false);
+      } else {
+        toggle.setAttribute("aria-expanded", false);
+        targetMenu.setAttribute("aria-hidden", true);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #865

Closes main nav dropdown on outside click

### QA
- ./run or demo
- sign in and open navigation dropdown
- click anywhere outside the dropdown
- dropdown should close