### PR TITLE
FSF ROS2

### DIFF
--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -32,8 +32,7 @@
 
 <b>apps</b>:
   <b>ros2-talker-listener</b>:
-    <b>command</b>: opt/ros/crystal/bin/ros2 launch \
-	demo_nodes_cpp talker_listener.launch.py
+    <b>command</b>: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
 
 
 

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -33,9 +33,6 @@
 <b>apps</b>:
   <b>ros2-talker-listener</b>:
     <b>command</b>: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
-
-
-
 </pre></code>
   </div>
   

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -2,15 +2,46 @@
   <div class='col-6'>
     <h4>Why are snaps good for ROS2 projects?</h4>
     <ul>
-      <li>Bundle all the runtime requirements, including the exact version of ROS, system libraries, etc.</li>
+      <li>Bundle all the runtime requirements, including the exact version of ROS and system libraries you need.</li>
       <li>Expand the distributions supported beyond just Ubuntu.</li>
-      <li>Directly control the delivery of application updates.</li>
+      <li>Directly and reliably control the delivery of application updates using existing infrastructure.</li>
       <li>Extremely simple creation of daemons.</li>
     </ul>
   </div>
 
+  <div class='col-6'>
+    <h4>How ros2-talker-listener defines snapcraft.yaml:</h4>
+    <code class="p-code-yaml"><pre><b>name</b>: ros2-talker-listener
+<b>version</b>: '0.1'
+<b>summary</b>: ROS2 Talker/Listener Example
+<b>description</b>: |
+  This example launches a ROS2 talker and listener.
+
+<b>confinement</b>: devmode
+<b>base</b>: core18
+
+<b>parts</b>:
+  <b>ros-demos</b>:
+    <b>plugin</b>: colcon
+    <b>source</b>: https://github.com/ros2/demos.git
+    <b>source-branch</b>: crystal
+    <b>colcon-rosdistro</b>: crystal
+    <b>colcon-source-space</b>: demo_nodes_cpp
+    <b>build-packages</b>: [make, gcc, g++]
+    <b>stage-packages</b>: [ros-crystal-ros2launch]
+
+<b>apps</b>:
+  <b>run</b>:
+    <b>command</b>: opt/ros/crystal/bin/ros2 launch \
+	demo_nodes_cpp talker_listener.launch.py
+
+
+
+</pre></code>
+  </div>
+  
   <div class="p-flow-details__continue">
     In just a few steps, you’ll have an example ROS2 app in the Snap Store.
-    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/ros2">Continue</a>
+    <a class="p-button--positive is-inline" href="/first-snap/ros2">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -31,7 +31,7 @@
     <b>stage-packages</b>: [ros-crystal-ros2launch]
 
 <b>apps</b>:
-  <b>run</b>:
+  <b>ros2-talker-listener</b>:
     <b>command</b>: opt/ros/crystal/bin/ros2 launch \
 	demo_nodes_cpp talker_listener.launch.py
 

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -1,0 +1,54 @@
+linux:
+  auto:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+    - action: Install the snap
+      command: sudo snap install --devmode --dangerous *.snap
+    - action: List your installed snaps to confirm
+      command: snap list
+    - action: Run the snap
+      command: test-ros2-talker-listener-{name}.run -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>test-ros2-talker-listener-{name}</code>)
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+    - action: Install the snap
+      command: sudo snap install --devmode --dangerous *.snap
+    - action: List your installed snaps to confirm
+      command: snap list
+    - action: Run the snap
+      command: test-ros2-talker-listener-{name}.run -h
+    - warning: |
+        Make sure the name matches what has been used previously (i.e <code>test-ros2-talker-listener-{name}</code>)
+macos:
+  auto:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: |
+        brew install squashfs
+        unsquashfs -l *.snap
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: |
+        brew install squashfs
+        unsquashfs -l *.snap
+windows:
+  auto:
+    - action: Run Windows Subsystem for Linux from the Windows Start menu
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run snapcraft
+      command: snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap
+  manual:
+    - action: Return to the root directory of the project containing your snapcraft.yaml and run the snapcraft Docker image
+      command: docker run -v $PWD:$PWD -w $PWD snapcore/snapcraft snapcraft
+    - action: You will find a .snap file in the same directory that you ran the snapcraft command. You can inspect the contents to ensure it contains all of the application's assets
+      command: unsquashfs -l *.snap

