### PR TITLE
Remove unnecessary js modules directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "build": "yarn run get-licenses && yarn run build-js && yarn run build-css",
     "build-css": "node-sass --include-path node_modules static/sass --output-style compressed --output static/css && postcss --use autoprefixer --no-map --replace 'static/css/**/*.css'",
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-bundle",
-    "copy-3rd-party-js": "cp node_modules/global-nav/dist/index.js static/js/modules/global-nav.js && cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
+    "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/global-nav/dist/index.js static/js/modules/global-nav.js && cp node_modules/d3/build/d3.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-bundle": "webpack",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "watch": "watch -p 'static/sass/**/*.scss' -p 'static/js/**/*.js' -c 'yarn run build'",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "webpack --watch",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp webapp/licenses.json"
+    "clean": "rm -rf node_modules yarn-error.log css static/js/modules static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle cache.tmp webapp/licenses.json"
   },
   "husky": {
     "hooks": {

--- a/static/js/modules/README.md
+++ b/static/js/modules/README.md
@@ -1,2 +1,0 @@
-This folder is for generated/built/copied JS modules.
-Don't put any files here manually as they will be git-ignored.


### PR DESCRIPTION
Removes unnecessary static/js/modules directory that is just a build artifact

### QA
Make sure build works regardless of static/js/modules folder existence:

- ./run build
- ./run clean
- ./run build
- ./run build

