### PR TITLE
Add name dispute screens

### DIFF
--- a/templates/publisher/register-name-dispute-success.html
+++ b/templates/publisher/register-name-dispute-success.html
@@ -1,0 +1,20 @@
+{% extends "publisher/_publisher_layout.html" %}
+
+{% block meta_title %}
+Snapcraft - Register name dispute
+{% endblock %}
+
+{% block content %}
+<div class="p-strip">
+    <div class="row">
+        <div class="col-12"></div>
+            <h1 class="p-heading--four"><a href="/snaps">&lsaquo; My snaps</a></h1>
+            <h1 class="p-heading--two">Thank you for requesting the name <strong>{{snap_name}}</strong></h1>
+            <p>We will proccess the details provided with the name dispute</p>
+            <p>Each case is reviewed individually and we can't provide an estimate on how long it will take for us to process this information. We will contact you once we confirm the information provided</p>
+            <hr />
+            <a href="/snaps" class="p-button--positive u-float-right">Return to my snaps</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/publisher/register-name-dispute.html
+++ b/templates/publisher/register-name-dispute.html
@@ -1,0 +1,68 @@
+{% extends "publisher/_publisher_layout.html" %}
+
+{% block meta_title %}
+Snapcraft - Register name dispute
+{% endblock %}
+
+{% block content %}
+<div class="p-strip">
+    <div class="row">
+        <div class="col-12">
+            <h1 class="p-heading--four"><a href="/snaps">&lsaquo; My snaps</a></h1>
+            <h1 class="p-heading--two">Claim the name <strong>{{snap_name}}</strong></h1>
+            {% if errors %}
+                {% for err in errors %}
+                    <div class="p-notification--negative">
+                        <p class="p-notification__response">
+                            <span class="p-notification__status">{{err.message}}</span>
+                        </p>
+                    </div>
+                {% endfor %}
+            {% endif %}
+            <p>Request the transfer of this snap name from it's current owner</p>
+        </div>
+    </div>
+    <form class="p-form p-form--stacked" action="" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <div class="row">
+            <div class="col-12">
+                <div class="p-form__group">
+                    <label class="p-form__label">Store</label>
+                    <div class="p-form__control u-clearfix">
+                        <span>Global</span>
+                    </div>
+                </div>
+                <div class="p-form__group">
+                    <label for="snap-name" class="p-form__label">Snap name</label>
+                    <div class="p-form__control u-clearfix">
+                        <span><strong>{{snap_name}}</strong></span>
+                        <input hidden="text" id="snap-name" name="snap-name" value="{{snap_name}}"/>
+                    </div>
+                </div>
+                <div class="p-form__group">
+                    <label for="claim-comment" class="p-form__label">Comment</label>
+                    <div class="p-form__control u-clearfix">
+                        <textarea id="claim-comment" name="claim-comment"></textarea>
+                        <p class="p-form-help-text">
+                            Why you have rights to claim this name
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <div class="row u-no-margin--top">
+                    <hr />
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <button type="submit" class="p-button--positive u-float-right">Submit name claim</button>
+                <a href="/register-snap" class="p-button--neutral u-float-right">Register a new name</a>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -9,13 +9,13 @@ Register new Snap name
 
   {% if conflict %}
     <div class="row">
-      <div class="col-8 push-2">
-        <h1 class="p-heading--two">{{ snap_name }} is already taken</h1>
+      <div class="col-12">
+        <h1 class="p-heading--two"><strong>{{ snap_name }}</strong> is already taken</h1>
       </div>
     </div>
   {% else %}
     <div class="row">
-        <div class="col-8 push-2">
+        <div class="col-12">
           <h1 class="p-heading--two">Register snap</h1>
         </div>
     </div>
@@ -23,10 +23,10 @@ Register new Snap name
 
   {% if conflict %}
       <div class="row">
-        <div class="col-8 push-2">
+        <div class="col-12">
             <div class="p-notification--caution">
               <p class="p-notification__response">
-                Another publisher already registered {{ snap_name }}. You can <a href="https://dashboard.snapcraft.io/register-snap/" class="p-link--external" target="_blank">file a dispute</a> to request a transfer of ownership or register a new name below.
+                Another publisher already registered <strong>{{ snap_name }}</strong>. You can <a href="/register-name-dispute?snap-name={{ snap_name }}">file a dispute</a> to request a transfer of ownership or register a new name below.
               </p>
             </div>
         </div>
@@ -35,10 +35,10 @@ Register new Snap name
 
   {% if already_owned %}
     <div class="row">
-      <div class="col-8 push-2">
+      <div class="col-12">
         <div class="p-notification--caution">
           <p class="p-notification__response">
