### PR TITLE
Basic snap embedded card endpoint

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -1,0 +1,23 @@
+// colour definitions
+$color-brand: #00302f;
+$color-accent: $color-brand;
+$color-navigation-background: #252525;
+
+// vanilla patterns
+@import 'vanilla-framework/scss/vanilla';
+
+@include vf-base;;
+
+@include vf-p-grid;
+@include vf-p-grid-modifications;
+@include vf-p-strip;
+
+// make max-width of the layout smaller for embedded view
+.row {
+  max-width: 40rem;
+}
+
+html,
+body {
+  background: $color-x-light; // This will be fix on vanilla https://github.com/vanilla-framework/vanilla-framework/issues/2129
+}

--- a/templates/_layout-embedded.html
+++ b/templates/_layout-embedded.html
@@ -1,0 +1,71 @@
+<!doctype html>
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
+
+    <title>{% block meta_title %}Snapcraft - Snaps are universal Linux packages{% endblock %}</title>
+
+    {% block meta %}
+      <meta property="og:title" content="{{ self.meta_title() }}"/>
+      <meta property="og:site_name" content="Snapcraft"/>
+      <meta property="og:type" content="{% block meta_type %}website{% endblock %}"/>
+      <meta property="og:description" content="{{ self.meta_description() }}"/>
+      <meta property="og:image" content="{% block meta_image %}https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png{% endblock %}" />
+      <meta property="og:url" content="https://snapcraft.io{% block meta_path %}{{ path }}{% endblock %}" />
+      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:site" content="@snapcraftio" />
+      <meta property="twitter:creator" content="@snapcraftio" />
+      <meta property="twitter:url" content="https://snapcraft.io{{ self.meta_path() }}" />
+    {% endblock %}
+
+    {% block extra_meta %}{% endblock %}
+
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
+
+    {# TODO: custom embedded stylesheet #}
+    <link rel="stylesheet" href="{{ static_url('css/styles-embedded.css') }}" />
+  </head>
+
+  <body>
+    {% block content %}{% endblock %}
+
+    {% block scripts_modules %}{% endblock %}
+    {% block scripts %}{% endblock %}
+
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org/",
+        "@id": "https://snapcraft.io/#organization",
+        "@type": "Organization",
+        "name": "Snapcraft",
+        "logo": "https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
+        "url": "https://snapcraft.io",
+        "sameAs": [
+          "https://developer.ubuntu.com/snapcraft",
+          "https://github.com/snapcore/snapcraft",
+          "https://en.wikipedia.org/wiki/Snappy_(package_manager)",
+          "https://twitter.com/snapcraftio",
+          "https://www.facebook.com/snapcraftio/",
+          "https://www.youtube.com/snapcraftio"
+        ]
+      }
+    </script>
+
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@id": "https://snapcraft.io/#website",
+        "@type": "WebPage",
+        "name": "Snapcraft",
+        "url": "https://snapcraft.io{{ self.meta_path() }}"
+      }
+    </script>
+
+    {% block meta_schema %}{% endblock %}
+  </body>
+</html>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -1,0 +1,9 @@
+{% extends "_layout-embedded.html" %}
+
+{% block content %}
+<div class="p-strip--light is-shallow">
+  <div class="row">
+    <h1>{{ snap_title }}</h1>
+  </div>
+</div>
+{% endblock content %}

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -3,7 +3,7 @@ from flask_testing import TestCase
 from webapp.app import create_app
 
 
-class GetDetailsPageTest(TestCase):
+class GetEmbeddedCardTest(TestCase):
     render_templates = False
 
     def setUp(self):
@@ -18,7 +18,7 @@ class GetDetailsPageTest(TestCase):
                 "confinement,categories",
             ]
         )
-        self.endpoint_url = "/" + self.snap_name
+        self.endpoint_url = "/" + self.snap_name + "/embedded"
 
     def create_app(self):
         app = create_app(testing=True)
