### PR TITLE
First snap flow for java

### DIFF
--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -35,7 +35,7 @@ Management
 	  java-8-openjdk-amd64"
       gradle release -x test -x createGitTag
     <b>install:</b> |
-      unzip DIST/freeplane_bin-*.zip -d 
+      unzip DIST/freeplane_bin-*.zip -d \
 	  $SNAPCRAFT_PART_INSTALL/
     <b>build-packages:</b>
       - unzip
@@ -43,7 +43,7 @@ Management
 
 <b>apps</b>:
   <b>freeplane</b>:
-    <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/
+    <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/ \
 	freeplane.sh</pre></code>
   </div>
 

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -12,9 +12,14 @@
     <h4>How freeplane defines snapcraft.yaml:</h4>
     <code class="p-code-yaml"><pre><b>name</b>: freeplane
 <b>version</b>: '1.6.10'
-<b>summary</b>: Application for Mind Mapping, Knowledge and Project Management
+<b>summary</b>: Application for Mind Mapping, Knowledge and Project 
+Management
 <b>description</b>: |
-  Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
+  Freeplane is a free and open source software application that supports 
+  thinking, sharing information and getting things done at work, in school 
+  and at home. The core of the software is tools for mind mapping (also 
+  known as concept mapping or information mapping) and using mapped 
+  information.
 
 <b>confinement</b>: devmode
 
@@ -24,17 +29,20 @@
     <b>plugin:</b> gradle
     <b>source:</b> .
     <b>build:</b> |
-      export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+      export JAVA_HOME="/usr/lib/jvm/
+	  java-8-openjdk-amd64"
       gradle release -x test -x createGitTag
     <b>install:</b> |
-      unzip DIST/freeplane_bin-*.zip -d $SNAPCRAFT_PART_INSTALL/
+      unzip DIST/freeplane_bin-*.zip -d 
+	  $SNAPCRAFT_PART_INSTALL/
     <b>build-packages:</b>
       - unzip
       - openjdk-8-jdk
 
 <b>apps</b>:
   <b>freeplane</b>:
-    <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/freeplane.sh</pre></code>
+    <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/
+	freeplane.sh</pre></code>
   </div>
 
   <div class="p-flow-details__continue">

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -5,10 +5,40 @@
       <li>Simplify installation instructions, regardless of distribution, to snap install myjavaapp.</li>
       <li>Directly control the delivery of automatic application updates.</li>
     </ul>
+	<p>Distributing a Java application for Linux and reaching the widest possible audience was complicated. Typically, the user had to make sure they had the JRE/SDK version and their environment configured correctly. When a Linux distribution changes the delivered JRE, this can be problematic for applications. Snapcraft ensures the correct JRE is shipped alongside the application at all times.</p>
+  </div>
+
+  <div class='col-6'>
+    <h4>How freeplane defines snapcraft.yaml:</h4>
+    <code class="p-code-yaml"><pre><b>name</b>: freeplane
+<b>version</b>: '1.6.10'
+<b>summary</b>: Application for Mind Mapping, Knowledge and Project Management
+<b>description</b>: |
+  Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
+
+<b>confinement</b>: devmode
+
+<b>parts:</b>
+  <b>freeplane:</b>
+    <b>after:</b> [desktop-glib-only]
+    <b>plugin:</b> gradle
+    <b>source:</b> .
+    <b>build:</b> |
+      export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+      gradle release -x test -x createGitTag
+    <b>install:</b> |
+      unzip DIST/freeplane_bin-*.zip -d $SNAPCRAFT_PART_INSTALL/
+    <b>build-packages:</b>
+      - unzip
+      - openjdk-8-jdk
+
+<b>apps</b>:
+  <b>freeplane</b>:
+    <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/freeplane.sh</pre></code>
   </div>
 
   <div class="p-flow-details__continue">
     In just a few steps, you’ll have an example Java app in the Snap Store.
-    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/java">Continue</a>
+    <a class="p-button--positive is-inline" href="/first-snap/java">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -15,11 +15,13 @@
 <b>summary</b>: Application for Mind Mapping, Knowledge and Project 
 Management
 <b>description</b>: |
-  Freeplane is a free and open source software application that supports 
-  thinking, sharing information and getting things done at work, in school 
-  and at home. The core of the software is tools for mind mapping (also 
-  known as concept mapping or information mapping) and using mapped 
-  information.
+  Freeplane is a free and open source software 
+  application that supports thinking, sharing 
+  information and getting things done at work, 
+  in school and at home. The core of the 
+  software is tools for mind mapping (also known 
+  as concept mapping or information mapping) 
+  and using mapped information.
 
 <b>confinement</b>: devmode
 

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -43,8 +43,8 @@ Management
 
 <b>apps</b>:
   <b>freeplane</b>:
-    <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/ \
-	freeplane.sh</pre></code>
+    <b>command</b>: desktop-launch \ 
+	$SNAP/freeplane-1.6.10/freeplane.sh</pre></code>
   </div>
 
   <div class="p-flow-details__continue">

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -5,7 +5,7 @@
       <li>Simplify installation instructions, regardless of distribution, to snap install myjavaapp.</li>
       <li>Directly control the delivery of automatic application updates.</li>
     </ul>
