### PR TITLE
Update to new markdown requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # App dependencies
-bleach==2.0.0
+bleach==3.1.0
 Flask==1.0.2
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # App dependencies
-bleach==3.1.0
+bleach==2.0.0
 Flask==1.0.2
 Flask-OpenID-Stateless==1.2.6
 Flask-WTF==0.14.2

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -291,7 +291,7 @@
                   <b>Italics:</b> <code>__Foo__</code>
                 </small></p>
                 <p><small>
-                  <b>Code:</b> Text indented with 4 spaces or inside <code>`</code>
+                  <b>Code:</b> Text indented with 3 spaces or inside <code>`</code>
                 </small></p>
               </div>
             </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -291,10 +291,7 @@
                   <b>Italics:</b> <code>__Foo__</code>
                 </small></p>
                 <p><small>
-                  <b>Links:</b> <code>[foo bar](https://foo.bar)</code>
-                </small></p>
-                <p><small>
-                  <b>Code:</b> Text blocks inside <code>`</code> or <code>```</code> pairs
+                  <b>Code:</b> Text indented with 4 spaces or inside <code>`</code>
                 </small></p>
               </div>
             </div>

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -124,6 +124,15 @@ class TestMarkdownParser(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
+    def test_parse_code_block_multiple_line_tree_spaces(self):
+        """Code with three space indentation
+        """
+        markdown = "   code\n   code line 2"
+        result = parse_markdown_description(markdown)
+        expected_result = "<pre><code>code\ncode line 2\n</code></pre>\n"
+
+        self.assertEqual(result, expected_result)
+
     def test_parse_code_line(self):
         """Code (text blocks inside ` or ``` pairs)
         """

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -8,16 +8,6 @@ class TestMarkdownParser(unittest.TestCase):
     parser allows only a limited amount of tags. We want a lot of tests for
     it to make sure on upgrades we don't lose the custom tags that we want
     to keep.
-
-    List of approved markdown tag allowed:
-
-    * Code (text blocks inside ` or ``` pairs)
-    * Lists (* Foo)
-    * Italics (_foo_)
-    * Bold (**foo**)
-    * Paragraph merging (consecutive lines are joined)
-    * Literal URLs auto-link https://foo.bar
-    * URLs with title [title for the link](https://foo.bar)
     """
 
     def test_parse_title(self):
@@ -27,7 +17,7 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p># title</p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_urls(self):
         """Literal URLs auto-link https://foo.bar
@@ -38,16 +28,20 @@ class TestMarkdownParser(unittest.TestCase):
             '<p><a href="https://toto.space">https://toto.space</a></p>\n'
         )
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_urls_title(self):
         """URLs with title [title for the link](https://foo.bar)
         """
         markdown = "[toto](https://toto.space)"
         result = parse_markdown_description(markdown)
-        expected_result = '<p><a href="https://toto.space">toto</a></p>\n'
+        expected_result = (
+            "<p>"
+            '[toto](<a href="https://toto.space">https://toto.space</a>)'
+            "</p>\n"
+        )
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_italics(self):
         """Italics (_foo_)
@@ -56,7 +50,7 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p><em>text</em></p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_bold(self):
         """Bold (**foo**)
@@ -65,7 +59,7 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p><strong>text</strong></p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_paragraph_merging(self):
         """Paragraph merging (consecutive lines are joined)
@@ -74,7 +68,7 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p>this is\n a paragraph</p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_paragraph(self):
         """Paragraphs
@@ -83,7 +77,7 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p>paragraph 1</p>\n<p>paragraph 2</p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_text(self):
         """Text conversion works
@@ -92,16 +86,43 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p>text</p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
-    def test_parse_code_block(self):
-        """Code (text blocks inside ` or ``` pairs)
+    def test_parse_triple_fences(self):
+        """Code (text blocks inside  ``` pairs)
         """
         markdown = "```code block```"
         result = parse_markdown_description(markdown)
+        expected_result = "<p><code>``code block``</code></p>\n"
+
+        self.assertEqual(result, expected_result)
+
+    def test_parse_single_fences(self):
+        """Code (text blocks inside  ` pairs)
+        """
+        markdown = "`code block`"
+        result = parse_markdown_description(markdown)
         expected_result = "<p><code>code block</code></p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
+
+    def test_parse_code_block_single_line(self):
+        """Code with four space indentation
+        """
+        markdown = "    code"
+        result = parse_markdown_description(markdown)
+        expected_result = "<pre><code>code\n</code></pre>\n"
+
+        self.assertEqual(result, expected_result)
+
+    def test_parse_code_block_multiple_line(self):
+        """Code with four space indentation
+        """
+        markdown = "    code\n    code line 2"
+        result = parse_markdown_description(markdown)
+        expected_result = "<pre><code>code\ncode line 2\n</code></pre>\n"
+
+        self.assertEqual(result, expected_result)
 
     def test_parse_code_line(self):
         """Code (text blocks inside ` or ``` pairs)
@@ -110,7 +131,7 @@ class TestMarkdownParser(unittest.TestCase):
         result = parse_markdown_description(markdown)
         expected_result = "<p><code>code line</code></p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_list(self):
         """Lists (* Foo)
@@ -121,7 +142,7 @@ class TestMarkdownParser(unittest.TestCase):
             "<ul>\n<li>item </li>\n<li>item </li>\n<li>item </li>\n</ul>\n"
         )
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_list_special_char(self):
         """Lists (• Foo)
@@ -132,7 +153,7 @@ class TestMarkdownParser(unittest.TestCase):
             "<ul>\n<li>item </li>\n<li>item </li>\n<li>item </li>\n</ul>\n"
         )
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_list_ordered(self):
         """Lists (* Foo)
@@ -143,13 +164,13 @@ class TestMarkdownParser(unittest.TestCase):
             "<ol>\n<li>item </li>\n<li>item </li>\n<li>item </li>\n</ol>\n"
         )
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)
 
     def test_parse_image_link(self):
         """Image link is converted into a simple link
         """
         markdown = "![image](link.png)"
         result = parse_markdown_description(markdown)
-        expected_result = '<p>!<a href="link.png">image</a></p>\n'
+        expected_result = "<p>" + markdown + "</p>\n"
 
-        assert result == expected_result
+        self.assertEqual(result, expected_result)

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -107,9 +107,9 @@ class TestMarkdownParser(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_parse_code_block_single_line(self):
-        """Code with four space indentation
+        """Code with three space indentation
         """
-        markdown = "    code"
+        markdown = "   code"
         result = parse_markdown_description(markdown)
         expected_result = "<pre><code>code\n</code></pre>\n"
 
@@ -120,7 +120,7 @@ class TestMarkdownParser(unittest.TestCase):
         """
         markdown = "    code\n    code line 2"
         result = parse_markdown_description(markdown)
-        expected_result = "<pre><code>code\ncode line 2\n</code></pre>\n"
+        expected_result = "<pre><code> code\n code line 2\n</code></pre>\n"
 
         self.assertEqual(result, expected_result)
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -1,6 +1,7 @@
 from mistune import (
     BlockGrammar,
     BlockLexer,
+    InlineGrammar,
     Renderer,
     Markdown,
     _pure_pattern,
@@ -9,7 +10,7 @@ from mistune import (
 import re
 
 
-class DescriptionGrammar(BlockGrammar):
+class DescriptionBlockGrammar(BlockGrammar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -44,10 +45,9 @@ class DescriptionGrammar(BlockGrammar):
 
 
 class DescriptionBlock(BlockLexer):
-    grammar_class = DescriptionGrammar
+    grammar_class = DescriptionBlockGrammar
 
     default_rules = [
-        "fences",
         "block_code",
         "list_block",
         "paragraph",
@@ -55,14 +55,49 @@ class DescriptionBlock(BlockLexer):
         "newline",
     ]
 
-    list_rules = ("fences", "block_code", "list_block", "text", "newline")
+    list_rules = ("block_code", "list_block", "text", "newline")
+
+
+class DescriptionInlineGrammar(InlineGrammar):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Rewrite to respect this convention:
+        # https://github.com/CanonicalLtd/snap-squad/issues/936
+        self.code = re.compile(r"^(`)([\S ]+)\1")
 
 
 class DescriptionInline(InlineLexer):
