### PR TITLE
Ignore GA script if dataLayer is undefined

### DIFF
--- a/static/js/base/ga.js
+++ b/static/js/base/ga.js
@@ -32,7 +32,7 @@ function triggerEvent(category, from, to, label) {
   }
 }
 
-if (dataLayer) {
+if (typeof dataLayer !== "undefined") {
   window.addEventListener("click", function(e) {
     let target = e.target;
     if (!target || !e.target.closest) {


### PR DESCRIPTION
If `base.js` is included on a page that doesn't include GA script it fails with an error that `dataLayer` is undefined.

This PR fixes that making sure `dataLayer` is ignored if not defined.