### PR TITLE
Report snap modal

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -2,6 +2,7 @@ import map from "./snap-details/map";
 import screenshots from "./snap-details/screenshots";
 import channelMap from "./snap-details/channelMap";
 import videos from "./snap-details/videos";
+import initReportSnap from "./snap-details/reportSnap";
 import { snapDetailsPosts, seriesPosts } from "./snap-details/blog-posts";
 import { storeCategories } from "./store-categories";
 import { initFSFLanguageSelect } from "./fsf-language-select";
@@ -16,6 +17,7 @@ export {
   snapDetailsPosts,
   seriesPosts,
   initFSFLanguageSelect,
+  initReportSnap,
   firstSnapFlow,
   videos,
   nps

--- a/static/js/public/snap-details/reportSnap.js
+++ b/static/js/public/snap-details/reportSnap.js
@@ -47,7 +47,8 @@ function buttonEnabled(button) {
 export default function initReportSnap(
   snapName,
   toggleSelector,
-  modalSelector
+  modalSelector,
+  formURL
 ) {
   const toggle = document.querySelector(toggleSelector);
   const modal = document.querySelector(modalSelector);
@@ -70,18 +71,12 @@ export default function initReportSnap(
     e.preventDefault();
     buttonLoading(reportForm.querySelector("button[type=submit]"));
 
-    fetch(`/${snapName}/report`, {
+    fetch(formURL, {
       method: "POST",
-      body: new FormData(reportForm)
+      body: new FormData(reportForm),
+      mode: "no-cors"
     })
-      .then(response => response.json())
-      .then(json => {
-        if (json.success) {
-          showSuccess(modal);
-        } else {
-          showError(modal);
-        }
-      })
+      .then(() => showSuccess(modal))
       .catch(() => showError(modal));
   });
 

--- a/static/js/public/snap-details/reportSnap.js
+++ b/static/js/public/snap-details/reportSnap.js
@@ -1,0 +1,69 @@
+import "whatwg-fetch";
+
+function toggleModal(modal) {
+  if (modal.style.display === "none") {
+    modal.style.display = "";
+  } else {
+    modal.style.display = "none";
+    showForm(modal);
+  }
+}
+
+function showForm(modal) {
+  modal.querySelector("button[type=submit]").disabled = false;
+  modal.querySelector(".js-report-snap-form").style.display = "";
+  modal.querySelector(".js-report-snap-success").style.display = "none";
+  modal.querySelector(".js-report-snap-error").style.display = "none";
+}
+
+function showSuccess(modal) {
+  modal.querySelector(".js-report-snap-form").style.display = "none";
+  modal.querySelector(".js-report-snap-success").style.display = "";
+  modal.querySelector(".js-report-snap-error").style.display = "none";
+}
+
+function showError(modal) {
+  modal.querySelector(".js-report-snap-form").style.display = "none";
+  modal.querySelector(".js-report-snap-success").style.display = "none";
+  modal.querySelector(".js-report-snap-error").style.display = "";
+}
+
+export default function initReportSnap(
+  snapName,
+  toggleSelector,
+  modalSelector
+) {
+  const toggle = document.querySelector(toggleSelector);
+  const modal = document.querySelector(modalSelector);
+  const reportForm = modal.querySelector("form");
+
+  toggle.addEventListener("click", event => {
+    event.preventDefault();
+    toggleModal(modal);
+  });
+  modal.addEventListener("click", event => {
+    const target = event.target;
+
+    if (target.closest(".js-modal-close")) {
+      toggleModal(modal);
+    }
+  });
+
+  reportForm.addEventListener("submit", e => {
+    e.preventDefault();
+    reportForm.querySelector("button[type=submit]").disabled = true;
+    fetch(`/${snapName}/report`, {
+      method: "POST",
+      body: new FormData(reportForm)
+    })
+      .then(response => response.json())
+      .then(json => {
+        if (json.success) {
+          showSuccess(modal);
+        } else {
+          showError(modal);
+        }
+      })
+      .catch(() => showError(modal));
+  });
+}

--- a/static/js/public/snap-details/reportSnap.js
+++ b/static/js/public/snap-details/reportSnap.js
@@ -1,36 +1,39 @@
 import "whatwg-fetch";
 
+const showEl = el => el.classList.remove("u-hide");
+const hideEl = el => el.classList.add("u-hide");
+
 function toggleModal(modal, show) {
   if (typeof show === "undefined") {
-    show = modal.style.display === "none";
+    show = modal.classList.contains("u-hide");
   }
 
   if (show) {
-    showForm(modal);
-    modal.style.display = "";
+    initForm(modal);
+    showEl(modal);
   } else {
-    modal.style.display = "none";
+    hideEl(modal);
   }
 }
 
-function showForm(modal) {
+function initForm(modal) {
   buttonEnabled(modal.querySelector("button[type=submit]"));
 
-  modal.querySelector(".js-report-snap-form").style.display = "";
-  modal.querySelector(".js-report-snap-success").style.display = "none";
-  modal.querySelector(".js-report-snap-error").style.display = "none";
+  showEl(modal.querySelector(".js-report-snap-form"));
+  hideEl(modal.querySelector(".js-report-snap-success"));
+  hideEl(modal.querySelector(".js-report-snap-error"));
 }
 
 function showSuccess(modal) {
-  modal.querySelector(".js-report-snap-form").style.display = "none";
-  modal.querySelector(".js-report-snap-success").style.display = "";
-  modal.querySelector(".js-report-snap-error").style.display = "none";
+  hideEl(modal.querySelector(".js-report-snap-form"));
+  showEl(modal.querySelector(".js-report-snap-success"));
+  hideEl(modal.querySelector(".js-report-snap-error"));
 }
 
 function showError(modal) {
-  modal.querySelector(".js-report-snap-form").style.display = "none";
-  modal.querySelector(".js-report-snap-success").style.display = "none";
-  modal.querySelector(".js-report-snap-error").style.display = "";
+  hideEl(modal.querySelector(".js-report-snap-form"));
+  hideEl(modal.querySelector(".js-report-snap-success"));
+  showEl(modal.querySelector(".js-report-snap-error"));
 }
 
 function buttonLoading(button) {

--- a/static/js/public/snap-details/reportSnap.js
+++ b/static/js/public/snap-details/reportSnap.js
@@ -1,7 +1,11 @@
 import "whatwg-fetch";
 
-function toggleModal(modal) {
-  if (modal.style.display === "none") {
+function toggleModal(modal, show) {
+  if (typeof show === "undefined") {
+    show = modal.style.display === "none";
+  }
+
+  if (show) {
     showForm(modal);
     modal.style.display = "";
   } else {
@@ -57,7 +61,7 @@ export default function initReportSnap(
   modal.addEventListener("click", event => {
     const target = event.target;
 
-    if (target.closest(".js-modal-close")) {
+    if (target.closest(".js-modal-close") || target === modal) {
       toggleModal(modal);
     }
   });
@@ -79,5 +83,12 @@ export default function initReportSnap(
         }
       })
       .catch(() => showError(modal));
+  });
+
+  // close modal on ESC
+  window.addEventListener("keyup", event => {
+    if (event.keyCode === 27) {
+      toggleModal(modal, false);
+    }
   });
 }

--- a/static/js/public/snap-details/reportSnap.js
+++ b/static/js/public/snap-details/reportSnap.js
@@ -2,15 +2,16 @@ import "whatwg-fetch";
 
 function toggleModal(modal) {
   if (modal.style.display === "none") {
+    showForm(modal);
     modal.style.display = "";
   } else {
     modal.style.display = "none";
-    showForm(modal);
   }
 }
 
 function showForm(modal) {
-  modal.querySelector("button[type=submit]").disabled = false;
+  buttonEnabled(modal.querySelector("button[type=submit]"));
+
   modal.querySelector(".js-report-snap-form").style.display = "";
   modal.querySelector(".js-report-snap-success").style.display = "none";
   modal.querySelector(".js-report-snap-error").style.display = "none";
@@ -28,6 +29,17 @@ function showError(modal) {
   modal.querySelector(".js-report-snap-error").style.display = "";
 }
 
+function buttonLoading(button) {
+  button.disabled = true;
+  button.innerHTML =
+    "<i class='p-icon--spinner u-animation--spin'></i> Submitting…";
+}
+
+function buttonEnabled(button) {
+  button.disabled = false;
+  button.innerHTML = "Submit report";
+}
+
 export default function initReportSnap(
   snapName,
   toggleSelector,
@@ -41,6 +53,7 @@ export default function initReportSnap(
     event.preventDefault();
     toggleModal(modal);
   });
+
   modal.addEventListener("click", event => {
     const target = event.target;
 
@@ -51,7 +64,8 @@ export default function initReportSnap(
 
   reportForm.addEventListener("submit", e => {
     e.preventDefault();
-    reportForm.querySelector("button[type=submit]").disabled = true;
+    buttonLoading(reportForm.querySelector("button[type=submit]"));
+
     fetch(`/${snapName}/report`, {
       method: "POST",
       body: new FormData(reportForm)

--- a/static/sass/_patterns_modal.scss
+++ b/static/sass/_patterns_modal.scss
@@ -1,0 +1,6 @@
+@mixin vf-p-modal-snapcraft {
+  .p-modal {
+    position: fixed; // make it stick to screen regardless of scroll
+    z-index: 100; // put it on top of everything (including global nav)
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -16,6 +16,7 @@ $color-navigation-background: #252525;
 @include vf-p-grid-modifications;
 @include vf-p-buttons;
 @include vf-p-strip;
+@include vf-p-modal;
 @include vf-p-muted-heading;
 @include vf-p-navigation;
 @include vf-p-notification;
@@ -203,6 +204,9 @@ $color-navigation-background: #252525;
 
 @import 'snapcraft-publicise';
 @include snapcraft-publicise;
+
+@import 'patterns_modal';
+@include vf-p-modal-snapcraft;
 
 html,
 body {

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -213,7 +213,7 @@
     </div>
   </div>
 
-  <div class="p-modal" id="report-snap-modal" style="display: none">
+  <div class="p-modal u-hide" id="report-snap-modal">
     <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
       <div class="js-report-snap-form">
         <header class="p-modal__header">
@@ -245,7 +245,7 @@
         </form>
       </div>
 
-      <div class="js-report-snap-success" style="display: none;">
+      <div class="js-report-snap-success u-hide">
         <header class="p-modal__header">
           <h2 class="p-modal__title" id="modal-title">Report submitted successfully</h2>
           <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
@@ -256,7 +256,7 @@
         </div>
       </div>
 
-      <div class="js-report-snap-error" style="display: none;">
+      <div class="js-report-snap-error u-hide">
         <header class="p-modal__header">
           <h2 class="p-modal__title" id="modal-title">Error submitting report</h2>
           <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -221,20 +221,21 @@
           <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
         </header>
 
-        <form>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          <input type="hidden" name="snap" value="{{package_name}}" />
+        {# report snap form submits to a Google Forms #}
+        {# names of the inputs need to be consistend with the original form #}
+        <form id="report-snap-form" action="https://docs.google.com/forms/d/e/1FAIpQLSelELZwXzvnDkx52GL7cpnQyWdc_Te6APDs843gIKRBHbh6jA/formResponse" method="POST">
+          <input type="hidden" name="entry.1703677219" value="{{package_name}}" />
           <label for="report-snap-reason">Choose a reason for reporting this snap</label>
-          <select id="report-snap-reason" name="reason" required>
+          <select id="report-snap-reason" name="entry.1193754313" required>
             <option value="" selected>Select an option</option>
-            <option value="copyright-violation">Copyright or trademark violation</option>
-            <option value="terms-violation">Snap Store terms of service violation</option>
+            <option value="Copyright or trademark violation">Copyright or trademark violation</option>
+            <option value="Snap Store terms of service violation">Snap Store terms of service violation</option>
           </select>
           <label for="report-snap-comment">Please provide more detailed reason to your report</label>
-          <textarea id="report-snap-comment" type="text" name="comment" placeholder="Comment..." rows="5" required></textarea>
+          <textarea id="report-snap-comment" type="text" name="entry.1170971435" placeholder="Comment..." rows="5" required></textarea>
 
           <label for="report-snap-email">Your email (optional)</label>
-          <input id="report-snap-email" type="email" name="email" placeholder="email@example.com" />
+          <input id="report-snap-email" type="email" name="entry.1424146082" placeholder="email@example.com" />
           <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
           <div class="u-align--right">
             <button type="button" class="js-modal-close">Cancel</button>
@@ -328,7 +329,10 @@
       }
 
       try {
-        snapcraft.public.initReportSnap('{{ package_name }}','.js-modal-open', '#report-snap-modal');
+        snapcraft.public.initReportSnap(
+          '{{ package_name }}', '.js-modal-open', '#report-snap-modal',
+          document.getElementById('report-snap-form').action
+        );
       } catch(e) {
         Raven.captureException(e);
       }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -238,7 +238,8 @@
           <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
           <div class="u-align--right">
             <button type="button" class="js-modal-close">Cancel</button>
-            <button type="submit" type="submit">Submit report</button>
+            {# use --dark fake class for spinner icon to be rendered correctly... #}
+            <button type="submit" type="submit" class="--dark">Submit report</button>
           </div>
         </form>
       </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -232,7 +232,7 @@
             <option value="Snap Store terms of service violation">Snap Store terms of service violation</option>
           </select>
           <label for="report-snap-comment">Please provide more detailed reason to your report</label>
-          <textarea id="report-snap-comment" type="text" name="entry.1170971435" placeholder="Comment..." rows="5" required></textarea>
+          <textarea id="report-snap-comment" type="text" name="entry.1170971435" placeholder="Comment..." rows="5" maxlength="1000" required></textarea>
 
           <label for="report-snap-email">Your email (optional)</label>
           <input id="report-snap-email" type="email" name="entry.1424146082" placeholder="email@example.com" />

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -201,6 +201,72 @@
     </div>
   {% endif %}
 
+  <div class="row">
+    <div class="col-12">
+      <hr />
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <p>Is there a problem with {{snap_title}}? <a class="js-modal-open">Report this app</a></p>
+    </div>
+  </div>
+
+  <div class="p-modal" id="report-snap-modal" style="display: none">
+    <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+      <div class="js-report-snap-form">
+        <header class="p-modal__header">
+          <h2 class="p-modal__title" id="modal-title">Report {{snap_title}}</h2>
+          <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
+        </header>
+
+        <form>
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <input type="hidden" name="snap" value="{{package_name}}" />
+          <label for="report-snap-reason">Choose a reason for reporting this snap</label>
+          <select id="report-snap-reason" name="reason" required>
+            <option value="" selected>Select an option</option>
+            <option value="copyright-violation">Copyright or trademark violation</option>
+            <option value="terms-violation">Snap Store terms of service violation</option>
+          </select>
+          <label for="report-snap-comment">Please provide more detailed reason to your report</label>
+          <textarea id="report-snap-comment" type="text" name="comment" placeholder="Comment..." rows="5" required></textarea>
+
+          <label for="report-snap-email">Your email (optional)</label>
+          <input id="report-snap-email" type="email" name="email" placeholder="email@example.com" />
+          <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
+          <div class="u-align--right">
+            <button type="button" class="js-modal-close">Cancel</button>
+            <button type="submit" type="submit">Submit report</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="js-report-snap-success" style="display: none;">
+        <header class="p-modal__header">
+          <h2 class="p-modal__title" id="modal-title">Report submitted successfully</h2>
+          <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
+        </header>
+        <p>Thanks for bringing this to our attention. Information you provided will help us investigate further.</p>
+        <div class="u-align--right">
+          <button type="button" class="p-button--positive js-modal-close">Close</button>
+        </div>
+      </div>
+
+      <div class="js-report-snap-error" style="display: none;">
+        <header class="p-modal__header">
+          <h2 class="p-modal__title" id="modal-title">Error submitting report</h2>
+          <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
+        </header>
+        <p>There was an error while sending your report. Please try again later.</p>
+        <div class="u-align--right">
+          <button type="button" class="p-button--positive js-modal-close">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   {% if api_error %}
     <div class="row">
       <div class="col-12">
@@ -232,7 +298,6 @@
   <script type="text/template" id="video-asciinema-template">
     {% include 'partials/_video.html' %}
   </script>
-
 {% endblock %}
 
 {% block scripts_modules %}
@@ -257,6 +322,12 @@
 
       try {
         snapcraft.public.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
+      try {
+        snapcraft.public.initReportSnap('{{ package_name }}','.js-modal-open', '#report-snap-modal');
       } catch(e) {
         Raven.captureException(e);
       }


### PR DESCRIPTION
Fixes #1556

Adds a modal dialog to report snap on snap details page.
Data is posted to Google Form.

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1568.run.demo.haus/
- go to snap details page of any suspicious snap
- scroll to the bottom of the page, click on 'Report this app' link
- fill the details in the form, Submit
- success message should be shown
- data should be added to [Report snap Google Sheet](https://docs.google.com/spreadsheets/d/1ju2IKRiMsVK17b6Fmtj335sj3xaawXcN4hYGZvxwR6s/edit)

<img width="1109" alt="screenshot 2019-02-06 at 16 20 42" src="https://user-images.githubusercontent.com/83575/52351495-2c7f2080-2a2b-11e9-92ac-82b9ec248440.png">