-	<p>Distributing a Java application for Linux and reaching the widest possible audience was complicated. Typically, the user had to make sure they had the JRE/SDK version and their environment configured correctly. When a Linux distribution changes the delivered JRE, this can be problematic for applications. Snapcraft ensures the correct JRE is shipped alongside the application at all times.</p>
+	<p>Distributing a Java application for Linux and reaching the widest possible audience is complicated. Typically, the user has to make sure the JRE/SDK version and their environment are configured correctly. When a Linux distribution changes the delivered JRE, this can be problematic for applications. Snapcraft ensures the correct JRE is shipped alongside the application at all times.</p>
   </div>
 
   <div class='col-6'>

--- a/webapp/first_snap/content/java/build.yaml
+++ b/webapp/first_snap/content/java/build.yaml
@@ -1,0 +1,54 @@
+linux:
+  auto:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+    - action: Install the snap
+      command: sudo snap install --devmode --dangerous *.snap
+    - action: List your installed snaps to confirm
+      command: snap list
+    - action: Run the snap
+      command: test-freeplane-{name} -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>test-freeplane-{name}</code>)
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+    - action: Install the snap
+      command: sudo snap install --devmode --dangerous *.snap
+    - action: List your installed snaps to confirm
+      command: snap list
+    - action: Run the snap
+      command: test-freeplane-{name} -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>test-freeplane-{name}</code>)
+macos:
+  auto:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: |
+        brew install squashfs
+        unsquashfs -l *.snap
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: |
+        brew install squashfs
+        unsquashfs -l *.snap
+windows:
+  auto:
+    - action: Run Windows Subsystem for Linux from the Windows Start menu
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -1,0 +1,69 @@
+name: freeplane-{name}
+download: git clone https://github.com/snapcraft-docs/freeplane
+createDir: |
+  cd freeplane
+  $EDITOR snapcraft.yaml
+metadata: |
+  name: freeplane
+  version: git
+  summary: Application for Mind Mapping, Knowledge and Project Management
+  description: |
+    Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
+explain:
+  metadata:
+    - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.
+    - code: |
+        name: freeplane
+    - warning: |
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
+    - text: Versions carry no semantic meaning in snaps.
+    - code: |
+        version: '1.6.10' 
+    - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
+    - code: |
+        description: |
+  security:
+    - text: The next section describes the level of confinement applied to your app.
+    - code: |
+        confinement: devmode
+    - text: Snaps are containerised to ensure more predictable application behaviour and greater security.
+    - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
+    - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
+  parts:
+    - text: |
+        Parts define how to build your app. Parts can be anything: programs, libraries, or other assets needed to create and run your application. Parts canpoint to local directories, remote git repositories, or tarballs. 
+    - code: |
+        parts:
+          freeplane:
+            after: [desktop-glib-only]
+            plugin: gradle
+            source: .
+            build: |
+              export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+              gradle release -x test -x createGitTag
+            install: |
+              unzip DIST/freeplane_bin-*.zip -d $SNAPCRAFT_PART_INSTALL/
+            build-packages:
+              - unzip
+              - openjdk-8-jdk
+    - text: |
+        The gradle plugin can build the application using standard parameters. In this case however we have overridden some gradle parameters (to disable testing, and prevent a new git tag being created), and set an appropriate JAVA_HOME in a build: script snippet.
+    - text: |
+        In the install: script snippet we’re unpacking the built application into a directory which later gets incorporated into the final snap, defined by the $SNAPCRAFT_PART_INSTALL variable.
+    - text: |    
+        The build requires an appropriate JDK/JRE and the install step requires the addition of the unzip command, so these are specified as build-packages.
+  apps:
+    - text: |
+        Apps are the commands and services exposed to end users. If your command name matches the snap name, users will be able run the command directly.
+    - text: |
+        If you don’t want your command prefixed you can request an alias for it on the Snapcraft forum. These are set up automatically when your snap is installed from the Snap Store.
+    - text: |
+        We have prefixed the FreePlane launch script with the desktop-launch helper script, provided by the desktop-glib-only remote part.
+    - code: |
+          apps:
+            freeplane:
+                command: desktop-launch $SNAP/freeplane-1.6.10/freeplane.sh
+    - warning: |
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
+    - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
+    - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -8,9 +8,7 @@ metadata: |
   version: '1.6.10'
   summary: Application for Mind Mapping, Knowledge and Project Management
   description: |
-    Freeplane is a free and open source software application that supports thinking, sharing information and getting things done 
-    at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information 
-    mapping) and using mapped information.
+    Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
 explain:
   metadata:
     - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -6,9 +6,14 @@ createDir: |
 metadata: |
   name: freeplane
   version: '1.6.10'
-  summary: Application for Mind Mapping, Knowledge and Project Management
+  summary: Application for Mind Mapping, Knowledge and Project 
+  Management
   description: |