@@ -107,7 +107,7 @@ class GetDetailsPageTest(TestCase):
         assert response.status_code == 404
 
     @responses.activate
-    def test_user_connected(self):
+    def test_get_card(self):
         payload = {
             "snap-id": "id",
             "name": "snapName",
@@ -147,126 +147,7 @@ class GetDetailsPageTest(TestCase):
             )
         )
 
-        metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        responses.add(
-            responses.Response(
-                method="POST", url=metrics_url, json={}, status=200
-            )
-        )
-
-        with self.client.session_transaction() as s:
-            s["openid"] = {"nickname": "toto"}
-
         response = self.client.get(self.endpoint_url)
 
         assert response.status_code == 200
-        self.assert_context("is_users_snap", True)
-
-    @responses.activate
-    def test_user_not_connected(self):
-        payload = {
-            "snap-id": "id",
-            "name": "snapName",
-            "snap": {
-                "title": "Snap Title",
-                "summary": "This is a summary",
-                "description": "this is a description",
-                "media": [],
-                "license": "license",
-                "prices": 0,
-                "publisher": {
-                    "display-name": "Toto",
-                    "username": "toto",
-                    "validation": True,
-                },
-                "categories": [{"name": "test"}],
-            },
-            "channel-map": [
-                {
-                    "channel": {
-                        "architecture": "amd64",
-                        "name": "stable",
-                        "risk": "stable",
-                        "track": "latest",
-                    },
-                    "created-at": "2018-09-18T14:45:28.064633+00:00",
-                    "version": "1.0",
-                    "confinement": "conf",
-                    "download": {"size": 100000},
-                }
-            ],
-        }
-
-        responses.add(
-            responses.Response(
-                method="GET", url=self.api_url, json=payload, status=200
-            )
-        )
-
-        metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        responses.add(
-            responses.Response(
-                method="POST", url=metrics_url, json={}, status=200
-            )
-        )
-
-        response = self.client.get(self.endpoint_url)
-
-        assert response.status_code == 200
-        self.assert_context("is_users_snap", False)
-
-    @responses.activate
-    def test_user_connected_on_not_own_snap(self):
-        payload = {
-            "snap-id": "id",
-            "name": "snapName",
-            "snap": {
-                "title": "Snap Title",
-                "summary": "This is a summary",
-                "description": "this is a description",
-                "media": [],
-                "license": "license",
-                "prices": 0,
-                "publisher": {
-                    "display-name": "Toto",
-                    "username": "toto",
-                    "validation": True,
-                },
-                "categories": [{"name": "test"}],
-            },
-            "channel-map": [
-                {
-                    "channel": {
-                        "architecture": "amd64",
-                        "name": "stable",
-                        "risk": "stable",
-                        "track": "latest",
-                    },
-                    "created-at": "2018-09-18T14:45:28.064633+00:00",
-                    "version": "1.0",
-                    "confinement": "conf",
-                    "download": {"size": 100000},
-                }
-            ],
-        }
-
-        responses.add(
-            responses.Response(
-                method="GET", url=self.api_url, json=payload, status=200
-            )
-        )
-
-        metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        responses.add(
-            responses.Response(
-                method="POST", url=metrics_url, json={}, status=200
-            )
-        )
-
-        with self.client.session_transaction() as s:
-            s["openid"] = {"nickname": "greg"}
-
-        response = self.client.get(self.endpoint_url)
-
-        assert response.status_code == 200
-        self.assert_context("is_users_snap", False)
+        self.assert_context("snap_title", "Snap Title")


### PR DESCRIPTION
Fixes #1599 

Adds new endpoint (`/[snap-name]/embedded`) that shows embeddable card with snap details.
Currently only displays snap name for test.

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1613.run.demo.haus/
- go to /[snap-name]/embedded (https://snapcraft-io-canonical-websites-pr-1613.run.demo.haus/toto/embedded)
- basic template should appear with snap name
- it should 404 normally for non existent or private snaps
