### PR TITLE
Don't break if total not set

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -51,7 +51,11 @@
           <a href="/store">&lsaquo; Categories</a>
           <h2>{{ category_display }} snaps</h2>
         {% else %}
-          <h2>We’ve found {{ total }} snaps</h2>
+          {% if total %}
+            <h2>We’ve found {{ total }} snaps</h2>
+          {% else %}
+            <h2>We’ve found some snaps</h2>
+          {% endif %}
         {% endif %}
       </div>
       <div class="row">

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -152,7 +152,10 @@ def store_blueprint(store_query=None, testing=False):
         except ApiError as api_error:
             status_code, error_info = _handle_errors(api_error)
 
-        total_results_count = searched_results["total"]
+        if "total" in searched_results:
+            total_results_count = searched_results["total"]
+        else:
+            total_results_count = None
 
         snaps_results = logic.get_searched_snaps(searched_results)
         links = logic.get_pages_details(


### PR DESCRIPTION
## Issue

The store api doesn't send the "total" number of results when searching by publisher ID, so breaks the template.

## QA

- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/search?category=&q=publisher%3A28zEonXNoBLvIB7xneRbltOsp0Nf7DwS
- See snaps :+1: 