-    Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
+    Freeplane is a free and open source software application that 
+    supports thinking, sharing information and getting things done 
+    at work, in school and at home. The core of the software is tools 
+    for mind mapping (also known as concept mapping or information 
+    mapping) and using mapped information.
 explain:
   metadata:
     - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -48,7 +48,7 @@ explain:
               - unzip
               - openjdk-8-jdk
     - text: |
-        The gradle plugin can build the application using standard parameters. In this case however we have overridden some gradle parameters (to disable testing, and prevent a new git tag being created), and set an appropriate JAVA_HOME in a build: script snippet.
+        The gradle plugin can build the application using standard parameters. However, in this case, we have overridden some gradle parameters (to disable testing, and prevent a new git tag being created), and set an appropriate JAVA_HOME in a build: script snippet.
     - text: |
         In the install: script snippet we’re unpacking the built application into a directory which later gets incorporated into the final snap, defined by the $SNAPCRAFT_PART_INSTALL variable.
     - text: |    

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -6,9 +6,14 @@ createDir: |
 metadata: |
   name: freeplane
   version: '1.6.10'
-  summary: Application for Mind Mapping, Knowledge and Project Management
+  summary: Application for Mind Mapping, Knowledge and Project 
+  Management
   description: |
-    Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
+    Freeplane is a free and open source software application that 
+    supports thinking, sharing information and getting things done 
+    at work, in school and at home. The core of the software is tools 
+    for mind mapping (also known as concept mapping or information 
+    mapping) and using mapped information.
 explain:
   metadata:
     - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.
@@ -56,10 +61,6 @@ explain:
   apps:
     - text: |
         Apps are the commands and services exposed to end users. If your command name matches the snap name, users will be able run the command directly.
-    - text: |
-        If you don’t want your command prefixed you can request an alias for it on the Snapcraft forum. These are set up automatically when your snap is installed from the Snap Store.
-    - text: |
-        We have prefixed the FreePlane launch script with the desktop-launch helper script, provided by the desktop-glib-only remote part.
     - code: |
           apps:
             freeplane:
@@ -67,4 +68,3 @@ explain:
     - warning: |
         <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
-    - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -6,13 +6,10 @@ createDir: |
 metadata: |
   name: freeplane
   version: '1.6.10'
-  summary: Application for Mind Mapping, Knowledge and Project 
-  Management
+  summary: Application for Mind Mapping, Knowledge and Project Management
   description: |
-    Freeplane is a free and open source software application that 
-    supports thinking, sharing information and getting things done 
-    at work, in school and at home. The core of the software is tools 
-    for mind mapping (also known as concept mapping or information 
+    Freeplane is a free and open source software application that supports thinking, sharing information and getting things done 
+    at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information 
     mapping) and using mapped information.
 explain:
   metadata:

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -5,7 +5,7 @@ createDir: |
   $EDITOR snapcraft.yaml
 metadata: |
   name: freeplane
-  version: git
+  version: '1.6.10'
   summary: Application for Mind Mapping, Knowledge and Project Management
   description: |
     Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The core of the software is tools for mind mapping (also known as concept mapping or information mapping) and using mapped information.
@@ -16,7 +16,8 @@ explain:
         name: freeplane
     - warning: |
         <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
-    - text: Versions carry no semantic meaning in snaps.
+    - text: |
+        Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
     - code: |
         version: '1.6.10' 
     - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
@@ -31,7 +32,7 @@ explain:
     - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
   parts:
     - text: |
-        Parts define how to build your app. Parts can be anything: programs, libraries, or other assets needed to create and run your application. Parts canpoint to local directories, remote git repositories, or tarballs. 
+        Parts define how to build your app. Parts can be anything: programs, libraries, or other assets needed to create and run your application. Parts can point to local directories, remote git repositories, or tarballs. 
     - code: |
         parts:
           freeplane:

--- a/webapp/first_snap/content/java/test.yaml
+++ b/webapp/first_snap/content/java/test.yaml
@@ -1,0 +1,16 @@
+macos:
+  - action: Create a Linux virtual machine for testing snaps
+    command: multipass launch -n testvm
+  - action: Return to the directory containing the .snap file and copy it into the virtual machine
+    command: 'multipass copy-files freeplane*.snap testvm:'
+  - action: Connect to the virtual machine
+    command: multipass shell testvm
+  - action: Install the snap inside the virtual machine
+    command: sudo snap install --dangerous freeplane*.snap
+  - action: Confirm the snap is installed by listing your installed snaps
+    command: snap list
+  - action: Run the snap inside the virtual machine
+    warning: You should change <code>freeplane</code> to <code>test-freeplane-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    command: freeplane -h
+  - action: Exit the virtual machine
+    command: exit


### PR DESCRIPTION
Added Java FSF using the existing template. I did not edit the snapcraft.yaml content or make any changes to the language-common sections.


### QA

- DEMO: https://snapcraft-io-canonical-websites-pr-1558.run.demo.haus/
- open Java section of first snap flow on home page
- go through the steps

<img width="979" alt="screenshot 2019-02-05 at 12 20 45" src="https://user-images.githubusercontent.com/83575/52270223-979ff880-2940-11e9-9acd-4163c9997d5d.png">
