### PR TITLE
Add preconnect to GA, Marketo, Assets Server

### DIFF
--- a/templates/_layout-brandstore.html
+++ b/templates/_layout-brandstore.html
@@ -2,6 +2,12 @@
 
 <html lang="en">
   <head>
+
+    <!-- Preconnect to establish early connections to important third-party origins -->
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="https://assets.ubuntu.com">
+    <link rel="preconnect" href="https://munchkin.marketo.net">
+
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/_layout-embedded.html
+++ b/templates/_layout-embedded.html
@@ -2,6 +2,12 @@
 
 <html lang="en">
   <head>
+
+    <!-- Preconnect to establish early connections to important third-party origins -->
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="https://assets.ubuntu.com">
+    <link rel="preconnect" href="https://munchkin.marketo.net">
+
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -2,6 +2,12 @@
 
 <html lang="en">
   <head>
+
+    <!-- Preconnect to establish early connections to important third-party origins -->
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect" href="https://assets.ubuntu.com">
+    <link rel="preconnect" href="https://munchkin.marketo.net">
+
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Done

`<link rel="preconnect">` informs the browser that your page intends to establish a connection to another origin, and that you’d like the process to start as soon as possible. 

https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect

## QA

- Run site locally
- Run performance audit from Chrome dev tools
- The following warning (4) should not be present in the subsequent report:

<img width="1435" alt="screenshot 2019-03-01 at 11 05 07" src="https://user-images.githubusercontent.com/505570/53631380-ae213300-3c12-11e9-8b4f-757bf607e35e.png">
