### PR TITLE
Convert dict_keys to list

### DIFF
--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -250,7 +250,7 @@ def snap_details_views(store, api, handle_errors):
         if button and button not in button_variants:
             button = "black"
 
-        architectures = context["channel_map"].keys()
+        architectures = list(context["channel_map"].keys())
 
         context.update(
             {


### PR DESCRIPTION
# Summary 

Fixes #1699 
- Convert dict_keys to list ([source](https://stackoverflow.com/questions/16819222/how-to-return-dictionary-keys-as-a-list-in-python))

# QA

- `./run`
- http://127.0.0.1:8004/ubuntu-mate-pi/embedded
- http://127.0.0.1:8004/toto/embedded