### PR TITLE
Remove snapcraft logo from empty default icon

### DIFF
--- a/templates/brand-store/search.html
+++ b/templates/brand-store/search.html
@@ -47,7 +47,7 @@
                 {% if snap.icon_url %}
                   <img src="{{ snap.icon_url }}"  alt="">
                 {% else %}
-                  <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg"  alt="">
+                  <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"  alt="">
                 {% endif %}
               </a>
               <div class="p-media-object__details">

--- a/templates/brand-store/store.html
+++ b/templates/brand-store/store.html
@@ -45,7 +45,7 @@ sudo service snapd restart</code></pre>
               {% if snap.icon_url %}
                 <img class="p-heading-icon__img" src="{{ snap.icon_url }}" alt="">
               {% else %}
-                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="">
+                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="">
               {% endif %}
             </span>
             <span class="p-media-object__details">

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -128,7 +128,7 @@ My published snaps — Linux software in the Snap Store
                   {% if snaps[snap].icon_url %}
                     <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
                   {% else %}
-                    <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-snap-list__image" />
+                    <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" class="p-snap-list__image" />
                   {% endif %}
                   <span class="p-snap-list__name">
                     {{snap}}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -100,7 +100,7 @@
                 {% if icon_url %}
                   src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %} snap"
                 {% else %}
-                  src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt=""
+                  src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt=""
                 {% endif %}
               />
             </div>

--- a/templates/store/_category-partial.html
+++ b/templates/store/_category-partial.html
@@ -7,7 +7,7 @@
             {% if snap.icon_url %}
               <img src="{{ snap.icon_url }}" class="p-media-object--snap__img" alt="">
             {% else %}
-              <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-media-object--snap__img" alt="">
+              <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" class="p-media-object--snap__img" alt="">
             {% endif %}
 
             <div class="p-media-object--snap__content">

--- a/templates/store/categories/iot.html
+++ b/templates/store/categories/iot.html
@@ -171,7 +171,7 @@
       </div>
       <div class="col-2">
         <a class="p-media-object--snap" href="/bl-gateway">
-          <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-media-object--snap__img" alt="">
+          <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" class="p-media-object--snap__img" alt="">
           <div class="p-media-object--snap__content">
             <h4 class="p-media-object--snap__title">
               bl-gateway
@@ -186,7 +186,7 @@
       </div>
       <div class="col-2">
         <a class="p-media-object--snap" href="/ixagent">
-          <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" class="p-media-object--snap__img" alt="">
+          <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" class="p-media-object--snap__img" alt="">
           <div class="p-media-object--snap__content">
             <h4 class="p-media-object--snap__title">
               ixagent

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -62,7 +62,7 @@
                 {% if snap.icon_url %}
                   <img src="{{ snap.icon_url }}"  alt="">
                 {% else %}
-                  <img src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg"  alt="">
+                  <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg"  alt="">
                 {% endif %}
                 </a>
                 <div class="p-media-object__details">

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -71,7 +71,7 @@
         {% if icon_url %}
           <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" data-live="icon" />
         {% else %}
-          <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/6fbb3483-snapcraft-default-snap-icon.svg" alt="" data-live="icon" />
+          <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" data-live="icon" />
         {% endif %}
         <div class="p-snap-heading__title">
           <h1 class="p-heading--two p-snap-heading__name" data-live="title">{{ snap_title }}</h1>


### PR DESCRIPTION
Fixes #710

Changes default snap icon into empty circle not to include snapcraft logo.

### QA

- ./run or demo
- go to snap details page of any snap with default icon
- instead of snapcraft logo empty circle should be shown
- find snaps with default icons in search, store page, etc - everywhere default icon should be an empty circle

<img width="1022" alt="screenshot 2019-02-08 at 09 41 51" src="https://user-images.githubusercontent.com/83575/52467423-c955d100-2b85-11e9-8fd2-53b20cf9cab9.png">
