### PR TITLE
Add simple snap embedded card template

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -10,7 +10,19 @@ $color-navigation-background: #252525;
 
 @include vf-p-grid;
 @include vf-p-grid-modifications;
+@include vf-p-headings;
+@include vf-p-lists;
 @include vf-p-strip;
+@include vf-p-tooltips;
+
+@include vf-u-align;
+@include vf-u-margin-collapse;
+
+@import 'snapcraft_banner';
+@include snapcraft-banner;
+
+@import 'snapcraft_details_heading';
+@include snapcraft-details-heading;
 
 // make max-width of the layout smaller for embedded view
 .row {

--- a/templates/_layout-embedded.html
+++ b/templates/_layout-embedded.html
@@ -27,8 +27,8 @@
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/fdc99abe-ico_16px.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/0f3c662c-ico_32px.png" sizes="32x32" />
 
-    {# TODO: custom embedded stylesheet #}
     <link rel="stylesheet" href="{{ static_url('css/styles-embedded.css') }}" />
+    <base target="_blank">
   </head>
 
   <body>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -1,9 +1,42 @@
 {% extends "_layout-embedded.html" %}
 
 {% block content %}
-<div class="p-strip--light is-shallow">
+<div class="p-strip--light is-shallow snapcraft-banner-background">
   <div class="row">
-    <h1>{{ snap_title }}</h1>
+    <div class="p-snap-heading">
+      {% if icon_url %}
+        <img class="p-snap-heading__icon" src="{{ icon_url }}" alt="{{ snap_title }} snap" data-live="icon" />
+      {% else %}
+        <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" data-live="icon" />
+      {% endif %}
+      <div class="p-snap-heading__title">
+        <h1 class="p-heading--two p-snap-heading__name" data-live="title">{{ snap_title }}</h1>
+        <ul class="p-inline-list--middot u-no-margin--bottom">
+          <li class="p-inline-list__item">
+            by {{ display_name(publisher, username) }}
+            {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
+            <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
+              <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
+              <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
+            </span>
+            {% endif %}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-shallow">
+  <div class="row">
+    <p>
+      <a href="https://snapcraft.io/{{ package_name }}">
+        <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" />
+      </a>
+    </p>
+    <hr/>
+    <p>{{ default_track }}/{{ lowest_risk_available }} {{ version }}</p>
+    <p><small>Published {{ last_updated }}</small></p>
   </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
Fixes #1600 

Adds more data to basic embedded card template.
Not it should contain icon, store button, latest release info.

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1618.run.demo.haus/
- go to `/[snap-name]/embedded` of any public snap (https://snapcraft-io-canonical-websites-pr-1618.run.demo.haus/vlc/embedded)
- simple embedded card content should appear for given snap

<img width="554" alt="screenshot 2019-02-19 at 12 58 41" src="https://user-images.githubusercontent.com/83575/53013441-1bc8a480-3446-11e9-869e-0d78d5e3b770.png">
