### PR TITLE
Upgrade talisker requests

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn webapp.app:create_app() --bind $1 --worker-class sync --workers 8 --name talisker-`hostname` --access-logfile -"
+RUN_COMMAND="talisker.gunicorn webapp.app:create_app() --bind $1 --worker-class sync --workers 8 --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ requests==2.21.0
 requests-cache==0.4.13
 responses==0.9.0
 ruamel.yaml==0.15.72
-talisker==0.11.0
+talisker[gunicorn]==0.14.2
 
 # Temporary fix to SSO redirect issue
 Werkzeug==0.14.1

--- a/webapp/api/requests.py
+++ b/webapp/api/requests.py
@@ -1,30 +1,13 @@
 import os
-from urllib.parse import urlparse
 
 import requests
 
-import prometheus_client
 import requests_cache
 from pybreaker import CircuitBreaker, CircuitBreakerError
 from webapp.api.exceptions import (
     ApiCircuitBreaker,
     ApiConnectionError,
     ApiTimeoutError,
-)
-
-timeout_counter = prometheus_client.Counter(
-    "feed_timeouts", "A counter of timed out requests", ["domain"]
-)
-connection_failed_counter = prometheus_client.Counter(
-    "feed_connection_failures",
-    "A counter of requests which failed to connect",
-    ["domain"],
-)
-latency_histogram = prometheus_client.Histogram(
-    "feed_latency_seconds",
-    "Feed requests retrieved",
-    ["domain", "code"],
-    buckets=[0.25, 0.5, 0.75, 1, 2, 3],
 )
 
 
@@ -61,21 +44,15 @@ class BaseSession:
         self.api_breaker = CircuitBreaker(fail_max=5, reset_timeout=60)
 
     def request(self, method, url, **kwargs):
-        domain = urlparse(url).netloc
-
         try:
             request = self.api_breaker.call(
                 super().request, method=method, url=url, **kwargs
             )
         except requests.exceptions.Timeout:
-            timeout_counter.labels(domain=domain).inc()
-
             raise ApiTimeoutError(
                 "The request to {} took too long".format(url)
             )
         except requests.exceptions.ConnectionError:
-            connection_failed_counter.labels(domain=domain).inc()
-
             raise ApiConnectionError(
                 "Failed to establish connection to {}.".format(url)
             )
@@ -83,10 +60,6 @@ class BaseSession:
             raise ApiCircuitBreaker(
                 "Requests are closed because of too many failures".format(url)
             )
-
-        latency_histogram.labels(
-            domain=domain, code=request.status_code
-        ).observe(request.elapsed.total_seconds())
 
         return request
 

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -1,4 +1,5 @@
 import os
+import talisker.requests
 from webapp import api
 from webapp.api.exceptions import (
     ApiResponseDecodeError,
@@ -75,8 +76,11 @@ class StoreApi:
             self.session = api.requests.Session()
         else:
             self.session = api.requests.CachedSession(timeout=(1, 6))
+
         self.session.headers.update(self.headers)
         self.session.headers.update(self.headers_v2)
+
+        talisker.requests.configure(self.session)
 
     def process_response(self, response):
         try:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,6 +9,7 @@ from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.debug import DebuggedApplication
 
 import talisker.flask
+import webapp.api
 import webapp.helpers as helpers
 from webapp.blog.views import blog
 from webapp.extensions import csrf
@@ -37,8 +38,12 @@ def create_app(testing=False):
     app.url_map.converters["regex"] = helpers.RegexConverter
 
     if not testing:
-        talisker.flask.register(app)
         init_extensions(app)
+
+        talisker.flask.register(app)
+        talisker.requests.configure(webapp.api.blog.api_session)
+        talisker.requests.configure(webapp.api.dashboard.api_session)
+        talisker.requests.configure(webapp.api.sso.api_session)
 
     app.config.from_object("webapp.configs." + app.config["WEBAPP"])
 


### PR DESCRIPTION
# Summary

- Upgrade to talisker 0.11.1
- Configure talisker metrics for each request.Session; this will allow us to get more metrics

# QA

- create `.env.local` with: `TALISKER_NETWORKS=172.17.0.1`
- `./run`
- Check that metrics for requests are there and working on `/_status/metrics`