### PR TITLE
s/Privacy/Visibility on publisher pages

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -114,7 +114,7 @@ My published snaps — Linux software in the Snap Store
         <thead>
           <tr>
             <th width="30%">Name</th>
-            <th width="10%">Privacy</th>
+            <th width="10%">Visibility</th>
             <th width="20%">Owner</th>
             <th width="20%">Latest release</th>
             <th width="10%">Version</th>

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -82,7 +82,7 @@
         <div class="row">
           <div class="col-2">
             <label>
-              Privacy:
+              Visibility:
             </label>
           </div>
           <div class="col-8">


### PR DESCRIPTION
# Summary

`s/Privacy/Visibility`

# QA

- `./run`
- Settings page should display Visibility instead of privacy
- List of snaps should display Visibility  instead of privacy