### PR TITLE
List disputed names

### DIFF
--- a/static/sass/_snapcraft_dispute-list.scss
+++ b/static/sass/_snapcraft_dispute-list.scss
@@ -1,17 +1,16 @@
 @mixin snapcraft-p-dispute-list {
-  .p-snapcraft-dispute-list__icon,
-  .p-snapcraft-dispute-list__link {
-    display: none;
-  }
-
   .p-snapcraft-dispute-list__item {
-    &--warning {
-      color: $color-negative;
+    .p-snapcraft-dispute-list__link {
+      display: none;
+    }
 
-      .p-snapcraft-dispute-list__icon {
-        display: inline-block;
-        margin-right: $sph-intra;
-      }
+    .p-snapcraft-dispute-list__muted {
+      color: $color-mid;
+    }
+
+    .p-snapcraft-dispute-list__icon {
+      display: inline-block;
+      margin-right: $sph-intra;
     }
 
     &:hover {

--- a/static/sass/_snapcraft_dispute-list.scss
+++ b/static/sass/_snapcraft_dispute-list.scss
@@ -10,7 +10,6 @@
 
     .p-snapcraft-dispute-list__icon {
       display: inline-block;
-      margin-right: $sph-intra;
     }
 
     &:hover {

--- a/static/sass/_snapcraft_dispute-list.scss
+++ b/static/sass/_snapcraft_dispute-list.scss
@@ -1,0 +1,23 @@
+@mixin snapcraft-p-dispute-list {
+  .p-snapcraft-dispute-list__icon,
+  .p-snapcraft-dispute-list__link {
+    display: none;
+  }
+
+  .p-snapcraft-dispute-list__item {
+    &--warning {
+      color: $color-negative;
+
+      .p-snapcraft-dispute-list__icon {
+        display: inline-block;
+        margin-right: $sph-intra;
+      }
+    }
+
+    &:hover {
+      .p-snapcraft-dispute-list__link {
+        display: block;
+      }
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -213,6 +213,9 @@ $color-navigation-background: #252525;
 @import 'patterns_strip_slanted';
 @include p-strip-slanted;
 
+@import 'snapcraft_dispute-list';
+@include snapcraft-p-dispute-list;
+
 html,
 body {
   background: $color-x-light; // This will be fix on vanilla https://github.com/vanilla-framework/vanilla-framework/issues/2129

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -138,7 +138,7 @@ My published snaps — Linux software in the Snap Store
                       {% if dispute_pending %}
                         &nbsp;<span class="p-tooltip p-tooltip--btm-center" aria-describedby="{{ snap }}-dispute-pending">
                           <i class="p-icon--warning"></i>
-                          <span class="p-tooltip__message" role="tooltip" id="{{ snap }}-dispute-pending">Name being disputed</span>
+                          <span class="p-tooltip__message" role="tooltip" id="{{ snap }}-dispute-pending">Name dispute in progress</span>
                         </span>
                       {% endif %}
                     </span>
@@ -195,7 +195,7 @@ My published snaps — Linux software in the Snap Store
                   </td>
                   <td>
                     {% if dispute_pending %}
-                      <span class="p-snapcraft-dispute-list__muted">(Snap name disputed)</span>
+                      <span class="p-snapcraft-dispute-list__muted">(Name dispute in progress)</span>
                     {% else %}
                       <a href="https://docs.snapcraft.io/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float--right">Publish to this name</a>
                     {% endif %}

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -169,18 +169,28 @@ My published snaps — Linux software in the Snap Store
   {% if registered_snaps %}
     <section class="p-strip is-shallow u-no-padding--top">
       <div class="row">
-        <div class="col-12">
-          <hr />
-          <h4>My registered snap names</h4>
-        </div>
+        <h4 class="p-heading--five">Registered names ({{ registered_snaps|count }})</h4>
       </div>
       <div class="row">
-        <p>
-          Names you own but have not pushed a snap to:
-        </p>
-        <p>
-          {% for registered_snap in registered_snaps|sort %}{% if loop.index > 1 %}, {% endif %}{{ registered_snap }}{% endfor %}
-        </p>
+        <table class="p-snapcraft-dispute-list">
+          <tbody>
+            {% for snap in registered_snaps|sort %}
+              <tr class="p-snapcraft-dispute-list__item{% if registered_snaps[snap].status != "Approved" %} p-snapcraft-dispute-list__item--warning{% endif %}">
+                <td width="25%">
+                  <i class="p-icon--warning p-snapcraft-dispute-list__icon"></i>
+                  {{ snap }}
+                </td>
+                <td>
+                  {% if registered_snaps[snap].status == "DisputePending" %}
+                    Snap name disputed
+                  {% else %}
+                    <a href="https://docs.snapcraft.io/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float--right">Publish to this name</a>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </section>
   {% endif %}

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -24,7 +24,7 @@ My published snaps — Linux software in the Snap Store
   <div class="row">
     <div class="col-12">
       <h1 class="p-heading--four u-float--left">My published snaps</h1>
-      <a href="/account/register-snap" class="p-button--neutral u-float--right p-snap-list__register">Register a snap name</a>
+      <a href="/account/register-snap" class="p-button--neutral u-float--right p-snap-list__register u-no-margin--top">Register a snap name</a>
     </div>
   </div>
   {% if not snaps %}
@@ -132,6 +132,12 @@ My published snaps — Linux software in the Snap Store
                   {% endif %}
                   <span class="p-snap-list__name">
                     {{snap}}
+                    {% if snaps[snap].status == "DisputePending" %}
+                      &nbsp;<span class="p-tooltip p-tooltip--btm-center" aria-describedby="{{ snap }}-dispute-pending">
+                        <i class="p-icon--warning"></i>
+                        <span class="p-tooltip__message" role="tooltip" id="{{ snap }}-dispute-pending">Name being disputed</span>
+                      </span>
+                    {% endif %}
                   </span>
                 </a>
               </td>
@@ -172,17 +178,19 @@ My published snaps — Linux software in the Snap Store
         <h4 class="p-heading--five">Registered names ({{ registered_snaps|count }})</h4>
       </div>
       <div class="row">
-        <table class="p-snapcraft-dispute-list">
+        <table>
           <tbody>
             {% for snap in registered_snaps|sort %}
-              <tr class="p-snapcraft-dispute-list__item{% if registered_snaps[snap].status != "Approved" %} p-snapcraft-dispute-list__item--warning{% endif %}">
+              <tr class="p-snapcraft-dispute-list__item">
                 <td width="25%">
-                  <i class="p-icon--warning p-snapcraft-dispute-list__icon"></i>
+                  {% if registered_snaps[snap].status == "DisputePending" %}
+                    <i class="p-icon--warning p-snapcraft-dispute-list__icon"></i>&nbsp;
+                  {% endif %}
                   {{ snap }}
                 </td>
                 <td>
                   {% if registered_snaps[snap].status == "DisputePending" %}
-                    Snap name disputed
+                    <span class="p-snapcraft-dispute-list__muted">(Snap name disputed)</span>
                   {% else %}
                     <a href="https://docs.snapcraft.io/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float--right">Publish to this name</a>
                   {% endif %}

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -122,50 +122,54 @@ My published snaps — Linux software in the Snap Store
         </thead>
         <tbody>
           {% for snap in snaps|sort %}
-            <tr>
-              <td>
-                <a href="/account/snaps/{{snap}}/listing" class="u-vertically-center">
-                  {% if snaps[snap].icon_url %}
-                    <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
-                  {% else %}
-                    <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" class="p-snap-list__image" />
-                  {% endif %}
-                  <span class="p-snap-list__name">
-                    {{snap}}
-                    {% if snaps[snap].status == "DisputePending" %}
-                      &nbsp;<span class="p-tooltip p-tooltip--btm-center" aria-describedby="{{ snap }}-dispute-pending">
-                        <i class="p-icon--warning"></i>
-                        <span class="p-tooltip__message" role="tooltip" id="{{ snap }}-dispute-pending">Name being disputed</span>
-                      </span>
+            {% with %}
+              {% set dispute_pending = snaps[snap].status == "DisputePending" %}
+              {% set published = snaps[snap].status == "Published" %}
+              <tr>
+                <td>
+                  <a href="/account/snaps/{{snap}}/listing" class="u-vertically-center">
+                    {% if snaps[snap].icon_url %}
+                      <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
+                    {% else %}
+                      <img src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" class="p-snap-list__image" />
                     {% endif %}
-                  </span>
-                </a>
-              </td>
-              <td>
-                {% if snaps[snap].private %}
-                  Private
+                    <span class="p-snap-list__name">
+                      {{snap}}
+                      {% if dispute_pending %}
+                        &nbsp;<span class="p-tooltip p-tooltip--btm-center" aria-describedby="{{ snap }}-dispute-pending">
+                          <i class="p-icon--warning"></i>
+                          <span class="p-tooltip__message" role="tooltip" id="{{ snap }}-dispute-pending">Name being disputed</span>
+                        </span>
+                      {% endif %}
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  {% if snaps[snap].private %}
+                    Private
+                  {% else %}
+                    Public
+                  {% endif %}
+                </td>
+                <td>
+                  {% if snaps[snap].publisher.username == current_user %}
+                    You
+                  {% else %}
+                    {{ snaps[snap].publisher['display-name'] }}
+                  {% endif %}
+                </td>
+                {% if published %}
+                  <td>{{ snaps[snap].latest_revisions[0].channels[0] }}</td>
                 {% else %}
-                  Public
+                  <td>Not released</td>
                 {% endif %}
-              </td>
-              <td>
-                {% if snaps[snap].publisher.username == current_user %}
-                  You
-                {% else %}
-                  {{ snaps[snap].publisher['display-name'] }}
-                {% endif %}
-              </td>
-              {% if snaps[snap].latest_revisions[0].status == 'Published' %}
-                <td>{{ snaps[snap].latest_revisions[0].channels[0] }}</td>
-              {% else %}
-                <td>Not released</td>
-              {% endif %}
-              <td>
-                <a href="/{{snap}}/releases">
-                  {{ snaps[snap].latest_revisions[0].version }}
-                </a>
-              </td>
-            </tr>
+                <td>
+                  <a href="/{{snap}}/releases">
+                    {{ snaps[snap].latest_revisions[0].version }}
+                  </a>
+                </td>
+              </tr>
+            {% endwith %}
           {% endfor %}
         </tbody>
       </table>
@@ -181,21 +185,23 @@ My published snaps — Linux software in the Snap Store
         <table>
           <tbody>
             {% for snap in registered_snaps|sort %}
-              <tr class="p-snapcraft-dispute-list__item">
-                <td width="25%">
-                  {% if registered_snaps[snap].status == "DisputePending" %}
-                    <i class="p-icon--warning p-snapcraft-dispute-list__icon"></i>&nbsp;
-                  {% endif %}
-                  {{ snap }}
-                </td>
-                <td>
-                  {% if registered_snaps[snap].status == "DisputePending" %}
-                    <span class="p-snapcraft-dispute-list__muted">(Snap name disputed)</span>
-                  {% else %}
-                    <a href="https://docs.snapcraft.io/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float--right">Publish to this name</a>
-                  {% endif %}
-                </td>
-              </tr>
+              {% with dispute_pending = registered_snaps[snap].status == "DisputePending" %}
+                <tr class="p-snapcraft-dispute-list__item">
+                  <td width="25%">
+                    {{ snap }}
+                    {% if dispute_pending %}
+                      &nbsp;<i class="p-icon--warning p-snapcraft-dispute-list__icon"></i>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if dispute_pending %}
+                      <span class="p-snapcraft-dispute-list__muted">(Snap name disputed)</span>
+                    {% else %}
+                      <a href="https://docs.snapcraft.io/releasing-your-app" target="_blank" class="p-link--external p-snapcraft-dispute-list__link u-float--right">Publish to this name</a>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endwith %}
             {% endfor %}
           </tbody>
         </table>


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snap-squad/issues/921

# USE STAGING API'S IF YOU'RE GOING TO CREATE SOME DISPUTES

Implemented as per:
![screenshot 2019-03-06 at 11 04 01 am](https://user-images.githubusercontent.com/479384/53900289-1e292200-4034-11e9-996d-a0c9dad09a7e.png)

# USE STAGING API'S IF YOU'RE GOING TO CREATE SOME DISPUTES

## QA
- Pull the branch
# USE STAGING API'S IF YOU'RE GOING TO CREATE SOME DISPUTES
- `./run`
- Visit http://0.0.0.0:8004/snaps
- If you have disputed names, they should be displayed as red with a warning icon
- Other registered snaps (unpublished) should be shown, hovering over the row should show a link to documentation

# USE STAGING API'S IF YOU'RE GOING TO CREATE SOME DISPUTES

## Screenshot
![screenshot_2019-03-06 my published snaps linux software in the snap store 1](https://user-images.githubusercontent.com/479384/53899946-482e1480-4033-11e9-9f0b-49662d2a7254.png)

# USE STAGING API'S IF YOU'RE GOING TO CREATE SOME DISPUTES
