### PR TITLE
Fix linter with latest version on flake8

### DIFF
--- a/webapp/blog/logic.py
+++ b/webapp/blog/logic.py
@@ -27,23 +27,23 @@ def replace_images_with_cloudinary(content):
     cloudinary = "https://res.cloudinary.com/"
 
     urls = [
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_350/\g<url>",
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_650/\g<url>",
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1300/\g<url>",
-        cloudinary + "canonical/image/fetch/q_auto,f_auto,w_1950/\g<url>",
+        cloudinary + r"canonical/image/fetch/q_auto,f_auto,w_350/\g<url>",
+        cloudinary + r"canonical/image/fetch/q_auto,f_auto,w_650/\g<url>",
+        cloudinary + r"canonical/image/fetch/q_auto,f_auto,w_1300/\g<url>",
+        cloudinary + r"canonical/image/fetch/q_auto,f_auto,w_1950/\g<url>",
     ]
 
     image_match = (
         r'<img(?P<prefix>[^>]*) src="(?P<url>[^"]+)"(?P<suffix>[^>]*)>'
     )
     replacement = (
-        "<img\g<prefix>"
+        r"<img\g<prefix>"
         f' decoding="async"'
         f' src="{urls[1]}"'
         f' srcset="{urls[0]} 350w, {urls[1]} 650w, {urls[2]} 1300w,'
         f' {urls[3]} 1950w"'
         f' sizes="(max-width: 400px) 350w, 650px"'
-        "\g<suffix>>"
+        r"\g<suffix>>"
     )
 
     return re.sub(image_match, replacement, content)
@@ -108,7 +108,7 @@ def change_url(feed, host):
     :returns: A string with converted urls
     """
     url_regex = re.compile(
-        "https:\/\/admin.insights.ubuntu.com(\/\d{4}\/\d{2}\/\d{2})?"
+        r"https:\/\/admin.insights.ubuntu.com(\/\d{4}\/\d{2}\/\d{2})?"
     )
     updated_feed = re.sub(url_regex, host, feed)
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -74,7 +74,7 @@ def store_blueprint(store_query=None, testing=False):
             featured_snaps_results = api.get_searched_snaps(
                 snap_searched="", category="featured", size=24, page=1
             )
-        except ApiError as api_error:
+        except ApiError:
             featured_snaps_results = []
 
         featured_snaps = logic.get_searched_snaps(featured_snaps_results)


### PR DESCRIPTION
# Summary 

Since the upgrade of `pycodestyle` to version 2.5.0 flake8 linter has become more strict on certain invalid characters for example: `\g`

> \g is in fact an invalid escape sequence.  In python3.8+ it will be a syntax error (you can enable it earlier by escalating warnings to errors)

Source: https://gitlab.com/pycqa/flake8/issues/474

# QA

- Make sure when accessing blog images are still pulled from cloudinary
- Make sure that on /blog/feed the links are snapcraft link (localhost on local machine)
- Make sure linter passes

love