--- a/webapp/first_snap/content/ros2/build.yaml
+++ b/webapp/first_snap/content/ros2/build.yaml
@@ -9,7 +9,7 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-ros2-talker-listener-{name}.run -h
+      command: test-ros2-talker-listener-{name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>test-ros2-talker-listener-{name}</code>)
   manual:
@@ -22,7 +22,7 @@ linux:
     - action: List your installed snaps to confirm
       command: snap list
     - action: Run the snap
-      command: test-ros2-talker-listener-{name}.run -h
+      command: test-ros2-talker-listener-{name} -h
     - warning: |
         Make sure the name matches what has been used previously (i.e <code>test-ros2-talker-listener-{name}</code>)
 macos:

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -59,7 +59,7 @@ explain:
     - text: Apps are the commands you want to expose to users and any background services your application provides.
     - code: |
         apps:
-          run:
+          ros2-talker-listener:
             command: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp \
             talker_listener.launch.py
     - warning: |

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -40,7 +40,7 @@ explain:
         Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets.
     - text: The <code>colcon</code> plugin is useful when building ROS application parts.
     - text: |
-        You can also use the <code>colcon-rosdistro</code> keyword to change the ROS distro required by the system. The command <code>snapcraft help colcon</code> gives more information on how this plugin works.
+        The plugin points to the ROS2 demos GitHub repository and uses <code>Crystal</code>, the latest ROS2 release available. You can use the <code>colcon-rosdistro</code> keyword to change the ROS distro required by the system. The <code>colcon-source-space</code> points to the source space containing the colcon C++ demo nodes packages. The command <code>snapcraft help colcon</code> gives more information on how this plugin works.
     - code: |
         parts:
           ros-demos:
@@ -52,16 +52,15 @@ explain:
             build-packages: [make, gcc, g++]
             stage-packages: [ros-crystal-ros2launch]
     - text: |
-        The <code>build-packages</code> sections lists the library dependencies that will be used by snapcraft to build the parts.
+        The <code>build-packages</code> section lists the dependencies that will be used by snapcraft to build the parts.
     - text: |
-        The <code>stage-packages</code> section specifies the list of libraries required by the ros2-talker-listener snap at runtime.
+        The <code>stage-packages</code> section specifies the list of components required by the ros2-talker-listener snap at runtime.
   apps:
-    - text: Apps are the commands you want to expose to users and any background services your application provides.
+    - text: Apps are the commands you want to expose to users and any background services your application provides. The command that runs within the snap uses the staged <code>ros-crystal-ros2launch</code> package to start the demo nodes talker/listener launch file.
     - code: |
         apps:
           ros2-talker-listener:
-            command: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp \
-            talker_listener.launch.py
+            command: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
     - warning: |
         <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -1,0 +1,68 @@
