### PR TITLE
Add embedded card modal to snap details page

### DIFF
--- a/static/js/public/public.js
+++ b/static/js/public/public.js
@@ -3,6 +3,7 @@ import screenshots from "./snap-details/screenshots";
 import channelMap from "./snap-details/channelMap";
 import videos from "./snap-details/videos";
 import initReportSnap from "./snap-details/reportSnap";
+import initEmbeddedCardModal from "./snap-details/embeddedCard";
 import { snapDetailsPosts, seriesPosts } from "./snap-details/blog-posts";
 import { storeCategories } from "./store-categories";
 import { initFSFLanguageSelect } from "./fsf-language-select";
@@ -16,6 +17,7 @@ export {
   storeCategories,
   snapDetailsPosts,
   seriesPosts,
+  initEmbeddedCardModal,
   initFSFLanguageSelect,
   initReportSnap,
   firstSnapFlow,

--- a/static/js/public/snap-details/embeddedCard.js
+++ b/static/js/public/snap-details/embeddedCard.js
@@ -1,0 +1,98 @@
+import { initEmbeddedCardPicker } from "../../publisher/publicise";
+
+const showEl = el => el.classList.remove("u-hide");
+const hideEl = el => el.classList.add("u-hide");
+
+function toggleModal(modal, show, initCallback) {
+  if (typeof show === "undefined") {
+    show = modal.classList.contains("u-hide");
+  }
+
+  if (show) {
+    if (initCallback) {
+      initCallback();
+    }
+    showEl(modal);
+  } else {
+    hideEl(modal);
+  }
+}
+
+export default function initEmbeddedCardModal(snapName) {
+  const toggle = document.querySelector(".js-embedded-card-toggle");
+  const modal = document.querySelector("#embedded-card-modal");
+  const dialog = modal.querySelector("#embedded-card-modal-dialog");
+  const previewFrame = modal.querySelector("#embedded-card-frame");
+  const codeElement = modal.querySelector("#snippet-card-html");
+  const buttonRadios = modal.querySelectorAll("input[name=store-button]");
+  const optionButtons = modal.querySelectorAll("input[type=checkbox]");
+  const previewTab = modal.querySelector(
+    "[aria-controls='embedded-card-modal-preview']"
+  );
+  const previewTabContent = modal.querySelector("#embedded-card-modal-preview");
+  const htmlTab = modal.querySelector(
+    "[aria-controls='embedded-card-modal-html']"
+  );
+  const htmlTabContent = modal.querySelector("#embedded-card-modal-html");
+
+  function updateHeightCallback() {
+    // adjust the height of the modal to size of the frame
+    dialog.style.minHeight = "";
+
+    setTimeout(() => {
+      dialog.style.minHeight = dialog.clientHeight + "px";
+    }, 1);
+  }
+
+  function showPreviewTab() {
+    hideEl(htmlTabContent);
+    showEl(previewTabContent);
+    htmlTab.setAttribute("aria-selected", "false");
+    previewTab.setAttribute("aria-selected", "true");
+    // re-render preview to make sure height is updated
+    renderCard();
+  }
+
+  function showHtmlTab() {
+    hideEl(previewTabContent);
+    showEl(htmlTabContent);
+    previewTab.setAttribute("aria-selected", "false");
+    htmlTab.setAttribute("aria-selected", "true");
+  }
+
+  function initFrame() {
+    showPreviewTab();
+  }
+
+  const renderCard = initEmbeddedCardPicker({
+    snapName,
+    previewFrame,
+    codeElement,
+    buttonRadios,
+    optionButtons,
+    updateHeightCallback
+  });
+
+  toggle.addEventListener("click", event => {
+    event.preventDefault();
+    toggleModal(modal, true, initFrame);
+  });
+
+  modal.addEventListener("click", event => {
+    const target = event.target;
+
+    if (target.closest(".js-modal-close") || target === modal) {
+      toggleModal(modal);
+    }
+  });
+
+  previewTab.addEventListener("click", e => {
+    e.preventDefault();
+    showPreviewTab();
+  });
+
+  htmlTab.addEventListener("click", e => {
+    e.preventDefault();
+    showHtmlTab();
+  });
+}

--- a/static/js/public/snap-details/embeddedCard.js
+++ b/static/js/public/snap-details/embeddedCard.js
@@ -13,8 +13,10 @@ function toggleModal(modal, show, initCallback) {
       initCallback();
     }
     showEl(modal);
+    document.body.style.overflow = "hidden";
   } else {
     hideEl(modal);
+    document.body.style.overflow = "";
   }
 }
 

