### PR TITLE
Increase first call timeout to 1 second

### DIFF
--- a/webapp/api/dashboard.py
+++ b/webapp/api/dashboard.py
@@ -17,7 +17,7 @@ from webapp.api.exceptions import (
 # is solved in the Store we will relax the requests `read` timeout according
 # to what the frontend (k8s ingress) permits.
 # See https://bugs.launchpad.net/snapstore/+bug/1785094 for more information.
-api_session = api.requests.Session(timeout=(.5, 6))
+api_session = api.requests.Session(timeout=(1, 6))
 
 
 DASHBOARD_API = os.getenv(

--- a/webapp/api/store.py
+++ b/webapp/api/store.py
@@ -74,7 +74,7 @@ class StoreApi:
         if testing or not cache:
             self.session = api.requests.Session()
         else:
-            self.session = api.requests.CachedSession()
+            self.session = api.requests.CachedSession(timeout=(1, 6))
         self.session.headers.update(self.headers)
         self.session.headers.update(self.headers_v2)
 


### PR DESCRIPTION
# Summary

Increase timeout to 1 second to avoid the big amount of timeouts we are getting

# QA

- `./run`
- Make sure store and publisher pages are still working (shouldn't impact any page)