### PR TITLE
Correct a typo: the snapcraft.yaml is in the project root

### DIFF
--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -28,7 +28,6 @@
               <span class="p-list-step__bullet">2</span>
               Open the snapcraft.yaml file in the root of the project
             </h4>
-            <p class="p-list-step__content">Create a snap/directory and begin a snapcraft.yaml file</p>
             {% set snippet_value = steps.createDir %}
             {% set snippet_id = "createdir" %}
             {% include "/partials/_code-snippet-multi.html" %}


### PR DESCRIPTION
We've moved the snapcraft.yaml files to the root of the repos. This message was never right, anyway. You don't begin a snapcraft.yaml, you open the existing one.