### PR TITLE
Allow removing of snap icon

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -19,7 +19,14 @@ const IS_CHROMIUM =
   typeof window.chrome !== "undefined" &&
   window.navigator.userAgent.indexOf("Edge") === -1; // Edge pretends to have window.chrome
 
-function initSnapIconEdit(changeIcon, removeIcon, iconId, iconInputId, state) {
+function initSnapIconEdit(
+  changeIcon,
+  removeIcon,
+  iconId,
+  iconInputId,
+  state,
+  updateFormState
+) {
   const snapIconEl = document.getElementById(iconId);
   const snapIconInput = document.getElementById(iconInputId);
   const changeIconEl = document.querySelector(changeIcon);
@@ -41,6 +48,7 @@ function initSnapIconEdit(changeIcon, removeIcon, iconId, iconInputId, state) {
     });
 
     updateState(state, { images });
+    snapIconEl.classList.remove("u-hide");
     removeIconEl.classList.remove("u-hide");
   });
 
@@ -56,9 +64,10 @@ function initSnapIconEdit(changeIcon, removeIcon, iconId, iconInputId, state) {
 
     const images = state.images.filter(image => image.type !== "icon");
 
-    updateState(state, { images });
-
     snapIconInput.value = "";
+    updateState(state, { images });
+    updateFormState();
+    snapIconEl.classList.add("u-hide");
     removeIconEl.classList.add("u-hide");
   });
 
@@ -157,7 +166,8 @@ function initForm(config, initialState, errors) {
       config.snapIconRemove,
       config.snapIcon,
       config.snapIconInput,
-      state
+      state,
+      updateFormState
     );
   }
 

--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -19,9 +19,11 @@ const IS_CHROMIUM =
   typeof window.chrome !== "undefined" &&
   window.navigator.userAgent.indexOf("Edge") === -1; // Edge pretends to have window.chrome
 
