### PR TITLE
Updated copy on notification displead on detail page of a snap you own

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -137,7 +137,7 @@
       <div class="row js-snap-owner-notification">
         <div class="p-notification--information">
           <p class="p-notification__response">
-            Ensure your snap stays always relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
+            Ensure your snap always stays relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
           </p>
         </div>
       </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -137,7 +137,7 @@
       <div class="row js-snap-owner-notification">
         <div class="p-notification--information">
           <p class="p-notification__response">
-            Ensure your snap stay always relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
+            Ensure your snap stays always relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snap-squad/issues/909

## QA

1. Pull the branch or run the demo service (if available)
2. Visit the public detail page of any snap you own
3. Check there is a notification and says `Ensure you snap stays always relevant...`
4. #winning