--- a/static/js/public/snap-details/embeddedCard.js
+++ b/static/js/public/snap-details/embeddedCard.js
@@ -26,14 +26,6 @@ export default function initEmbeddedCardModal(snapName) {
   const codeElement = modal.querySelector("#snippet-card-html");
   const buttonRadios = modal.querySelectorAll("input[name=store-button]");
   const optionButtons = modal.querySelectorAll("input[type=checkbox]");
-  const previewTab = modal.querySelector(
-    "[aria-controls='embedded-card-modal-preview']"
-  );
-  const previewTabContent = modal.querySelector("#embedded-card-modal-preview");
-  const htmlTab = modal.querySelector(
-    "[aria-controls='embedded-card-modal-html']"
-  );
-  const htmlTabContent = modal.querySelector("#embedded-card-modal-html");
 
   function updateHeightCallback() {
     // adjust the height of the modal to size of the frame
@@ -44,24 +36,8 @@ export default function initEmbeddedCardModal(snapName) {
     }, 1);
   }
 
-  function showPreviewTab() {
-    hideEl(htmlTabContent);
-    showEl(previewTabContent);
-    htmlTab.setAttribute("aria-selected", "false");
-    previewTab.setAttribute("aria-selected", "true");
-    // re-render preview to make sure height is updated
-    renderCard();
-  }
-
-  function showHtmlTab() {
-    hideEl(previewTabContent);
-    showEl(htmlTabContent);
-    previewTab.setAttribute("aria-selected", "false");
-    htmlTab.setAttribute("aria-selected", "true");
-  }
-
   function initFrame() {
-    showPreviewTab();
+    renderCard();
   }
 
   const renderCard = initEmbeddedCardPicker({
@@ -84,15 +60,5 @@ export default function initEmbeddedCardModal(snapName) {
     if (target.closest(".js-modal-close") || target === modal) {
       toggleModal(modal);
     }
-  });
-
-  previewTab.addEventListener("click", e => {
-    e.preventDefault();
-    showPreviewTab();
-  });
-
-  htmlTab.addEventListener("click", e => {
-    e.preventDefault();
-    showHtmlTab();
   });
 }

--- a/static/js/publisher/publicise.js
+++ b/static/js/publisher/publicise.js
@@ -79,7 +79,9 @@ const getCurrentFormState = (buttonRadios, optionButtons) => {
 
   // get state of store button radio
   let checked = buttonRadios.filter(b => b.checked);
-  state.button = checked[0].value;
+  if (checked.length > 0) {
+    state.button = checked[0].value;
+  }
 
   // get state of options checkboxes
   optionButtons.forEach(checkbox => {
@@ -134,26 +136,40 @@ function initEmbeddedCardPicker(options) {
     });
   });
 
-  buttonRadios.filter(r => r.value === "black")[0].checked = true;
-  previewFrame.src = getCardPath(snapName, getFormState());
-  codeElement.innerHTML = getCardEmbedHTML(snapName, getFormState());
+  if (buttonRadios.length > 0) {
+    buttonRadios.filter(r => r.value === "black")[0].checked = true;
+  }
+
+  // update the frame (but only if it's visible)
+  if (previewFrame.offsetParent !== null) {
+    previewFrame.src = getCardPath(snapName, getFormState());
+    codeElement.innerHTML = getCardEmbedHTML(snapName, getFormState());
+  }
 
   previewFrame.addEventListener("load", function() {
     // calulate frame height to be a bit bigger then content itself
     // to have some spare room for responsiveness
-    const height =
-      Math.floor(
-        (previewFrame.contentWindow.document.body.scrollHeight + 20) / 10
-      ) * 10;
+    if (previewFrame.offsetParent) {
+      const height =
+        Math.floor(
+          (previewFrame.contentWindow.document.body.scrollHeight + 20) / 10
+        ) * 10;
 
-    state = {
-      ...state,
-      frameHeight: height
-    };
-    // don't re-render the iframe not to trigger load again
-    previewFrame.style.height = height + "px";
+      state = {
+        ...state,
+        frameHeight: height
+      };
+      // don't re-render the iframe not to trigger load again
+      previewFrame.style.height = height + "px";
+
+      if (options.updateHeightCallback) {
+        options.updateHeightCallback(height);
+      }
+    }
     renderCode(state);
   });
+
+  return () => render(state);
 }
 
 export { initSnapButtonsPicker, initEmbeddedCardPicker };

