### PR TITLE
Embedded screenshot

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -41,3 +41,8 @@ body {
     width: calc(100% - 1px);
   }
 }
+
+.p-store-badge--right {
+  float: right;
+  margin-left: $sph-intra;
+}

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -30,6 +30,8 @@
       <div class="col-7" id="js-options">
           <input type="checkbox" name="show-summary" id="option-show-summary">
           <label for="option-show-summary">Show summary</label>
+          <input type="checkbox" name="show-screenshot" id="option-show-screenshot">
+          <label for="option-show-screenshot">Show screenshot</label>
       </div>
     </div>
   </div>
@@ -54,7 +56,7 @@
     </div>
     <div class="col-7">
       <div class="p-code-copyable">
-        <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded?button=black" frameborder="0" width="100%" height="320px" style="border: 1px solid" &gt;&lt;/iframe&gt;</code>
+        <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded?button=black" frameborder="0" width="100%" height="320px" style="border: 1px solid #CCC; border-radius: 2px;" &gt;&lt;/iframe&gt;</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
       </div>
     </div>

--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -30,7 +30,7 @@
       <div class="col-7" id="js-options">
           <input type="checkbox" name="show-summary" id="option-show-summary">
           <label for="option-show-summary">Show summary</label>
-          <input type="checkbox" name="show-screenshot" id="option-show-screenshot">
+          <input type="checkbox" name="show-screenshot" id="option-show-screenshot" {% if not has_screenshot %}disabled{%endif%}>
           <label for="option-show-screenshot">Show screenshot</label>
       </div>
     </div>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -27,6 +27,15 @@
   </div>
 </div>
 
+{% if show_screenshot and screenshots[0] %}
+<div class="p-strip is-shallow">
+  <div class="row">
+  {% set screenshot = screenshots[0] %}
+  {% include "partials/_snap-screenshot.html" %}
+  </div>
+</div>
+{% endif %}
+
 {% if button or show_summary %}
 <div class="p-strip is-shallow">
   <div class="row">

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -40,7 +40,7 @@
 <div class="p-strip is-shallow">
   <div class="row">
     {% if button %}
-    <div class="{%if show_summary %}u-float--right{% endif %}">
+    <div class="{%if show_summary %}p-store-badge--right{% endif %}">
       <a href="https://snapcraft.io/{{ package_name }}">
         <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
       </a>

--- a/tests/publisher/snaps/tests_publicise_cards.py
+++ b/tests/publisher/snaps/tests_publicise_cards.py
@@ -35,7 +35,7 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         self.check_call_by_api_url(responses.calls)
 
-        assert response.status_code == 404
+        self.assertEqual(response.status_code, 404)
         self.assert_template_used("404.html")
 
     @responses.activate
@@ -48,6 +48,7 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "private": False,
             "snap_name": snap_name,
             "keywords": [],
+            "media": [],
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -56,12 +57,37 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         self.check_call_by_api_url(responses.calls)
 
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)
         self.assert_template_used("publisher/publicise/embedded_cards.html")
 
         self.assert_context("snap_id", "id")
         self.assert_context("snap_title", "test snap")
         self.assert_context("snap_name", snap_name)
+        self.assert_context("has_screenshot", False)
+
+    @responses.activate
+    def test_publicise_snap_with_screenshot(self):
+        snap_name = "test-snap"
+
+        payload = {
+            "snap_id": "id",
+            "title": "test snap",
+            "private": False,
+            "snap_name": snap_name,
+            "keywords": [],
+            "media": [{"url": "this is a url", "type": "screenshot"}],
+        }
+
+        responses.add(responses.GET, self.api_url, json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used("publisher/publicise/embedded_cards.html")
+
+        self.assert_context("has_screenshot", True)
 
     @responses.activate
     def test_publicise_private_snap(self):
@@ -73,6 +99,7 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "private": True,
             "snap_name": snap_name,
             "keywords": [],
+            "media": [],
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)
@@ -81,5 +108,5 @@ class GetPubliciseCardsPage(BaseTestCases.EndpointLoggedInErrorHandling):
 
         self.check_call_by_api_url(responses.calls)
 
-        assert response.status_code == 404
+        self.assertEqual(response.status_code, 404)
         self.assert_template_used("404.html")

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1031,7 +1031,12 @@ def get_publicise_cards(snap_name):
     if snap_details["private"]:
         return flask.abort(404, "No snap named {}".format(snap_name))
 
+    screenshots = filter_screenshots(snap_details["media"])
+    has_screenshot = True if screenshots else False
+
     context = {
+        "details": snap_details,
+        "has_screenshot": has_screenshot,
         "snap_name": snap_details["snap_name"],
         "snap_title": snap_details["title"],
         "snap_id": snap_details["snap_id"],

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -254,6 +254,7 @@ def snap_details_views(store, api, handle_errors):
             {
                 "button": button,
                 "show_summary": flask.request.args.get("summary"),
+                "show_screenshot": flask.request.args.get("screenshot"),
             }
         )
 


### PR DESCRIPTION
Fixes #1605 

Adds screenshot to embeddable card.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1657.run.demo.haus/
- go to Publicise page of any snap (with a screenshot), Embeddable card section
- 'Show screenshot' option should be available
- Click on it, screenshot should appear in preview, height of frame should adapt, code should adapt to show screenshot
- Copy the code (change "snapcraft.io" in URL to demo URL: https://snapcraft-io-canonical-websites-pr-1657.run.demo.haus/) , try if it creates proper card
- go to Publicise page of any snap (without a screenshot), Embeddable card section
- 'Show screenshot' checkbox should be disabled

<img width="822" alt="screenshot 2019-03-07 at 13 28 56" src="https://user-images.githubusercontent.com/83575/53956825-fa6de680-40dc-11e9-918a-75c40cc6c4db.png">
