### PR TITLE
Add list of categories to snap details page

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -75,15 +75,20 @@
         {% endif %}
         <div class="p-snap-heading__title">
           <h1 class="p-heading--two p-snap-heading__name" data-live="title">{{ snap_title }}</h1>
-          <p class="p-snap-heading__publisher">
-            by {{ display_name(publisher, username) }}
-            {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
-            <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
-              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
-              <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
-            </span>
-            {% endif %}
-          </p>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item">
+              by {{ display_name(publisher, username) }}
+              {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
+              <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
+                <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
+                <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
+              </span>
+              {% endif %}
+            </li>
+            {% for category in categories %}<li class="p-inline-list__item">
+              <a href="/search?category={{category.slug}}">{{ category.name }}</a>
+            </li>{% endfor %}
+          </ul>
         </div>
 
       {% if not webapp_config['STORE_QUERY'] %}

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -15,7 +15,7 @@ class GetDetailsPageTest(TestCase):
                 self.snap_name,
                 "?fields=title,summary,description,license,contact,website,",
                 "publisher,prices,media,download,version,created-at,"
-                "confinement",
+                "confinement,categories",
             ]
         )
         self.endpoint_url = "/" + self.snap_name
@@ -75,6 +75,7 @@ class GetDetailsPageTest(TestCase):
                     "username": "toto",
                     "validation": True,
                 },
+                "categories": [{"name": "test"}],
             },
             "channel-map": [
                 {
@@ -130,6 +131,7 @@ class GetDetailsPageTest(TestCase):
                     "username": "toto",
                     "validation": True,
                 },
+                "categories": [{"name": "test"}],
             },
             "channel-map": [
                 {
@@ -182,6 +184,7 @@ class GetDetailsPageTest(TestCase):
                     "username": "toto",
                     "validation": True,
                 },
+                "categories": [{"name": "test"}],
             },
             "channel-map": [
                 {

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -19,7 +19,7 @@ SNAP_INFO_URL = "".join(
         SNAPCRAFT_IO_API_V2,
         "snaps/info/{snap_name}",
         "?fields=title,summary,description,license,contact,website,publisher,",
-        "prices,media,download,version,created-at,confinement",
+        "prices,media,download,version,created-at,confinement,categories",
     ]
 )
 

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -165,27 +165,31 @@ def convert_date(date_to_convert):
         return date_parsed.strftime("%-d %B %Y")
 
 
+categories_list = [
+    "development",
+    "games",
+    "social",
+    "productivity",
+    "utilities",
+    "photo-and-video",
+    "server-and-cloud",
+    "security",
+    "devices-and-iot",
+    "music-and-audio",
+    "entertainment",
+    "art-and-design",
+]
+
+blacklist = ["featured"]
+
+
 def get_categories(categories_json):
     """Retrieve and flatten the nested array from the legacy API response.
 
     :param categories_json: The returned json
     :returns: A list of categories
     """
-    categories_list = [
-        "development",
-        "games",
-        "social",
-        "productivity",
-        "utilities",
-        "photo-and-video",
-        "server-and-cloud",
-        "security",
-        "devices-and-iot",
-        "music-and-audio",
-        "entertainment",
-        "art-and-design",
-    ]
-    blacklist = ["featured"]
+
     categories = []
 
     if "_embedded" in categories_json:
@@ -201,6 +205,26 @@ def get_categories(categories_json):
                 {
                     "slug": category,
                     "name": category.capitalize().replace("-", " "),
+                }
+            )
+
+    return categories
+
+
+def get_snap_categories(snap_categories):
+    """Retrieve list of categories with names for a snap.
+
+    :param snap_categories: List of snap categories from snap info API
+    :returns: A list of categories with names
+    """
+    categories = []
+
+    for cat in snap_categories:
+        if cat["name"] not in blacklist:
+            categories.append(
+                {
+                    "slug": cat["name"],
+                    "name": cat["name"].capitalize().replace("-", " "),
                 }
             )
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -376,10 +376,14 @@ def store_blueprint(store_query=None, testing=False):
             ):
                 is_users_snap = True
 
+        # build list of categories of a snap
+        categories = logic.get_snap_categories(details["snap"]["categories"])
+
         context = {
             # Data direct from details API
             "snap_title": details["snap"]["title"],
             "package_name": details["name"],
+            "categories": categories,
             "icon_url": icons[0] if icons else None,
             "version": last_version,
             "license": details["snap"]["license"],


### PR DESCRIPTION
Fixes #1496 

Adds links to categories to snap details pages (under snap name)

### QA

- ./run or demo
- go to any snap with category (for example via Store page)
- list of categories of this snap should be linked under snap name
- go to publisher listing page of any snap you own
- add it to two categories, Save
- see if both categories show on snap details page
- remember to remove any testing categories from test snaps!

<img width="1039" alt="screenshot 2019-02-07 at 12 52 33" src="https://user-images.githubusercontent.com/83575/52410057-876e5180-2ad7-11e9-815c-e72f67fa50d4.png">
