### PR TITLE
Improve responsive styles for embedded card

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -42,7 +42,18 @@ body {
   }
 }
 
-.p-store-badge--right {
-  float: right;
-  margin-left: $sph-intra;
+// responsive styles for summary + badge
+@media screen and (min-width: $breakpoint-x-small) {
+  .p-embedded-description {
+    display: flex;
+  }
+
+  .p-embedded-description__summary {
+    flex-grow: 1;
+    margin-right: $sph-intra;
+  }
+
+  .p-embedded-description__badge {
+    flex-shrink: 0;
+  }
 }

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -39,17 +39,18 @@
 {% if button or show_summary %}
 <div class="p-strip is-shallow">
   <div class="row">
-    {% if button %}
-    <div class="{%if show_summary %}p-store-badge--right{% endif %}">
-      <a href="https://snapcraft.io/{{ package_name }}">
-        <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
-      </a>
+    <div class="p-embedded-description">
+      {% if show_summary %}
+        <h4 class="p-embedded-description__summary">{{ summary }}</h4>
+      {% endif %}
+      {% if button %}
+      <div class="p-embedded-description__badge">
+        <a href="https://snapcraft.io/{{ package_name }}">
+          <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
+        </a>
+      </div>
+      {% endif %}
     </div>
-    {% endif %}
-
-    {% if show_summary %}
-      <h4 class="u-no-margin--bottom">{{ summary }}</h4>
-    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
Fixes #1667

Improves responsive layout of embedded card (makes the store badge drop to own row on small screens)

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1676.run.demo.haus/
- open embedded card of some snap (with summary and store badge): https://snapcraft-io-canonical-websites-pr-1676.run.demo.haus/skype/embedded?summary=true&button=black
- make sure store badge appears below summary on small screens
- try out different display options on Publicise page, make sure all of them look fine

<img width="439" alt="Screenshot 2019-03-11 at 14 39 28" src="https://user-images.githubusercontent.com/83575/54130183-358b5500-4410-11e9-8579-554a73ac6d48.png">