--- a/static/sass/_snapcraft_embedded_card_modal.scss
+++ b/static/sass/_snapcraft_embedded_card_modal.scss
@@ -1,9 +1,12 @@
 @mixin snapcraft-embedded-card-modal {
   .p-embedded-card-modal-dialog {
     @media screen and (min-width: $breakpoint-medium) {
+      position: absolute;
+      top: 1.5rem;
       width: 80%;
     }
   }
+
 
   .p-heading-label {
     margin-bottom: $spv-intra;

--- a/static/sass/_snapcraft_embedded_card_modal.scss
+++ b/static/sass/_snapcraft_embedded_card_modal.scss
@@ -1,0 +1,12 @@
+@mixin snapcraft-embedded-card-modal {
+  .p-embedded-card-modal-dialog {
+    @media screen and (min-width: $breakpoint-medium) {
+      width: 80%;
+    }
+  }
+
+  .p-heading-label {
+    margin-bottom: $spv-intra;
+    margin-top: $spv-intra--expanded;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -216,6 +216,9 @@ $color-navigation-background: #252525;
 @import 'snapcraft_dispute-list';
 @include snapcraft-p-dispute-list;
 
+@import 'snapcraft_embedded_card_modal';
+@include snapcraft-embedded-card-modal;
+
 html,
 body {
   background: $color-x-light; // This will be fix on vanilla https://github.com/vanilla-framework/vanilla-framework/issues/2129

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -178,6 +178,9 @@
           <tr><th>License</th><td data-live="license">{{ license }}</td></tr>
           <tr><th>Last updated</th><td>{{ last_updated }}</td></tr>
         </table>
+        <h4>Share this snap</h4>
+        <p>Generate an embeddable card to be shared on external websites.</p>
+        <p><button class="p-button--neutral js-embedded-card-toggle">Create embeddable card</button></p>
       </div>
     </div>
   </div>
@@ -308,6 +311,8 @@
       </div>
     </div>
   </div>
+
+  {% include "store/snap-details/_embedded_card_modal.html" %}
   {% endif %}
   {% if is_preview %}
     </div>
@@ -385,6 +390,13 @@
       } catch(e) {
         Raven.captureException(e);
       }
+
+      try {
+        snapcraft.public.initEmbeddedCardModal('{{ package_name }}');
+      } catch(e) {
+        Raven.captureException(e);
+      }
+
 
       {% if countries %}
         try {

--- a/templates/store/snap-details/_embedded_card_modal.html
+++ b/templates/store/snap-details/_embedded_card_modal.html
@@ -1,0 +1,59 @@
+<div class="p-modal u-hide" id="embedded-card-modal">
+  <div class="p-modal__dialog p-embedded-card-modal-dialog u-no-margin--bottom" id="embedded-card-modal-dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title">Share embeddable card</h2>
+      <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
+    </header>
+    <p>Customise your embeddable card using the options below.</p>
+    <div class="row u-no-padding">
+      <div class="col-4">
+        <label class="p-heading-label">Snap Store button:</label>
+
+        <input type="radio" name="store-button" id="store-button-dark" checked="checked" value="black">
+        <label for="store-button-dark">Dark</label>
+        <input type="radio" name="store-button" id="store-button-light" value="white">
+        <label for="store-button-light">Light</label>
+        <input type="radio" name="store-button" id="store-button-hide" value="">
+        <label for="store-button-hide">Hide button</label>
+
+        <label class="p-heading-label">Options:</label>
+
+        <input type="checkbox" name="show-channels" id="option-show-channels" checked>
+        <label for="option-show-channels">Show all channels</label>
+        <input type="checkbox" name="show-summary" id="option-show-summary" checked>
+        <label for="option-show-summary">Show summary</label>
+        <input type="checkbox" name="show-screenshot" id="option-show-screenshot" {% if not screenshots %}disabled{% else %}checked{% endif %}>
+        <label for="option-show-screenshot">Show screenshot</label>
+
+      </div>
+      <div class="col-8">
+        <nav class="p-tabs">
+          <ul class="p-tabs__list" role="tablist">
+            <li class="p-tabs__item" role="presentation">
+              <a href="#section1" class="p-tabs__link" tabindex="0" role="tab" aria-controls="embedded-card-modal-preview" aria-selected="true">Preview</a>
+            </li>
+            <li class="p-tabs__item" role="presentation">
+              <a href="#section2" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="embedded-card-modal-html">HTML</a>
+            </li>
+          </ul>
+        </nav>
+        <div>
+          <div id="embedded-card-modal-preview">
+            <iframe id="embedded-card-frame"
+              class="snapcraft-publicise__embedded-frame"
+              width="100%" height="650px"
+              frameborder="0" style="border: 1px solid #CCC; border-radius: 2px;">
+            </iframe>
+          </div>
+        </div>
+
+        <div id="embedded-card-modal-html" class="u-hide">
+          <div class="p-code-copyable">
+            <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ package_name }}/embedded?button=black&channels=true&summary=true&screenshot=true" frameborder="0" width="100%" height="650px" style="border: 1px solid #CCC; border-radius: 2px;" &gt;&lt;/iframe&gt;</code>
+            <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/store/snap-details/_embedded_card_modal.html
+++ b/templates/store/snap-details/_embedded_card_modal.html
@@ -1,5 +1,5 @@
 <div class="p-modal u-hide" id="embedded-card-modal">
-  <div class="p-modal__dialog p-embedded-card-modal-dialog u-no-margin--bottom" id="embedded-card-modal-dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <div class="p-modal__dialog p-embedded-card-modal-dialog" id="embedded-card-modal-dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">
       <h2 class="p-modal__title">Share embeddable card</h2>
       <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
@@ -18,40 +18,25 @@
 
         <label class="p-heading-label">Options:</label>
 
-        <input type="checkbox" name="show-channels" id="option-show-channels" checked>
+        <input type="checkbox" name="show-channels" id="option-show-channels">
         <label for="option-show-channels">Show all channels</label>
-        <input type="checkbox" name="show-summary" id="option-show-summary" checked>
+        <input type="checkbox" name="show-summary" id="option-show-summary">
         <label for="option-show-summary">Show summary</label>
-        <input type="checkbox" name="show-screenshot" id="option-show-screenshot" {% if not screenshots %}disabled{% else %}checked{% endif %}>
+        <input type="checkbox" name="show-screenshot" id="option-show-screenshot" {% if not screenshots %}disabled{% endif %}>
         <label for="option-show-screenshot">Show screenshot</label>
 
       </div>
       <div class="col-8">
-        <nav class="p-tabs">
-          <ul class="p-tabs__list" role="tablist">
-            <li class="p-tabs__item" role="presentation">
-              <a href="#section1" class="p-tabs__link" tabindex="0" role="tab" aria-controls="embedded-card-modal-preview" aria-selected="true">Preview</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#section2" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="embedded-card-modal-html">HTML</a>
-            </li>
-          </ul>
-        </nav>
-        <div>
-          <div id="embedded-card-modal-preview">
-            <iframe id="embedded-card-frame"
-              class="snapcraft-publicise__embedded-frame"
-              width="100%" height="650px"
-              frameborder="0" style="border: 1px solid #CCC; border-radius: 2px;">
-            </iframe>
-          </div>
-        </div>
-
-        <div id="embedded-card-modal-html" class="u-hide">
-          <div class="p-code-copyable">
-            <code class="p-code-copyable__input" id="snippet-card-html">&lt;iframe src="https://snapcraft.io/{{ package_name }}/embedded?button=black&channels=true&summary=true&screenshot=true" frameborder="0" width="100%" height="650px" style="border: 1px solid #CCC; border-radius: 2px;" &gt;&lt;/iframe&gt;</code>
-            <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
-          </div>
+        <label class="p-heading-label">Preview:</label>
+        <iframe id="embedded-card-frame"
+          class="snapcraft-publicise__embedded-frame"
+          width="100%" height="320px"
+          frameborder="0" style="border: 1px solid #CCC; border-radius: 2px;">
+        </iframe>
+        <label class="p-heading-label">HTML:</label>
+        <div class="p-code-copyable">
+          <code class="p-code-copyable__input" id="snippet-card-html"></code>
+          <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #1678
Fixes #1679 

Adds dialog with embeddable card to snap details page.

### QA

- ./run or  https://snapcraft-io-canonical-websites-pr-1695.run.demo.haus/
- go to snap details page of any snap
- click on 'Create embeddable card' button
- modal should appear with options for embedded cards
- click on different options, see how preview adapts
- click on HTML tab to see the code
- copy the code and see it it works as expected

<img width="1099" alt="Screenshot 2019-03-15 at 10 28 47" src="https://user-images.githubusercontent.com/83575/54421640-23a9fa80-470d-11e9-979d-118ffdfb829e.png">
