### PR TITLE
Fixed layout when a snap shows only world distribution metrics

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -208,7 +208,7 @@
       </div>
 
       <div class="p-strip is-shallow">
-        <div class="row u-equal-height">
+        <div class="row {% if normalized_os %}u-equal-height{% endif %}">
           {% if countries %}
             <div class="{% if normalized_os %}col-8{% else %}col-12{% endif %} js-snap-map-holder" data-live="installed_base_by_country_percent">
               <h4>Where people are using {{ snap_title }}</h4>


### PR DESCRIPTION
Fixes #1625 

## QA
1. Pull the branch or run the demo service
2. Open a snap that only displays map distribution but not OS distribution metrics i.e. [snap-store-proxy](https://snapcraft.io/snap-store-proxy)
3. Check the map is full width
4. Open another snap displaying world and OS distribution metrics i.e. [skype](https://snapcraft.io/skype)
4. #winning