-    def _process_link(self, m, link, title=None):
-        line = m.group(0)
-        if line[0] != "!":
-            return super()._process_link(m, link, title)
+    grammar_class = DescriptionInlineGrammar
+
+    # Removed rules: link, reflink
+    default_rules = [
+        "escape",
+        "inline_html",
+        "autolink",
+        "url",
+        "footnote",
+        "nolink",
+        "double_emphasis",
+        "emphasis",
+        "code",
+        "linebreak",
+        "strikethrough",
+        "text",
+    ]
+    inline_html_rules = [
+        "escape",
+        "inline_html",
+        "autolink",
+        "url",
+        "nolink",
+        "double_emphasis",
+        "emphasis",
+        "code",
+        "linebreak",
+        "strikethrough",
+        "text",
+    ]
 
 
 renderer = Renderer()

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -70,13 +70,11 @@ class DescriptionInlineGrammar(InlineGrammar):
 class DescriptionInline(InlineLexer):
     grammar_class = DescriptionInlineGrammar
 
-    # Removed rules: link, reflink
+    # Removed rules: inline_html, link, reflink
     default_rules = [
         "escape",
-        "inline_html",
         "autolink",
         "url",
-        "footnote",
         "nolink",
         "double_emphasis",
         "emphasis",
@@ -87,7 +85,6 @@ class DescriptionInline(InlineLexer):
     ]
     inline_html_rules = [
         "escape",
-        "inline_html",
         "autolink",
         "url",
         "nolink",

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -42,6 +42,7 @@ class DescriptionBlockGrammar(BlockGrammar):
             flags=re.M,
         )
         self.list_bullet = re.compile(r"^ *(?:[•*+-]|\d+\.) +")
