### PR TITLE
Add optional channel map to embeddable card

### DIFF
--- a/templates/publisher/publicise/embedded_cards.html
+++ b/templates/publisher/publicise/embedded_cards.html
@@ -28,9 +28,11 @@
         Options:
       </div>
       <div class="col-7" id="js-options">
-          <input type="checkbox" name="show-summary" id="option-show-summary">
+          <input type="checkbox" name="show-channels" id="option-show-channels" checked>
+          <label for="option-show-channels">Show all channels</label>
+          <input type="checkbox" name="show-summary" id="option-show-summary" checked>
           <label for="option-show-summary">Show summary</label>
-          <input type="checkbox" name="show-screenshot" id="option-show-screenshot" {% if not has_screenshot %}disabled{%endif%}>
+          <input type="checkbox" name="show-screenshot" id="option-show-screenshot" {% if not has_screenshot %}disabled{% else %}checked{% endif %}>
           <label for="option-show-screenshot">Show screenshot</label>
       </div>
     </div>
@@ -43,7 +45,7 @@
     <div class="col-7">
       <iframe id="embedded-card-frame"
         class="snapcraft-publicise__embedded-frame"
-        src="/{{snap_name}}/embedded?button=black"
+        src="/{{snap_name}}/embedded?button=black&channels=true&summary=true&screenshot=true"
         width="100%" height="320px"
         frameborder="0" style="border: 1px solid #CCC; border-radius: 2px;">
       </iframe>
@@ -56,7 +58,7 @@
     </div>
     <div class="col-7">
       <div class="p-code-copyable">
-        <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded?button=black" frameborder="0" width="100%" height="320px" style="border: 1px solid #CCC; border-radius: 2px;" &gt;&lt;/iframe&gt;</code>
+        <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ snap_name }}/embedded?button=black&channels=true&summary=true&screenshot=true" frameborder="0" width="100%" height="320px" style="border: 1px solid #CCC; border-radius: 2px;" &gt;&lt;/iframe&gt;</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
       </div>
     </div>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -60,8 +60,29 @@
 
 <div class="p-strip is-shallow">
   <div class="row">
-    <p>{{ default_track }}/{{ lowest_risk_available }} {{ version }}</p>
-    <p><small>Published {{ last_updated }}</small></p>
+    {% if show_channels %}
+      <table>
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Version</th>
+            <th width="25%">Published</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for release in channel_map[default_architecture][default_track] %}
+          <tr>
+            <td>{% if default_track == "latest"%}{{ default_track }}/{% endif %}{{ release.channel }}</td>
+            <td>{{ release.version }}</td>
+            <td>{{ release["created-at"] }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>{{ default_track }}/{{ lowest_risk_available }} {{ version }}</p>
+      <p><small>Published {{ last_updated }}</small></p>
+    {% endif %}
   </div>
 </div>
 {% endblock content %}

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -66,7 +66,7 @@
           <tr>
             <th>Channel</th>
             <th>Version</th>
-            <th width="25%">Published</th>
+            <th width="33%">Published</th>
           </tr>
         </thead>
         <tbody>

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -250,9 +250,15 @@ def snap_details_views(store, api, handle_errors):
         if button and button not in button_variants:
             button = "black"
 
+        architectures = context["channel_map"].keys()
+
         context.update(
             {
+                "default_architecture": (
+                    "amd64" if "amd64" in architectures else architectures[0]
+                ),
                 "button": button,
+                "show_channels": flask.request.args.get("channels"),
                 "show_summary": flask.request.args.get("summary"),
                 "show_screenshot": flask.request.args.get("screenshot"),
             }


### PR DESCRIPTION
Fixes #1603

Add option to show/hide all channels in embeddable card

## QA

- ./run or https://snapcraft-io-canonical-websites-pr-1665.run.demo.haus/
- go to Publicise page of any snap
- 'Show all channels' option should be available
- All options should be checked by default
- Uncheck 'Show all channels', channel map should be removed from preview (replaced with version name)
- Try different configurations of options, make sure they work as expected

<img width="1029" alt="screenshot 2019-03-08 at 15 55 49" src="https://user-images.githubusercontent.com/83575/54035902-ab967e80-41ba-11e9-8a23-d5ad923e6a35.png">