-            You already own '<a href="/account/snaps/{{ snap_name }}/listing">{{ snap_name }}</a>'.
+            You already own '<a href="/account/snaps/{{ snap_name }}/listing"><strong>{{ snap_name }}</strong></a>'.
           </p>
         </div>
       </div>
@@ -47,7 +47,7 @@ Register new Snap name
 
   {% if not conflict %}
     <div class="row">
-      <div class="col-8 push-2">
+      <div class="col-12">
         <p>Before you can push your snap to the store, its name must be registered</p>
       </div>
     </div>
@@ -55,7 +55,7 @@ Register new Snap name
 
   {% if errors %}
       <div class="row">
-        <div class="col-8 push-2">
+        <div class="col-12">
           {% for error in errors %}
             <div class="p-notification--caution">
               <p class="p-notification__response">
@@ -72,7 +72,7 @@ Register new Snap name
 
     {% if available_stores %}
       <div class="row">
-        <div class="col-4 push-2">
+        <div class="col-8">
           <label for="snap-store">Store</label>
           <div class="p-form-validation__field">
             <select name="store" id="snap-store">
@@ -87,7 +87,7 @@ Register new Snap name
     {% endif %}
 
     <div class="row">
-      <div class="col-8 push-2">
+      <div class="col-8">
         <div class="p-form-validation">
           <label for="snap-name">Snap name</label>
           <div class="p-form-validation__field">
@@ -108,13 +108,13 @@ Register new Snap name
     </div>
 
     <div class="row u-no-margin--top">
-      <div class="col-8 push-2">
+      <div class="col-12">
         <hr/>
       </div>
     </div>
 
     <div class="row u-no-margin--top">
-      <div class="col-8 push-2 u-clearfix u-align--right">
+      <div class="col-12 u-clearfix u-align--right">
           <input type="submit" class="p-button--positive u-no-margin--top u-float-right" value="Register"/>
           <a class="p-button--neutral u-float-right" href="/account/snaps">Cancel</a>
       </div>