+        self.block_code = re.compile(r"^( {3}[^\n]+\n*)+")
 
 
 class DescriptionBlock(BlockLexer):
@@ -56,6 +57,14 @@ class DescriptionBlock(BlockLexer):
     ]
 
     list_rules = ("block_code", "list_block", "text", "newline")
+
+    # Need to extend this function since I need to modify this
+    # https://github.com/lepture/mistune/blob/v0.8.4/mistune.py#L29
+    def parse_block_code(self, m):
+        # clean leading whitespace
+        block_code_leading_pattern = re.compile(r"^ {3}", re.M)
+        code = block_code_leading_pattern.sub("", m.group(0))
+        self.tokens.append({"type": "code", "lang": None, "text": code})
 
 
 class DescriptionInlineGrammar(InlineGrammar):

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1112,7 +1112,7 @@ def post_preview(snap_name):
     for item in state:
         if item == "description":
             context[item] = parse_markdown_description(
-                bleach.clean(state[item])
+                bleach.clean(state[item], tags=[])
             )
         else:
             context[item] = state[item]

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -54,7 +54,9 @@ def snap_details_views(store, api, handle_errors):
         if not details.get("channel-map"):
             flask.abort(404, "No snap named {}".format(snap_name))
 
-        clean_description = bleach.clean(details["snap"]["description"])
+        clean_description = bleach.clean(
+            details["snap"]["description"], tags=[]
+        )
         formatted_description = parse_markdown_description(clean_description)
 
         channel_maps_list = logic.convert_channel_maps(


### PR DESCRIPTION
# Summary

Fixes #1675 
Fixes #1693 

Update to latest version of markdown requirements.

- Remove links `[title](url)`
- Remove triple fences handling
- Keep four space for code blocks

# QA

- `./run`
- Modify description for snap and try to hack around with fences and links
- You can see the requirements for fences [here](https://github.com/canonical-websites/snapcraft.io/issues/1693)
