### PR TITLE
Make whole content of a embedded card clickable as a link to the store

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -27,6 +27,17 @@ $color-navigation-background: #252525;
 
 // CUSTOM STYLES FOR EMBEDDED CARD
 
+// cover whole card with a link to the Store page
+.p-embedded-card-link {
+  bottom: 0;
+  display: block;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 10;
+}
+
 // make max-width of the layout smaller for embedded view
 .row {
   max-width: 40rem;

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -45,9 +45,7 @@
       {% endif %}
       {% if button %}
       <div class="p-embedded-description__badge">
-        <a href="https://snapcraft.io/{{ package_name }}">
-          <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
-        </a>
+        <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
       </div>
       {% endif %}
     </div>
@@ -86,4 +84,6 @@
     {% endif %}
   </div>
 </div>
+
+<a class="p-embedded-card-link" href="https://snapcraft.io/{{ package_name }}"></a>
 {% endblock content %}


### PR DESCRIPTION
Fixes https://github.com/CanonicalLtd/snap-squad/issues/941

Makes whole embedded card clickable, so it can link to snap details page even if there is no 'Store Button' in it.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1724.run.demo.haus/
- Sign in, go to Publicise page of any snap, choose Embeddable cards
- Whole card preview should be clickable and link to snap details page
- Turn off store button option, card should be still clickable
