### PR TITLE
Sort categories for listing page

### DIFF
--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -269,7 +269,10 @@ def get_listing_snap(snap_name):
     except ApiError:
         categories_results = []
 
-    categories = get_categories(categories_results)
+    categories = sorted(
+        get_categories(categories_results),
+        key=lambda category: category["slug"],
+    )
 
     snap_categories = logic.replace_reserved_categories_key(
         snap_details["categories"]


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1528

## QA
- Pull branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/listing
- The dropdown of categories should be sorted alphabetically