-function initSnapIconEdit(iconElId, iconInputId, state) {
+function initSnapIconEdit(changeIcon, removeIcon, iconId, iconInputId, state) {
+  const snapIconEl = document.getElementById(iconId);
   const snapIconInput = document.getElementById(iconInputId);
-  const snapIconEl = document.getElementById(iconElId);
+  const changeIconEl = document.querySelector(changeIcon);
+  const removeIconEl = document.querySelector(removeIcon);
 
   snapIconInput.addEventListener("change", function() {
     const iconFile = this.files[0];
@@ -39,11 +41,30 @@ function initSnapIconEdit(iconElId, iconInputId, state) {
     });
 
     updateState(state, { images });
+    removeIconEl.classList.remove("u-hide");
   });
 
-  snapIconEl.addEventListener("click", function() {
+  changeIconEl.addEventListener("click", function(e) {
+    e.preventDefault();
     snapIconInput.click();
   });
+
+  removeIconEl.addEventListener("click", function(e) {
+    e.preventDefault();
+    snapIconEl.src = "";
+    snapIconEl.alt = "";
+
+    const images = state.images.filter(image => image.type !== "icon");
+
+    updateState(state, { images });
+
+    snapIconInput.value = "";
+    removeIconEl.classList.add("u-hide");
+  });
+
+  if (state.images.filter(image => image.type === "icon").length > 0) {
+    removeIconEl.classList.remove("u-hide");
+  }
 }
 
 function initFormNotification(formElId, notificationElId) {
@@ -130,8 +151,14 @@ function initForm(config, initialState, errors) {
 
   formEl.appendChild(diffInput);
 
-  if (config.snapIconImage && config.snapIconInput) {
-    initSnapIconEdit(config.snapIconImage, config.snapIconInput, state);
+  if (config.snapIconRemove && config.snapIcon && config.snapIconInput) {
+    initSnapIconEdit(
+      config.snapIconChange,
+      config.snapIconRemove,
+      config.snapIcon,
+      config.snapIconInput,
+      state
+    );
   }
 
   initFormNotification(config.form, config.formNotification);

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -55,7 +55,8 @@ describe("initSnapIconEdit", () => {
       ".js-remove-icon",
       "test-icon-id",
       "test-id",
-      state
+      state,
+      () => {}
     );
 
     let event = new Event("change");
@@ -71,12 +72,14 @@ describe("initSnapIconEdit", () => {
   });
 
   test("should remove icon when clicked", () => {
+    const cb = jest.fn();
     market.initSnapIconEdit(
       ".js-change-icon",
       ".js-remove-icon",
       "test-icon-id",
       "test-id",
-      state
+      state,
+      cb
     );
 
     let event = new Event("change");
@@ -91,6 +94,7 @@ describe("initSnapIconEdit", () => {
 
     expect(icon.src).toBe("");
     expect(removeBtn.classList.contains("u-hide")).toEqual(true);
+    expect(cb.mock.calls.length).toEqual(1);
   });
 
   test("should show the remove icon when icon is set", () => {
@@ -104,7 +108,8 @@ describe("initSnapIconEdit", () => {
       ".js-remove-icon",
       "test-icon-id",
       "test-id",
-      state
+      state,
+      () => {}
     );
 
     expect(removeBtn.classList.contains("u-hide")).toEqual(false);

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -14,43 +14,90 @@
   .p-editable-icon {
     $white-overlay-color: rgba(255, 255, 255, .5);
     $black-overlay-color: rgba(0, 0, 0, .5);
-
+    $white-overlay-strong-color: rgba(255, 255, 255, .9);
+    border: 1px solid $color-mid-light;
     cursor: pointer;
+    display: inline-block;
+    margin-bottom: $sph-inter;
+    margin-right: $sph-inter;
     position: relative;
 
-    img {
-      height: 100%;
-      width: 100%;
-    }
-
-    &::after {
-      background: transparent;
-      border-radius: 50%;
-      bottom: 0;
-      box-shadow: 0 0 0 20px $white-overlay-color;
-      content: "";
-      left: 0;
-      pointer-events: none;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-
-    &::before {
-      background: $black-overlay-color;
-      background-image: url('#{$assets-path}e90af3d3-edit-icon-white.svg');
-      background-position: 50% 50%;
+    .p-editable-icon__icon {
+      @include vf-icon-plus(007aa6);
+      background-position: center;
       background-repeat: no-repeat;
-      border-radius: 0 0 100px 100px; // radius has to be in px to create half circle
-      bottom: 0;
-      content: "";
-      display: block;
-      left: 0;
-      pointer-events: none;
-      position: absolute;
-      right: 0;
-      top: 50%;
+      background-size: 1rem;
+      height: 60px;
+      overflow: hidden;
+      position: relative;
+      width: 60px;
+
+      &::after {
+        background: transparent;
+        border-radius: 50%;
+        bottom: 0;
+        box-shadow: 0 0 0 20px $white-overlay-color;
+        content: "";
+        left: 0;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      img {
+        background: $color-x-light;
+        height: 100%;
+        width: 100%;
+
+        &[src=""] {
+          display: none;
+        }
+      }
+
+      .p-editable-icon__change {
+        align-items: center;
+        background: $white-overlay-strong-color;
+        bottom: 0;
+        color: $color-link;
+        display: flex;
+        justify-content: center;
+        left: 0;
+        opacity: 0;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      &:hover img:not([src=""]) + .p-editable-icon__change {
+        opacity: 1;
+      }
     }
+
+    &:hover {
+      border-color: $color-link;
+    }
+
+    &__label {
+      line-height: 60px;
+      padding-top: .25rem;
+    }
+  }
+
+  .p-editable-icon__actions {
+    display: block;
+    float: left;
+  }
+
+  .p-editable-icon__delete {
+    align-items: center;
+    display: flex;
+    height: 2rem;
+    justify-content: center;
+    margin-bottom: .5rem;
+    margin-left: -1rem;
+    width: 2rem;
   }
 
   // Stick the Revert, Apply buttons to the top

--- a/static/sass/_snapcraft_market.scss
+++ b/static/sass/_snapcraft_market.scss
@@ -32,27 +32,10 @@
       position: relative;
       width: 60px;
 
-      &::after {
-        background: transparent;
-        border-radius: 50%;
-        bottom: 0;
-        box-shadow: 0 0 0 20px $white-overlay-color;
-        content: "";
-        left: 0;
-        pointer-events: none;
-        position: absolute;
-        right: 0;
-        top: 0;
-      }
-
       img {
         background: $color-x-light;
         height: 100%;
         width: 100%;
-
-        &[src=""] {
-          display: none;
-        }
       }
 
       .p-editable-icon__change {

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -100,12 +100,8 @@
           <div class="col-8 u-vertically-center">
             <div class="p-editable-icon">
               <div class="p-editable-icon__icon js-change-icon">
-                <img id="snap_icon_image"
-                     {% if icon_url %}
+                <img id="snap_icon_image"{% if not icon_url %} class="u-hide"{% endif %}
                      src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %} snap"
-                     {% else %}
-                     src="" alt=""
-                     {% endif %}
                 />
                 <span class="p-editable-icon__change">Edit</span>
               </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -95,19 +95,33 @@
 
         <div class="row" data-validation-name="icon">
           <div class="col-2">
-            <div class="p-media-object__image--large p-editable-icon">
-              <img id="snap_icon_image"
-                {% if icon_url %}
-                  src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %} snap"
-                {% else %}
-                  src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt=""
-                {% endif %}
-              />
+            <label class="p-editable-icon__label" for="snap_icon">Snap icon:</label>
+          </div>
+          <div class="col-8 u-vertically-center">
+            <div class="p-editable-icon">
+              <div class="p-editable-icon__icon js-change-icon">
+                <img id="snap_icon_image"
+                     {% if icon_url %}
+                     src="{{ icon_url }}" alt="{% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %} snap"
+                     {% else %}
+                     src="" alt=""
+                     {% endif %}
+                />
+                <span class="p-editable-icon__change">Edit</span>
+              </div>
             </div>
+            <div class="p-editable-icon__actions">
+              <a class="p-editable-icon__delete js-remove-icon u-hide"><i class="p-icon--delete"></i></a>
+            </div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-2">
+            <label for="snap-title">Title:</label>
           </div>
           <div class="col-8">
             <div class="p-form-validation {% if field_errors and field_errors['title'] %}is-error{% endif %}">
-              <label for="snap-title">Title:</label>
               <div class="p-form-validation__field">
                 <input class="p-form-validation__input" id="snap-title" type="text" name="title" value="{{ snap_title }}" required maxlength="64"/>
               </div>
@@ -507,7 +521,9 @@
   Raven.context(function () {
     snapcraft.publisher.initMultiselect('.js-license', {{ licenses|tojson }}, ' OR ');
     snapcraft.publisher.market.initForm({
-      snapIconImage: "snap_icon_image",
+      snapIconChange: ".js-change-icon",
+      snapIconRemove: ".js-remove-icon",
+      snapIcon: "snap_icon_image",
       snapIconInput: "snap_icon",
       form: "market-form",
       formNotification: "market-form-status",


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1682

## Done

- New layout (label to the left)
- Added "Change" button (rather then clicking on the image)
- Made the image slightly bigger - why not?
- Added a "Remove" button

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_name>/listing
- Add remove an icon, reload the page etc.
- See that it works as expected