### PR TITLE
Update home page banner to new slanted strip design

### DIFF
--- a/static/sass/_patterns_strip_slanted.scss
+++ b/static/sass/_patterns_strip_slanted.scss
@@ -1,0 +1,55 @@
+// based on https://github.com/vanilla-framework/vanilla-framework/pull/2051
+
+@mixin p-strip-slanted {
+  $horizontal-edge-padding: $spv-inter--regular-scaleable;
+  $slanted-edge-padding: $horizontal-edge-padding * 2; // coloured area takes half the rectangle surface area; to visually compensate, we multiply it by 2
+  $bleed: -3px; // stretch outside to compensate for aliasing; otherwise edge of image underneath becomes visible as you resize
+
+  %vf-strip-slanted {
+    background-position: 50% 50%;
+    margin-top: $bleed;
+    overflow: hidden;
+    position: relative;
+
+    @media (max-width: $breakpoint-large) {
+      background-size: cover;
+      padding: $spv-inter--regular-scaleable 0 $slanted-edge-padding;
+    }
+    @media (min-width: $breakpoint-large) {
+      background-size: 5000px 667px; // actual svg size
+      padding: $spv-inter--regular-scaleable 0 $slanted-edge-padding;
+    }
+
+    &::after {
+      background-position: 100% 100%;
+      background-repeat: no-repeat;
+      bottom: $bleed;
+      content: '';
+      left: $bleed;
+      pointer-events: none; // keep the content underneath it interactive
+      position: absolute;
+      right: $bleed;
+      top: $bleed;
+      z-index: 1;
+
+      @media only screen and (max-width: $breakpoint-large) {
+        background-size: auto $slanted-edge-padding;
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        background-size: 100%;
+      }
+    }
+  }
+
+  .p-strip-slanted--snapcraft {
+    @extend %vf-strip;
+    @extend %vf-strip-slanted;
+    background-image: url('#{$assets-path}a3c29307-hero-bg-snapcraft-1--nowhite.svg');
+    color: $color-light;
+
+    &::after {
+      background-image: url('#{$assets-path}077b5e59-hero-bg-mask-snapcraft--white-orange--bigger-accent.svg');
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -210,6 +210,9 @@ $color-navigation-background: #252525;
 @import 'patterns_modal';
 @include vf-p-modal-snapcraft;
 
+@import 'patterns_strip_slanted';
+@include p-strip-slanted;
+
 html,
 body {
   background: $color-x-light; // This will be fix on vanilla https://github.com/vanilla-framework/vanilla-framework/issues/2129

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1_uwPkHmAgV6_uE9ISqIgXjZGJxXPBD90vdeO95h7ikE/edit{% endblock %}
 
 {% block content %}
-<div id="main-content" class="p-strip--image snapcraft-banner-background">
+<div id="main-content" class="p-strip-slanted--snapcraft">
   <h1 class="u-off-screen">Snapcraft</h1>
   <div class="row">
     {% if nps %}


### PR DESCRIPTION
Fixes #1391 

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1677.run.demo.haus/
- go to store home page
- enjoy brand new slanted strip design
- compare with [design](https://user-images.githubusercontent.com/2741678/48841400-3fb61480-ed89-11e8-81ea-fae097442164.png)
- play with different screen sizes to make sure it works nice
- check in different browsers

<img width="1130" alt="Screenshot 2019-03-11 at 16 46 57" src="https://user-images.githubusercontent.com/83575/54137206-7f2e6c80-441d-11e9-9ab5-1bfa0bfb1215.png">
<img width="421" alt="Screenshot 2019-03-11 at 16 47 25" src="https://user-images.githubusercontent.com/83575/54137205-7e95d600-441d-11e9-9e36-b9d4cd7b508b.png">
