### PR TITLE
Ensure categories wrap on mobile

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -45,6 +45,7 @@ $color-navigation-background: #252525;
 @include vf-u-image-position;
 @include vf-u-equal-height;
 @include vf-u-hide;
+@include vf-u-show;
 
 @import 'patterns_fluid-grid';
 @include p-fluid-grid;

--- a/templates/store/_snap-header-information.html
+++ b/templates/store/_snap-header-information.html
@@ -1,0 +1,7 @@
+by {{ display_name(publisher, username) }}
+{% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
+<span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
+  <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
+  <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
+</span>
+{% endif %}

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -75,15 +75,12 @@
         {% endif %}
         <div class="p-snap-heading__title">
           <h1 class="p-heading--two p-snap-heading__name" data-live="title">{{ snap_title }}</h1>
+          <div class="u-hide u-show--small">
+            {% include 'store/_snap-header-information.html' %}
+          </div>
           <ul class="p-inline-list--middot">
-            <li class="p-inline-list__item">
-              by {{ display_name(publisher, username) }}
-              {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
-              <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
-                <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />
-                <span class="p-tooltip__message u-align--center" role="tooltip" id="{{ package_name }}-tooltip">Verified account</span>
-              </span>
-              {% endif %}
+            <li class="p-inline-list__item u-hide--small">
+              {% include 'store/_snap-header-information.html' %}
             </li>
             {% for category in categories %}<li class="p-inline-list__item">
               <a href="/search?category={{category.slug}}">{{ category.name }}</a>


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/905

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/senor-limon or https://snapcraft-io-canonical-websites-pr-1620.run.demo.haus/senor-limon
- Resize the browser and ensure the categories don't wrap