+name: test-ros2-talker-listener-{name}
+download: git clone https://github.com/snapcraft-docs/ros2-talker-listener
+createDir: |
+  cd ros2-talker-listener
+  $EDITOR snapcraft.yaml
+metadata: |
+  name: ros2-talker-listener
+  version: '0.1'
+  summary: ROS2 Talker/Listener Example
+  description: |
+    This example launches a ROS2 talker and listener.
+explain:
+  metadata:
+    - text: The name must be unique in the Snap Store. Valid snap names consist of lower-case alphanumeric characters and hyphens. They cannot be all numbers. They also cannot start or end with a hyphen.
+    - code: |
+        name: ros2-talker-listener
+    - warning: |
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
+    - text: Versions carry no semantic meaning in snaps. Use text that best identifies that release, it won't be used to compare against the preceding or following one.
+    - code: |
+        version: git
+    - text: The summary can not exceed 79 characters. You can use a pipe ‘|’ in the description key to declare a multi-line description.
+    - code: |
+        description: |
+  security:
+    - text: The next section describes the level of confinement applied to your app.
+    - code: |
+        confinement: devmode
+    - text: Snaps are containerised to ensure more predictable application behaviour and greater security.
+    - text: It’s best to start a snap with the confinement in warning mode, rather than strictly applied. This is indicated through the <code>devmode</code> keyword.
+    - text: Once an app is working well in devmode, you can review confinement violations, add appropriate interfaces, and switch to strict confinement.
+  base:
+    - text: In general, snaps cannot see the root filesystem on end user systems. This prevents conflict with other applications and increases security. However, applications still need some location to act as the root filesystem. They would also benefit from common libraries (e.g. libc) being in this root filesystem rather than bundled into each application.
+    - text: The base keyword specifies a special kind of snap that provides a minimal set of libraries common to most applications. It will be mounted as the root filesystem for your application.
+    - code: |
+        base: core18
+    - text: The <code>core18</code> base is recommended.
+  parts:
+    - text: |
+        Parts define what sources are needed to assemble your app. Parts can be anything: programs, libraries, or other needed assets.
+    - text: The <code>colcon</code> plugin is useful when building ROS application parts.
+    - text: |
+        You can also use the <code>colcon-rosdistro</code> keyword to change the ROS distro required by the system. The command <code>snapcraft help colcon</code> gives more information on how this plugin works.
+    - code: |
+        parts:
+          ros-demos:
+            plugin: colcon
+            source: https://github.com/ros2/demos.git
+            source-branch: crystal
+            colcon-rosdistro: crystal
+            colcon-source-space: demo_nodes_cpp
+            build-packages: [make, gcc, g++]
+            stage-packages: [ros-crystal-ros2launch]
+    - text: |
+        The <code>build-packages</code> sections lists the library dependencies that will be used by snapcraft to build the parts.
+    - text: |
+        The <code>stage-packages</code> section specifies the list of libraries required by the ros2-talker-listener snap at runtime.
+  apps:
+    - text: Apps are the commands you want to expose to users and any background services your application provides.
+    - code: |
+        apps:
+          run:
+            command: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp \
+            talker_listener.launch.py
+    - warning: |
+        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
+    - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
+    - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -1,0 +1,16 @@
+macos:
+  - action: Create a Linux virtual machine for testing snaps
+    command: multipass launch -n testvm
+  - action: Return to the directory containing the .snap file and copy it into the virtual machine
+    command: 'multipass copy-files ros2-talker-listener*.snap testvm:'
+  - action: Connect to the virtual machine
+    command: multipass shell testvm
+  - action: Install the snap inside the virtual machine
+    command: sudo snap install --dangerous ros2-talker-listener*.snap
+  - action: Confirm the snap is installed by listing your installed snaps
+    command: snap list
+  - action: Run the snap inside the virtual machine
+    warning: You should change <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
+    command: test-ros2-talker-listener-{name}.run -h
+  - action: Exit the virtual machine
+    command: exit

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -11,6 +11,6 @@ macos:
     command: snap list
   - action: Run the snap inside the virtual machine
     warning: You should change <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name), as written into the snapcraft.yaml file earlier.
-    command: test-ros2-talker-listener-{name}.run -h
+    command: test-ros2-talker-listener-{name} -h
   - action: Exit the virtual machine
     command: exit


### PR DESCRIPTION
This is the updated FSF ROS2 guide.

The YAML shown on the template page builds correctly, and the snap runs.

The description primarily highlights the benefits of snaps to the robotics audience. I've made the changes after consulting with Kyle.

I've also updated the test section to reflect the correct invocation of the snap, as the snap name and the application name are different.

Please note this guide requires the edge release of snapcraft to work correctly. It will require changing the template to mention that (different from the instructions for other guides). @evandandrea can you please make this change:

snap install snapcraft --classic --edge

And maybe instructions for those who already have other releases, perhaps if they have followed other guides, to refresh snapcraft.