### PR TITLE
Summary option for publicise embeddable card

### DIFF
--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -64,7 +64,7 @@ const getCardEmbedHTML = (snapName, options) => {
   return `&lt;iframe src="https://snapcraft.io${getCardPath(
     snapName,
     options
-  )}" frameborder="0" width="100%" height="320px" style="border: 1px solid" &gt;&lt;/iframe&gt;`;
+  )}" frameborder="0" width="100%" height="320px" style="border: 1px solid #CCC; border-radius: 2px;"&gt;&lt;/iframe&gt;`;
 };
 
 // get form state from inputs

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -38,7 +38,18 @@ function initSnapButtonsPicker() {
 // EMBEDDABLE CARDS
 
 const getCardPath = (snapName, button) => {
-  return `/${snapName}/embedded?button=${button}`;
+  const path = `/${snapName}/embedded`;
+  let params = "";
+
+  if (button) {
+    params = `button=${button}`;
+  }
+
+  if (params) {
+    params = `?${params}`;
+  }
+
+  return `${path}${params}`;
 };
 
 const getCardEmbedHTML = (snapName, button) => {

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -37,12 +37,20 @@ function initSnapButtonsPicker() {
 
 // EMBEDDABLE CARDS
 
-const getCardPath = (snapName, button) => {
+const getCardPath = (snapName, options = {}) => {
   const path = `/${snapName}/embedded`;
   let params = "";
 
-  if (button) {
-    params = `button=${button}`;
+  if (options.button) {
+    params = `button=${options.button}`;
+  }
+
+  if (options["show-summary"]) {
+    if (params) {
+      params = `${params}&`;
+    }
+
+    params += `summary=true`;
   }
 
   if (params) {
@@ -52,30 +60,68 @@ const getCardPath = (snapName, button) => {
   return `${path}${params}`;
 };
 
-const getCardEmbedHTML = (snapName, button) => {
+const getCardEmbedHTML = (snapName, options) => {
   return `&lt;iframe src="https://snapcraft.io${getCardPath(
     snapName,
-    button
+    options
   )}" frameborder="0" width="100%" height="320px" style="border: 1px solid" &gt;&lt;/iframe&gt;`;
+};
+
+// get form state from inputs
+const getCurrentState = (buttonRadios, optionButtons) => {
+  var state = {};
+
+  // get state of store button radio
+  var checked = buttonRadios.filter(b => b.checked);
+
+  if (checked[0].value) {
+    state.button = checked[0].value;
+  }
+
+  // get state of options checkboxes
+  optionButtons.forEach(checkbox => {
+    if (checkbox.checked) {
+      state[checkbox.name] = true;
+    }
+  });
+
+  return state;
 };
 
 function initEmbeddedCardPicker(options) {
   const { snapName, previewFrame, codeElement } = options;
   const buttonRadios = [].slice.call(options.buttonRadios);
+  const optionButtons = [].slice.call(options.optionButtons);
+
+  const render = () => {
+    const state = getCurrentState(buttonRadios, optionButtons);
+    previewFrame.src = getCardPath(snapName, state);
+    codeElement.innerHTML = getCardEmbedHTML(snapName, state);
+  };
 
   buttonRadios.forEach(radio => {
     radio.addEventListener("change", e => {
       if (e.target.checked) {
-        var buttonValue = e.target.value;
-        previewFrame.src = getCardPath(snapName, buttonValue);
-        codeElement.innerHTML = getCardEmbedHTML(snapName, buttonValue);
+        render();
       }
     });
   });
 
+  optionButtons.forEach(checkbox => {
+    checkbox.addEventListener("change", () => {
+      render();
+    });
+  });
+
   buttonRadios.filter(r => r.value === "black")[0].checked = true;
-  previewFrame.src = getCardPath(snapName, "black");
-  codeElement.innerHTML = getCardEmbedHTML(snapName, "black");
+  previewFrame.src = getCardPath(
+    snapName,
+    getCurrentState(buttonRadios, optionButtons)
+  );
+  codeElement.innerHTML = getCardEmbedHTML(
+    snapName,
+    getCurrentState(buttonRadios, optionButtons)
+  );
 }
 
 export { initSnapButtonsPicker, initEmbeddedCardPicker };

--- a/static/sass/_snapcraft_banner.scss
+++ b/static/sass/_snapcraft_banner.scss
@@ -6,5 +6,14 @@
     background-image: url('#{$assets-path}9689339a-snapcraft-hero-background--light.png');
     background-position: 50% 0;
     background-size: 1440px 1440px;
+
+    @media screen and (max-width: $breakpoint-small) {
+      background-size: 640px 640px;
+    }
+
+    @media screen and (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
+      background-size: 820px 820px;
+    }
+
   }
 }

--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -16,6 +16,7 @@ $color-navigation-background: #252525;
 @include vf-p-tooltips;
 
 @include vf-u-align;
+@include vf-u-floats;
 @include vf-u-margin-collapse;
 
 @import 'snapcraft_banner';
@@ -23,6 +24,8 @@ $color-navigation-background: #252525;
 
 @import 'snapcraft_details_heading';
 @include snapcraft-details-heading;
+
+// CUSTOM STYLES FOR EMBEDDED CARD
 
 // make max-width of the layout smaller for embedded view
 .row {

--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -32,7 +32,12 @@ $color-navigation-background: #252525;
   max-width: 40rem;
 }
 
-html,
 body {
   background: $color-x-light; // This will be fix on vanilla https://github.com/vanilla-framework/vanilla-framework/issues/2129
+
+  &.is-chrome {
+    // workaround for Chrome background overflowing iframe border
+    background: none;
+    width: calc(100% - 1px);
+  }
 }

--- a/templates/_layout-embedded.html
+++ b/templates/_layout-embedded.html
@@ -71,7 +71,11 @@
         "url": "https://snapcraft.io{{ self.meta_path() }}"
       }
     </script>
-
+    <script>
+      if (navigator.appVersion.indexOf("Chrome/") != -1) {
+        document.body.classList.add("is-chrome");
+      }
+    </script>
     {% block meta_schema %}{% endblock %}
   </body>
 </html>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -17,7 +17,7 @@
           <label for="store-button-dark">Dark</label>
           <input type="radio" name="store-button" id="store-button-light" value="white">
           <label for="store-button-light">Light</label>
-          <input type="radio" name="store-button" id="store-button-hide" value="none">
+          <input type="radio" name="store-button" id="store-button-hide" value="">
           <label for="store-button-hide">Hide button</label>
       </div>
     </div>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -43,7 +43,7 @@
         class="snapcraft-publicise__embedded-frame"
         src="/{{snap_name}}/embedded?button=black"
         width="100%" height="320px"
-        frameborder="0" style="border: 1px solid">
+        frameborder="0" style="border: 1px solid #CCC; border-radius: 2px;">
       </iframe>
     </div>
   </div>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -40,6 +40,7 @@
     </div>
     <div class="col-7">
       <iframe id="embedded-card-frame"
+        class="snapcraft-publicise__embedded-frame"
         src="/{{snap_name}}/embedded?button=black"
         width="100%" height="320px"
         frameborder="0" style="border: 1px solid">

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -22,6 +22,17 @@
       </div>
     </div>
   </div>
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+      <div class="col-2">
+        Options:
+      </div>
+      <div class="col-7" id="js-options">
+          <input type="checkbox" name="show-summary" id="option-show-summary">
+          <label for="option-show-summary">Show summary</label>
+      </div>
+    </div>
+  </div>
 
   <div class="row">
     <div class="col-2">
@@ -61,7 +72,8 @@
       snapName: "{{ snap_name }}",
       previewFrame: document.getElementById('embedded-card-frame'),
       codeElement: document.getElementById('snippet-card-html'),
-      buttonRadios: document.querySelectorAll("input[name=store-button]")
+      buttonRadios: document.querySelectorAll("input[name=store-button]"),
+      optionButtons: document.querySelectorAll("#js-options input[type=checkbox]")
     });
 
     if (typeof ClipboardJS !== 'undefined') {

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -27,16 +27,30 @@
   </div>
 </div>
 
+{% if button != "none" or show_summary %}
 <div class="p-strip is-shallow">
   <div class="row">
     {% if button != "none" %}
-    <p>
+    <div class="{%if show_summary %}u-float--right{% endif %}">
       <a href="https://snapcraft.io/{{ package_name }}">
         <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
       </a>
-    </p>
-    <hr/>
+    </div>
     {% endif %}
+
+    {% if show_summary %}
+      <h4>{{ summary }}</h4>
+    {% endif %}
+  </div>
+</div>
+
+<div class="row">
+  <hr class="u-no-margin--bottom"/>
+</div>
+{% endif %}
+
+<div class="p-strip is-shallow">
+  <div class="row">
     <p>{{ default_track }}/{{ lowest_risk_available }} {{ version }}</p>
     <p><small>Published {{ last_updated }}</small></p>
   </div>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -27,10 +27,10 @@
   </div>
 </div>
 
-{% if button != "none" or show_summary %}
+{% if button or show_summary %}
 <div class="p-strip is-shallow">
   <div class="row">
-    {% if button != "none" %}
+    {% if button %}
     <div class="{%if show_summary %}u-float--right{% endif %}">
       <a href="https://snapcraft.io/{{ package_name }}">
         <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
@@ -39,7 +39,7 @@
     {% endif %}
 
     {% if show_summary %}
-      <h4>{{ summary }}</h4>
+      <h4 class="u-no-margin--bottom">{{ summary }}</h4>
     {% endif %}
   </div>
 </div>

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -137,6 +137,21 @@ class GetEmbeddedCardTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assert_context("snap_title", "Snap Title")
+        self.assert_context("button", None)
+
+    @responses.activate
+    def test_get_card_default_button(self):
+        payload = self.snap_payload
+
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=200
+            )
+        )
+
+        response = self.client.get(self.endpoint_url + "?button=test")
+
+        self.assertEqual(response.status_code, 200)
         self.assert_context("button", "black")
 
     @responses.activate

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -245,9 +245,9 @@ def snap_details_views(store, api, handle_errors):
 
         context = _get_context_snap_details(snap_name)
 
-        button_variants = ["black", "white", "none"]
+        button_variants = ["black", "white"]
         button = flask.request.args.get("button")
-        if button not in button_variants:
+        if button and button not in button_variants:
             button = "black"
 
         context.update(

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -250,7 +250,12 @@ def snap_details_views(store, api, handle_errors):
         if button not in button_variants:
             button = "black"
 
-        context.update({"button": button})
+        context.update(
+            {
+                "button": button,
+                "show_summary": flask.request.args.get("summary"),
+            }
+        )
 
         return (
             flask.render_template("store/snap-embedded-card.html", **context),


### PR DESCRIPTION
Fixes #1604

Adds optional summary to embedded card

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1653.run.demo.haus/
- go to Publicize page of any snap, Embeddable card section
- "Show summary" option should be available to select
- Select "Show summary", summary should appear in the iframe (embedded code should update respectively)
- Check if summary works with and without the button


<img width="1034" alt="screenshot 2019-03-05 at 16 55 28" src="https://user-images.githubusercontent.com/83575/53818255-169c4700-3f68-11e9-8134-c1dbc13fe5aa.png">
