### PR TITLE
Embedded snap store button settings

### DIFF
--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -1,4 +1,4 @@
-function publicise() {
+function initSnapButtonsPicker() {
   const languagePicker = document.querySelector(".js-language-select");
 
   function showLanguage(language) {
@@ -33,4 +33,4 @@ function publicise() {
   }
 }
 
-export { publicise };
+export { initSnapButtonsPicker };

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -1,3 +1,5 @@
+// SNAP STORE BUTTONS
+
 function initSnapButtonsPicker() {
   const languagePicker = document.querySelector(".js-language-select");
 
@@ -33,4 +35,36 @@ function initSnapButtonsPicker() {
   }
 }
 
-export { initSnapButtonsPicker };
+// EMBEDDABLE CARDS
+
+const getCardPath = (snapName, button) => {
+  return `/${snapName}/embedded?button=${button}`;
+};
+
+const getCardEmbedHTML = (snapName, button) => {
+  return `&lt;iframe src="https://snapcraft.io${getCardPath(
+    snapName,
+    button
+  )}" frameborder="0" width="100%" height="320px" style="border: 1px solid" &gt;&lt;/iframe&gt;`;
+};
+
+function initEmbeddedCardPicker(options) {
+  const { snapName, previewFrame, codeElement } = options;
+  const buttonRadios = [].slice.call(options.buttonRadios);
+
+  buttonRadios.forEach(radio => {
+    radio.addEventListener("change", e => {
+      if (e.target.checked) {
+        var buttonValue = e.target.value;
+        previewFrame.src = getCardPath(snapName, buttonValue);
+        codeElement.innerHTML = getCardEmbedHTML(snapName, buttonValue);
+      }
+    });
+  });
+
+  buttonRadios.filter(r => r.value === "black")[0].checked = true;
+  previewFrame.src = getCardPath(snapName, "black");
+  codeElement.innerHTML = getCardEmbedHTML(snapName, "black");
+}
+
+export { initSnapButtonsPicker, initEmbeddedCardPicker };

--- a/static/js/publisher/publisher.js
+++ b/static/js/publisher/publisher.js
@@ -3,7 +3,7 @@ import { selector } from "./metrics/filters";
 import * as market from "./form";
 import { initMultiselect } from "./form/multiselect";
 import { enableInput, changeHandler } from "./settings";
-import { publicise } from "./publicise";
+import * as publicise from "./publicise";
 import { initCategories } from "./market/categories";
 import markdownToggle from "./market/markdown";
 import stickyListingBar from "./market/stickyListingBar";

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -5,12 +5,34 @@
   <div class="row">
     <h4>Promote your snap using embeddable responsive card</h4>
   </div>
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+      <div class="col-2">
+        <label>
+          Snap Store button:
+        </label>
+      </div>
+      <div class="col-7">
+          <input type="radio" name="store-button" id="store-button-dark" checked="checked" value="black">
+          <label for="store-button-dark">Dark</label>
+          <input type="radio" name="store-button" id="store-button-light" value="white">
+          <label for="store-button-light">Light</label>
+          <input type="radio" name="store-button" id="store-button-hide" value="none">
+          <label for="store-button-hide">Hide button</label>
+      </div>
+    </div>
+  </div>
+
   <div class="row">
     <div class="col-2">
       <label>Preview:</label>
     </div>
     <div class="col-7">
-      <iframe src="/{{snap_name}}/embedded" width="100%" height="320px" frameborder="0" style="border: 1px solid"></iframe>
+      <iframe id="embedded-card-frame"
+        src="/{{snap_name}}/embedded?button=black"
+        width="100%" height="320px"
+        frameborder="0" style="border: 1px solid">
+      </iframe>
     </div>
   </div>
 
@@ -20,7 +42,7 @@
     </div>
     <div class="col-7">
       <div class="p-code-copyable">
-        <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded" frameborder="0" width="100%" height="320px" style="border: 1px solid" &gt;&lt;/iframe&gt;</code>
+        <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded?button=black" frameborder="0" width="100%" height="320px" style="border: 1px solid" &gt;&lt;/iframe&gt;</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
       </div>
     </div>
@@ -32,11 +54,19 @@
 {% endblock %}
 
 {% block scripts %}
-  <script>
-    Raven.context(function () {
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
+<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script>
+  Raven.context(function () {
+    snapcraft.publisher.publicise.initEmbeddedCardPicker({
+      snapName: "{{ snap_name }}",
+      previewFrame: document.getElementById('embedded-card-frame'),
+      codeElement: document.getElementById('snippet-card-html'),
+      buttonRadios: document.querySelectorAll("input[name=store-button]")
     });
-  </script>
+
+    if (typeof ClipboardJS !== 'undefined') {
+      new ClipboardJS('.js-clipboard-copy');
+    }
+  });
+</script>
 {% endblock %}

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -139,7 +139,8 @@
   <script src="{{ static_url('js/dist/publisher.js') }}"></script>
   <script>
     Raven.context(function () {
-      snapcraft.publisher.publicise();
+      snapcraft.publisher.publicise.initSnapButtonsPicker();
+
       if (typeof ClipboardJS !== 'undefined') {
         new ClipboardJS('.js-clipboard-copy');
       }

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -29,12 +29,14 @@
 
 <div class="p-strip is-shallow">
   <div class="row">
+    {% if button != "none" %}
     <p>
       <a href="https://snapcraft.io/{{ package_name }}">
-        <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" />
+        <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
       </a>
     </p>
     <hr/>
+    {% endif %}
     <p>{{ default_track }}/{{ lowest_risk_available }} {{ version }}</p>
     <p><small>Published {{ last_updated }}</small></p>
   </div>

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -245,13 +245,14 @@ def snap_details_views(store, api, handle_errors):
 
         context = _get_context_snap_details(snap_name)
 
+        button_variants = ["black", "white", "none"]
+        button = flask.request.args.get("button")
+        if button not in button_variants:
+            button = "black"
+
         context.update(
             {
-                "is_linux": (
-                    "Linux" in flask.request.headers.get("User-Agent", "")
-                    and "Android"
-                    not in flask.request.headers.get("User-Agent", "")
-                )
+                "button": button
             }
         )
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -250,11 +250,7 @@ def snap_details_views(store, api, handle_errors):
         if button not in button_variants:
             button = "black"
 
-        context.update(
-            {
-                "button": button
-            }
-        )
+        context.update({"button": button})
 
         return (
             flask.render_template("store/snap-embedded-card.html", **context),


### PR DESCRIPTION
Fixes #1602 

Add snap store button settings to publicise embedded card page.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1626.run.demo.haus/
- go to publicise page of any snap, choose embeddable card
- there should be a radio button to choose a button style
- choose different button style
- see preview frame update
- see the HTML code update

<img width="1017" alt="screenshot 2019-02-21 at 16 00 41" src="https://user-images.githubusercontent.com/83575/53178284-dc3ebb80-35f1-11e9-934f-c1bb70fe403f.png">