--- a/tests/publisher/tests_register_name_dispute.py
+++ b/tests/publisher/tests_register_name_dispute.py
@@ -1,0 +1,138 @@
+import responses
+from tests.publisher.endpoint_testing import BaseTestCases
+
+
+class GetRegisterNameDisputePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = "/register-name-dispute"
+        super().setUp(snap_name=None, endpoint_url=endpoint_url)
+
+
+class GetRegisterNameDisputePage(BaseTestCases.BaseAppTesting):
+    def setUp(self):
+        super().setUp(
+            snap_name="test-snap",
+            api_url=None,
+            endpoint_url="/register-name-dispute",
+        )
+
+    @responses.activate
+    def test_register_name_dispute_logged_in(self):
+        self._log_in(self.client)
+
+        endpoint_url = "{}?snap-name={}".format(
+            self.endpoint_url, self.snap_name
+        )
+        response = self.client.get(endpoint_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used("publisher/register-name-dispute.html")
+        self.assert_context("snap_name", "test-snap")
+
+    @responses.activate
+    def test_register_name_dispute_redirect_no_snap_name(self):
+        self._log_in(self.client)
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, "/register-snap")
+
+
+class PostRegisterNameDisputeNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        endpoint_url = "/register-name-dispute"
+        super().setUp(
+            snap_name=None, endpoint_url=endpoint_url, method_endpoint="POST"
+        )
+
+
+class PostRegisterNameDispute(BaseTestCases.EndpointLoggedIn):
+    def setUp(self):
+        api_url = (
+            "https://dashboard.snapcraft.io/dev/api/register-name-dispute/"
+        )
+        endpoint_url = "/register-name-dispute"
+
+        super().setUp(
+            snap_name="test-snap",
+            api_url=api_url,
+            endpoint_url=endpoint_url,
+            method_api="POST",
+            method_endpoint="POST",
+        )
+        self.comment = "claim test-snap"
+
+    @responses.activate
+    def test_post_missing_fields(self):
+        self._log_in(self.client)
+
+        api_payload_mock = {
+            "error_list": [
+                {
+                    "message": "an error",
+                    "code": "missing-field",
+                    "extra": {"field": "field"},
+                }
+            ]
+        }
+
+        responses.add(
+            responses.POST, self.api_url, json=api_payload_mock, status=400
+        )
+
+        response = self.client.post(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        errors = self.get_context_variable("errors")
+        self.assertEqual(errors, api_payload_mock["error_list"])
+
+    @responses.activate
+    def test_post_already_owned_or_disputed(self):
+        self._log_in(self.client)
+
+        api_payload_mock = {
+            "error_list": [
+                {
+                    "message": "an error",
+                    "code": "an-error-code",
+                    "extra": {"something-extra": "extra something"},
+                }
+            ]
+        }
+
+        responses.add(
+            responses.POST, self.api_url, json=api_payload_mock, status=409
+        )
+
+        response = self.client.post(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        errors = self.get_context_variable("errors")
+        self.assertEqual(errors, api_payload_mock["error_list"])
+
+    @responses.activate
+    def test_post_name_dispute(self):
+        self._log_in(self.client)
+
+        responses.add(responses.POST, self.api_url, json={}, status=201)
+        data = {"snap-name": self.snap_name, "comment": self.comment}
+        response = self.client.post(self.endpoint_url, data=data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used(
+            "publisher/register-name-dispute-success.html"
+        )
+        self.assert_context("snap_name", "test-snap")
+
+    @responses.activate
+    def test_post_name_dispute_error(self):
+        self._log_in(self.client)
+
+        responses.add(responses.POST, self.api_url, json={}, status=403)
+        data = {"snap-name": self.snap_name, "comment": self.comment}
+        response = self.client.post(self.endpoint_url, data=data)
+
+        self.assertEqual(response.status_code, 502)
+        self.assert_template_used("50X.html")

--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -51,6 +51,8 @@ SNAP_INFO_URL = "".join([DASHBOARD_API, "snaps/info/{snap_name}"])
 
 REGISTER_NAME_URL = "".join([DASHBOARD_API, "register-name/"])
 
+REGISTER_NAME_DISPUTE_URL = "".join([DASHBOARD_API, "register-name-dispute/"])
+
 REVISION_HISTORY_URL = "".join([DASHBOARD_API, "snaps/{snap_id}/history"])
 
 SNAP_RELEASE_HISTORY_URL = "".join(
@@ -186,6 +188,21 @@ def post_register_name(
 
     response = api_session.post(
         url=REGISTER_NAME_URL,
+        headers=get_authorization_header(session),
+        json=json,
+    )
+
+    if authentication.is_macaroon_expired(response.headers):
+        raise MacaroonRefreshRequired
+
+    return process_response(response)
+
+
+def post_register_name_dispute(session, snap_name, claim_comment):
+    json = {"snap_name": snap_name, "comment": claim_comment}
+
+    response = api_session.post(
+        url=REGISTER_NAME_DISPUTE_URL,
         headers=get_authorization_header(session),
         json=json,
     )

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -806,6 +806,45 @@ def post_register_name():
     return flask.redirect(flask.url_for("account.get_account"))
 
 
+@publisher_snaps.route("/register-name-dispute")
+@login_required
+def get_register_name_dispute():
+    snap_name = flask.request.args.get("snap-name")
+    if not snap_name:
+        return flask.redirect(
+            flask.url_for(".get_register_name", snap_name=snap_name)
+        )
+    return flask.render_template(
+        "publisher/register-name-dispute.html", snap_name=snap_name
+    )
+
+
+@publisher_snaps.route("/register-name-dispute", methods=["POST"])
+@login_required
+def post_register_name_dispute():
+    try:
+        snap_name = flask.request.form.get("snap-name")
+        claim_comment = flask.request.form.get("claim-comment")
+        api.post_register_name_dispute(
+            flask.session, bleach.clean(snap_name), bleach.clean(claim_comment)
+        )
+    except ApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code in [400, 409]:
+            return flask.render_template(
+                "publisher/register-name-dispute.html",
+                snap_name=snap_name,
+                errors=api_response_error_list.errors,
+            )
+        else:
+            return _handle_error_list(api_response_error_list.errors)
+    except ApiError as api_error:
+        return _handle_errors(api_error)
+
+    return flask.render_template(
+        "publisher/register-name-dispute-success.html", snap_name=snap_name
+    )
+
+
 @publisher_snaps.route("/<snap_name>/settings")
 @login_required
 def get_settings(snap_name):


### PR DESCRIPTION
## Done
Adds a flow to register name disputes.

## QA
- **Set your environment to use the staging APIs**
- **Set your environment to use the staging APIs**
- **Set your environment to use the staging APIs**
- **Are you using the staging APIs?**
- **DO YOU EVEN STAGING APIS?**

- Then go to `/register-snap`
- Try to register a snap name that is already registered. 
- You should then see a message telling you name is already registered and giving you a link to `file a dispute`. Click the link.
- Try and submit the dispute without a message and verify you get an error for a required field.
- Add a message and submit, make sure you land in a success page.

- Navigate to `/register-name-dispute?snap-name=<snap_you_already_own>`
- Try and submit a dispute and see you get an error message saying you already own the name

- Navigate to `/register-name-dispute?snap-name=<snap_already_in_dispute>`
- Try and submit a dispute and see you get an error message saying you have already submitted a dispute for the name.

## Issues
FIxes #1523 
