### PR TITLE
Order channels by track/risk/branch

### DIFF
--- a/static/js/libs/channels.js
+++ b/static/js/libs/channels.js
@@ -120,14 +120,14 @@ function createChannelTree(channelList) {
 function sortAlphaNum(list, hoistValue) {
   let numbers = [];
   let strings = [];
-  let latest = [];
+  let hoistList = [];
   list.forEach(item => {
     // numbers are defined by any string starting any of the following patterns:
     //   just a number – 1,2,3,4,
     //   numbers on the left in a pattern – 2018.3 , 1.1, 1.1.23 ...
     //   or numbers on the left with strings at the end – 1.1-hotfix
     if (hoistValue && item === hoistValue) {
-      latest.push(item);
+      hoistList.push(item);
     } else if (isNaN(parseInt(item.substr(0, 1)))) {
       strings.push(item);
     } else {
@@ -137,21 +137,20 @@ function sortAlphaNum(list, hoistValue) {
 
   // Ignore case
   strings.sort(function(a, b) {
-    return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
+    return a.toLowerCase().localeCompare(b.toLowerCase());
   });
 
-  strings = latest.concat(strings);
+  strings = hoistList.concat(strings);
 
   // Sort numbers (that are actually strings)
   numbers.sort((a, b) => {
-    return b[0].localeCompare(a[0], undefined, {
+    return b.localeCompare(a, undefined, {
       numeric: true,
       sensitivity: "base"
     });
   });
 
   // Join the arrays together again
-
   return strings.concat(numbers);
 }
 

--- a/static/js/libs/channels.js
+++ b/static/js/libs/channels.js
@@ -1,0 +1,262 @@
+const RISKS = ["stable", "candidate", "beta", "edge"];
+
+/**
+ * Parse a channel string into an object
+ * @param {string} channelString
+ * @param {{defaultTrack: string}} options
+ * @returns {{format: {risk: boolean, track: boolean, branch: boolean}, risk: *, track: (string|*), branch: (string|*)}}
+ */
+function parseChannel(channelString, options) {
+  const format = {
+    track: false,
+    risk: false,
+    branch: false
+  };
+  const channelArr = ["latest", undefined, "_base"];
+
+  if (options) {
+    if (options.defaultTrack) {
+      channelArr[0] = options.defaultTrack;
+    }
+  }
+
+  const parts = channelString.split("/");
+  if (parts.length === 1) {
+    channelArr[1] = channelString;
+    format.risk = true;
+  } else if (parts.length === 2) {
+    if (RISKS.indexOf(parts[0]) === -1) {
+      channelArr[0] = parts[0];
+      channelArr[1] = parts[1];
+      format.track = true;
+      format.risk = true;
+    } else {
+      channelArr[1] = parts[0];
+      channelArr[2] = parts[1];
+      format.risk = true;
+      format.branch = true;
+    }
+  } else if (parts.length === 3) {
+    channelArr[0] = parts[0];
+    channelArr[1] = parts[1];
+    channelArr[2] = parts[2];
+    format.track = true;
+    format.risk = true;
+    format.branch = true;
+  }
+
+  return {
+    track: channelArr[0],
+    risk: channelArr[1],
+    branch: channelArr[2],
+    format: format
+  };
+}
+
+/**
+ * Create a tree from a list of channels
+ * @param {[{track: string, risk: string, branch: string, format: {track: boolean, branch: boolean, format: boolean}}]} channelList
+ * @returns {{
+ *    track: {
+ *      name: string,
+ *      risks: {
+ *        risk: {
+ *          name: string,
+ *          branches: {
+ *            branch: {
+ *              name: string
+ *            }
+ *          }
+ *        }
+ *      }
+ *    }
+ *  }}
+ */
+function createChannelTree(channelList) {
+  const tracks = {};
+
+  channelList.forEach(channel => {
+    if (!tracks[channel.track]) {
+      tracks[channel.track] = {
+        name: channel.track,
+        risks: {}
+      };
+    }
+
+    let level = tracks[channel.track];
+
+    if (!level.risks[channel.risk]) {
+      level.risks[channel.risk] = {
+        name: channel.risk
+      };
+    }
+
+    level = level.risks[channel.risk];
+
+    if (!level.branches) {
+      level.branches = {};
+    }
+
+    level.branches[channel.branch] = {
+      name: channel.branch
+    };
+  });
+
+  return tracks;
+}
+
+/**
+ * Sort a list of strings
+ * The output order will be:
+ *  - hoistValue
+ *  - strings
+ *    - ascending
+ *  - numbers
+ *    - descending
+ * @param {[string]} list
+ * @param {string} hoistValue A value to always appear at the top
+ * @returns {*[]}
+ */
+function sortAlphaNum(list, hoistValue) {
+  let numbers = [];
+  let strings = [];
+  let latest = [];
+  list.forEach(item => {
+    // numbers are defined by any string starting any of the following patterns:
+    //   just a number – 1,2,3,4,
+    //   numbers on the left in a pattern – 2018.3 , 1.1, 1.1.23 ...
+    //   or numbers on the left with strings at the end – 1.1-hotfix
+    if (hoistValue && item === hoistValue) {
+      latest.push(item);
+    } else if (isNaN(parseInt(item.substr(0, 1)))) {
+      strings.push(item);
+    } else {
+      numbers.push(item);
+    }
+  });
+
+  // Ignore case
+  strings.sort(function(a, b) {
+    return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
+  });
+
+  strings = latest.concat(strings);
+
+  // Sort numbers (that are actually strings)
+  numbers.sort((a, b) => {
+    return b[0].localeCompare(a[0], undefined, {
+      numeric: true,
+      sensitivity: "base"
+    });
+  });
+
+  // Join the arrays together again
+
+  return strings.concat(numbers);
+}
+
+/**
+ * Sort channels into the following format:
+ * defaultTrack/stable
+ * defaultTrack/stable/branches
+ * defaultTrack/candidate
+ * defaultTrack/candidate/branches
+ * defaultTrack/beta
+ * defaultTrack/beta/branches
+ * defaultTrack/edge
+ * defaultTrack/edge/branches
+ * track/stable
+ * track/stable/branches
+ * ...
+ *
+ * @param {[string]} channels An array of "risk" / "track/risk" / "track/risk/branch"
+ * @param {{defaultTrack: string}} options
+ * @returns {{tree: Array, list: Array}}
+ */
+function sortChannels(channels, options) {
+  const channelList = channels.map(channel => parseChannel(channel, options));
+  const channelTree = createChannelTree(channelList);
+
+  const sortedByTrack = [];
+
+  let track = "latest";
+  if (options && options.defaultTrack) {
+    track = options.defaultTrack;
+  }
+
+  const trackOrder = sortAlphaNum(Object.keys(channelTree), track);
+
+  trackOrder.forEach(track => {
+    sortedByTrack.push(channelTree[track]);
+  });
+
+  sortedByTrack.map(track => {
+    const riskOrder = Object.keys(track.risks).sort((a, b) => {
+      return RISKS.indexOf(a) - RISKS.indexOf(b);
+    });
+
+    track.risks = riskOrder.map(risk => track.risks[risk]);
+
+    track.risks.map(risk => {
+      const branchOrder = sortAlphaNum(Object.keys(risk.branches), "_base");
+
+      risk.branches = branchOrder.map(branch => risk.branches[branch]);
+
+      return risk;
+    });
+
+    return track;
+  });
+
+  const toArray = () => {
+    const list = [];
+    sortedByTrack.forEach(track => {
+      if (track.risks) {
+        track.risks.forEach(risk => {
+          if (risk.branches.length > 1 || risk.branches[0].name !== "_base") {
+            risk.branches.forEach(branch => {
+              const format = channelList.filter(
+                item =>
+                  item.track === track.name &&
+                  item.risk === risk.name &&
+                  item.branch === branch.name
+              )[0].format;
+              const str = [];
+              if (format.track) {
+                str.push(track.name);
+              }
+              if (format.risk) {
+                str.push(risk.name);
+              }
+              if (format.branch) {
+                str.push(branch.name);
+              }
+              list.push(str.join("/"));
+            });
+          } else {
+            const format = channelList.filter(item => {
+              return item.track === track.name && item.risk === risk.name;
+            })[0].format;
+            const str = [];
+            if (format.track) {
+              str.push(track.name);
+            }
+            if (format.risk) {
+              str.push(risk.name);
+            }
+            list.push(str.join("/"));
+          }
+        });
+      }
+    });
+
+    return list;
+  };
+
+  return {
+    tree: sortedByTrack,
+    list: toArray()
+  };
+}
+
+export { sortChannels, parseChannel, createChannelTree, sortAlphaNum };

--- a/static/js/libs/channels.test.js
+++ b/static/js/libs/channels.test.js
@@ -251,7 +251,8 @@ describe("createChannelTree", () => {
 
 describe("sortAlphaNum", () => {
   it("sorts numbers", () => {
-    expect(sortAlphaNum(["0", "5", "2", "6", "7", "1", "8"])).toEqual([
+    expect(sortAlphaNum(["0", "5", "2", "11", "6", "7", "1", "8"])).toEqual([
+      "11",
       "8",
       "7",
       "6",
@@ -280,30 +281,25 @@ describe("sortAlphaNum", () => {
   });
 
   it("sorts a mixture of numbers, semver and text", () => {
-    expect(sortAlphaNum(["0.0.1", "5", "zzz", "latest"])).toEqual([
+    expect(sortAlphaNum(["0.0.1", "5", "zzz", "11", "latest"])).toEqual([
       "latest",
       "zzz",
+      "11",
       "5",
       "0.0.1"
     ]);
   });
 
   it("puts latest first if isTrack and no defaultTrack", () => {
-    expect(sortAlphaNum(["0.0.1", "5", "test", "latest"], "latest")).toEqual([
-      "latest",
-      "test",
-      "5",
-      "0.0.1"
-    ]);
+    expect(
+      sortAlphaNum(["0.0.1", "5", "test", "11", "latest"], "latest")
+    ).toEqual(["latest", "test", "11", "5", "0.0.1"]);
   });
 
   it("puts defaultTrack first if isTrack and defaultTrack set", () => {
-    expect(sortAlphaNum(["0.0.1", "5", "test", "latest"], "test")).toEqual([
-      "test",
-      "latest",
-      "5",
-      "0.0.1"
-    ]);
+    expect(
+      sortAlphaNum(["0.0.1", "5", "test", "11", "latest"], "test")
+    ).toEqual(["test", "latest", "11", "5", "0.0.1"]);
   });
 });
 

--- a/static/js/libs/channels.test.js
+++ b/static/js/libs/channels.test.js
@@ -1,0 +1,533 @@
+import {
+  sortChannels,
+  parseChannel,
+  createChannelTree,
+  sortAlphaNum
+} from "./channels";
+
+describe("parseChannel", () => {
+  describe("risk", () => {
+    it("should return as 'latest' track", () => {
+      expect(parseChannel("stable")).toEqual({
+        track: "latest",
+        risk: "stable",
+        branch: "_base",
+        format: {
+          track: false,
+          risk: true,
+          branch: false
+        }
+      });
+    });
+  });
+
+  describe("track/risk", () => {
+    it("should return with track", () => {
+      expect(parseChannel("test/stable")).toEqual({
+        track: "test",
+        risk: "stable",
+        branch: "_base",
+        format: {
+          track: true,
+          risk: true,
+          branch: false
+        }
+      });
+    });
+  });
+
+  describe("risk/branch", () => {
+    it("should return with branch and 'latest' track", () => {
+      expect(parseChannel("stable/test")).toEqual({
+        track: "latest",
+        risk: "stable",
+        branch: "test",
+        format: {
+          track: false,
+          risk: true,
+          branch: true
+        }
+      });
+    });
+  });
+
+  describe("options", () => {
+    describe("defaultTrack", () => {
+      it("should add the default track for risk only string", () => {
+        expect(parseChannel("stable", { defaultTrack: "test" })).toEqual({
+          track: "test",
+          risk: "stable",
+          branch: "_base",
+          format: {
+            track: false,
+            risk: true,
+            branch: false
+          }
+        });
+      });
+    });
+  });
+});
+
+describe("createChannelTree", () => {
+  let channelList;
+  describe("risk only", () => {
+    beforeEach(() => {
+      channelList = ["stable", "beta", "candidate", "edge"].map(channel =>
+        parseChannel(channel)
+      );
+    });
+
+    it("should return the risks within 'latest'", () => {
+      expect(createChannelTree(channelList)).toEqual({
+        latest: {
+          name: "latest",
+          risks: {
+            stable: {
+              name: "stable",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            },
+            beta: {
+              name: "beta",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            },
+            candidate: {
+              name: "candidate",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            },
+            edge: {
+              name: "edge",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+
+  describe("track/risk", () => {
+    beforeEach(() => {
+      channelList = ["stable", "latest/edge", "test/candidate"].map(channel =>
+        parseChannel(channel)
+      );
+    });
+    it("should return 'latest' and others", () => {
+      expect(createChannelTree(channelList)).toEqual({
+        latest: {
+          name: "latest",
+          risks: {
+            stable: {
+              name: "stable",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            },
+            edge: {
+              name: "edge",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            }
+          }
+        },
+        test: {
+          name: "test",
+          risks: {
+            candidate: {
+              name: "candidate",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+
+  describe("risk/branch", () => {
+    beforeEach(() => {
+      channelList = ["stable", "beta/test", "edge/1.0.1", "edge/hotfix"].map(
+        channel => parseChannel(channel)
+      );
+    });
+
+    it("should return latest tracks with different branches on the tracks", () => {
+      expect(createChannelTree(channelList)).toEqual({
+        latest: {
+          name: "latest",
+          risks: {
+            stable: {
+              name: "stable",
+              branches: {
+                _base: {
+                  name: "_base"
+                }
+              }
+            },
+            beta: {
+              name: "beta",
+              branches: {
+                test: {
+                  name: "test"
+                }
+              }
+            },
+            edge: {
+              name: "edge",
+              branches: {
+                hotfix: {
+                  name: "hotfix"
+                },
+                "1.0.1": {
+                  name: "1.0.1"
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+  describe("mix of risk/branch and risk only", () => {
+    beforeEach(() => {
+      channelList = [
+        "stable",
+        "stable/test",
+        "stable/1.0.1",
+        "stable/hotfix"
+      ].map(channel => parseChannel(channel));
+    });
+    it("should return no branch risk, above all branches", () => {
+      expect(createChannelTree(channelList)).toEqual({
+        latest: {
+          name: "latest",
+          risks: {
+            stable: {
+              name: "stable",
+              branches: {
+                _base: {
+                  name: "_base"
+                },
+                test: {
+                  name: "test"
+                },
+                "1.0.1": {
+                  name: "1.0.1"
+                },
+                hotfix: {
+                  name: "hotfix"
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+});
+
+describe("sortAlphaNum", () => {
+  it("sorts numbers", () => {
+    expect(sortAlphaNum(["0", "5", "2", "6", "7", "1", "8"])).toEqual([
+      "8",
+      "7",
+      "6",
+      "5",
+      "2",
+      "1",
+      "0"
+    ]);
+  });
+
+  it("sorts semver", () => {
+    expect(sortAlphaNum(["0.0.1", "1.0.1", "2.0.2"])).toEqual([
+      "2.0.2",
+      "1.0.1",
+      "0.0.1"
+    ]);
+  });
+
+  it("sorts text", () => {
+    expect(sortAlphaNum(["aaa", "zzzzz", "cccc", "test"])).toEqual([
+      "aaa",
+      "cccc",
+      "test",
+      "zzzzz"
+    ]);
+  });
+
+  it("sorts a mixture of numbers, semver and text", () => {
+    expect(sortAlphaNum(["0.0.1", "5", "zzz", "latest"])).toEqual([
+      "latest",
+      "zzz",
+      "5",
+      "0.0.1"
+    ]);
+  });
+
+  it("puts latest first if isTrack and no defaultTrack", () => {
+    expect(sortAlphaNum(["0.0.1", "5", "test", "latest"], "latest")).toEqual([
+      "latest",
+      "test",
+      "5",
+      "0.0.1"
+    ]);
+  });
+
+  it("puts defaultTrack first if isTrack and defaultTrack set", () => {
+    expect(sortAlphaNum(["0.0.1", "5", "test", "latest"], "test")).toEqual([
+      "test",
+      "latest",
+      "5",
+      "0.0.1"
+    ]);
+  });
+});
+
+describe("sortChannels", () => {
+  describe("tracks", () => {
+    it("should return in the track order, with latest first", () => {
+      expect(
+        sortChannels(["zzz/edge", "stable", "1/beta", "5.9.0/candidate"]).tree
+      ).toEqual([
+        {
+          name: "latest",
+          risks: [
+            {
+              name: "stable",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: "zzz",
+          risks: [
+            {
+              name: "edge",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: "5.9.0",
+          risks: [
+            {
+              name: "candidate",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: "1",
+          risks: [
+            {
+              name: "beta",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+    });
+  });
+
+  describe("track/risk", () => {
+    it("should return with 'latest' track first, with risks in order of stability", () => {
+      expect(
+        sortChannels(["zzz/edge", "stable", "1/beta", "1/candidate"]).tree
+      ).toEqual([
+        {
+          name: "latest",
+          risks: [
+            {
+              name: "stable",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: "zzz",
+          risks: [
+            {
+              name: "edge",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: "1",
+          risks: [
+            {
+              name: "candidate",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            },
+            {
+              name: "beta",
+              branches: [
+                {
+                  name: "_base"
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+    });
+  });
+
+  describe("track/risk/branch", () => {
+    describe("'latest' track first, with risks in order of stability, then branches in order", () => {
+      it("should return as a tree", () => {
+        expect(
+          sortChannels([
+            "zzz/edge",
+            "stable",
+            "1/beta/1.0.1",
+            "1/beta/hotfix",
+            "1/candidate"
+          ]).tree
+        ).toEqual([
+          {
+            name: "latest",
+            risks: [
+              {
+                name: "stable",
+                branches: [
+                  {
+                    name: "_base"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            name: "zzz",
+            risks: [
+              {
+                name: "edge",
+                branches: [
+                  {
+                    name: "_base"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            name: "1",
+            risks: [
+              {
+                name: "candidate",
+                branches: [
+                  {
+                    name: "_base"
+                  }
+                ]
+              },
+              {
+                name: "beta",
+                branches: [
+                  {
+                    name: "hotfix"
+                  },
+                  {
+                    name: "1.0.1"
+                  }
+                ]
+              }
+            ]
+          }
+        ]);
+      });
+      it("should return as a list", () => {
+        expect(
+          sortChannels([
+            "zzz/edge",
+            "stable",
+            "1/beta/1.0.1",
+            "1/beta/hotfix",
+            "1/candidate"
+          ]).list
+        ).toEqual([
+          "stable",
+          "zzz/edge",
+          "1/candidate",
+          "1/beta/hotfix",
+          "1/beta/1.0.1"
+        ]);
+      });
+    });
+  });
+
+  describe("options", () => {
+    describe("defaultTrack", () => {
+      it("should return with default track as latest", () => {
+        expect(
+          sortChannels(["latest/stable", "test/stable"], {
+            defaultTrack: "test"
+          }).list
+        ).toEqual(["test/stable", "latest/stable"]);
+      });
+    });
+
+    describe("maintainFormat", () => {
+      it("should maintain the format", () => {
+        expect(
+          sortChannels(["test/stable", "stable"], {
+            maintainFormat: true
+          }).list
+        ).toEqual(["stable", "test/stable"]);
+      });
+    });
+  });
+});

--- a/static/js/publisher/metrics/metrics.js
+++ b/static/js/publisher/metrics/metrics.js
@@ -22,7 +22,12 @@ function renderMetrics(metrics) {
     });
   });
 
-  activeDevicesMetrics(metrics.activeDevices.selector, activeDevices);
+  activeDevicesMetrics(
+    metrics.activeDevices.selector,
+    activeDevices,
+    metrics.activeDevices.type,
+    metrics.defaultTrack
+  );
 
   // Territories
   territoriesMetrics(metrics.territories.selector, metrics.territories.metrics);

--- a/static/sass/_snapcraft_metrics.scss
+++ b/static/sass/_snapcraft_metrics.scss
@@ -6,6 +6,7 @@
 
     .p-tooltip {
       position: absolute;
+      z-index: 100;
 
       .p-tooltip__message {
         display: block;

--- a/templates/publisher/metrics.html
+++ b/templates/publisher/metrics.html
@@ -85,6 +85,7 @@ Publisher metrics for {{ snap_title }}
       snapcraft.publisher.selector('.metrics-period', 'period');
       snapcraft.publisher.selector('.active-devices', 'active-devices');
       snapcraft.publisher.metrics({
+        defaultTrack: {{ default_track|tojson }},
         activeDevices: {
           selector: '#activeDevices',
           metrics: {{ active_devices|safe }},

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -29,3 +29,11 @@ def get_licenses():
         licenses = []
 
     return licenses
+
+
+def get_default_track(snap_name):
+    # until default tracks are supported by the API we special case node
+    # to use 10, rather then latest
+    default_track = "10" if snap_name == "node" else "latest"
+
+    return default_track

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -3,6 +3,7 @@ from json import loads
 import flask
 
 import pycountry
+import webapp.helpers as helpers
 import webapp.api.dashboard as api
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
@@ -189,12 +190,17 @@ def publisher_snap_metrics(snap_name):
 
     nodata = not any([country_devices, active_devices])
 
+    # until default tracks are supported by the API we special case node
+    # to use 10, rather then latest
+    default_track = helpers.get_default_track(snap_name)
+
     context = {
         # Data direct from details API
         "snap_name": snap_name,
         "snap_title": details["title"],
         "metric_period": metric_requested["period"],
         "active_device_metric": installed_base_metric,
+        "default_track": default_track,
         "private": details["private"],
         # Metrics data
         "nodata": nodata,

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -5,6 +5,7 @@ import flask
 
 import bleach
 import humanize
+import webapp.helpers as helpers
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
 import webapp.store.logic as logic
@@ -362,7 +363,7 @@ def store_blueprint(store_query=None, testing=False):
 
         # until default tracks are supported by the API we special case node
         # to use 10, rather then latest
-        default_track = "10" if details["name"] == "node" else "latest"
+        default_track = helpers.get_default_track(details["name"])
 
         lowest_risk_available = logic.get_lowest_available_risk(
             channel_maps_list, default_track


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1475

It also updates a few things.
- Added a channels module for sorting arbitrary channel strings (will update the channel map to use this at some point).
- Added "defaultTrack" to metrics page (currently hardcoded for [node](https://snapcraft.io/node)
- Moved the hardcoded logic for node to the helpers module.
- Made the tooltip appear above the site navigation

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/metrics?active-devices=channel
- Hover over the graph and move about - the order of channels should only change if there's no data for that channel on that day.