### PR TITLE
Updated content and style on /home and /store

### DIFF
--- a/static/sass/_patterns_strip_slanted.scss
+++ b/static/sass/_patterns_strip_slanted.scss
@@ -7,9 +7,11 @@
 
   %vf-strip-slanted {
     background-position: 50% 50%;
+    background-color: #106363;
     margin-top: $bleed;
     overflow: hidden;
     position: relative;
+    min-height: 30vh;
 
     @media (max-width: $breakpoint-large) {
       background-size: cover;

--- a/static/sass/_search-form.scss
+++ b/static/sass/_search-form.scss
@@ -1,6 +1,19 @@
 @mixin search-form {
-  .p-form--search {
+
+  .snapcraft-banner-background .p-form--search {
     width: 100%;
+  }
+
+  .p-form--search {
+    width: 60%;
+
+    @media screen and (max-width: $breakpoint-navigation-threshold) {
+      width: 100%;
+
+      .p-button--positive {
+        width: 100%;
+      }
+    }
 
     .p-form__group {
       flex-grow: 1;

--- a/static/sass/_snapcraft_store.scss
+++ b/static/sass/_snapcraft_store.scss
@@ -1,0 +1,10 @@
+@mixin snapcraft-store {
+  .p-strip--snap-store {
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2d2d2d 67%, #383838 88%, #2e2e2e 100%, #393939 100%);
+  }
+
+  .p-icon--snap-store {
+    height: 10rem;
+    width: 10rem;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -220,6 +220,9 @@ $color-navigation-background: #252525;
 @import 'patterns_strip_slanted';
 @include p-strip-slanted;
 
+@import 'snapcraft_store';
+@include snapcraft-store;
+
 @import 'snapcraft_dispute-list';
 @include snapcraft-p-dispute-list;
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
     {% endif %}
     <div class="col-12">
       <h2>The app store for Linux</h2>
-      <p>Publish your app for Linux users &mdash;<br class="u-hide--small" /> for desktop, cloud, and Internet of Things.</p>
+      <p class="u-no-padding--top p-heading--four">Publish your app for Linux users &mdash;<br class="u-hide--small" /> for desktop, cloud, and Internet of Things.</p>
       <a href="/first-snap" class="p-button--positive">Package & publish your app</a>
     </div>
   </div>

--- a/templates/partials/search-bar.html
+++ b/templates/partials/search-bar.html
@@ -1,4 +1,4 @@
-<section id="main-content" class="p-strip--image is-shallow snapcraft-banner-background">
+<section id="main-content" class="p-strip--image p-strip-slanted--snapcraft">
   <div class="row">
     {% if not webapp_config['STORE_QUERY'] %}
       <h1 class="p-heading--two">Search thousands of snaps used by millions of people across 41 Linux distributions</h1>
@@ -7,23 +7,10 @@
       {{ webapp_config['STORE_SEARCH_INTRO']|safe }}
     {% endif %}
     <form action="/search" class="p-form p-form--inline p-form--search">
-      {% if categories %}
-        <div class="p-form__group p-form__group--no-grow">
-          <label for="category-input" class="u-off-screen">Category</label>
-          <div class="p-form__control u-clearfix">
-            <select id="category-input" name="category" class="u-no-margin--bottom">
-              <option value="">All snaps</option>
-              {% for category in categories %}
-                <option value="{{ category.slug }}">{{ category.name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-        </div>
-      {% endif %}
       <div class="p-form__group">
         <label for="search-input" class="u-off-screen">Search</label>
         <div class="p-form__control u-clearfix">
-          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" value="{{ query }}" />
+          <input class="u-no-margin--bottom" id="search-input" type="search" name="q" placeholder="Search thousand of snaps" value="{{ query }}" />
         </div>
       </div>
       <button type="submit" alt="search" class="p-button--positive">Search</button>

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -53,7 +53,7 @@
   <section class="p-strip--image is-deep is-dark p-strip--snap-store">
     <div class="row u-vertically-center">
       <div class="col-7 u-fade-left--medium">
-        <h1 class="p-heading--two">Access the App Store for Linux <br>from your desktop</h1>
+        <h1 class="p-heading--two">Access the App Store for Linux <br class="u-hide--small u-hide--medium">from your desktop</h1>
         <p class="u-no-padding--top p-heading--four">Easily find and install new applications or remove existing installed applications with the Snap Store snap.</p>
         <p class="u-hide--large u-hide--medium u-align--center">
           <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" alt="Get the Snap Store snap" class="p-icon--snap-store u-fade-up">

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -50,6 +50,23 @@
       </div>
     {% endfor %}
   </section>
+  <section class="p-strip--image is-deep is-dark p-strip--snap-store">
+    <div class="row u-vertically-center">
+      <div class="col-7 u-fade-left--medium">
+        <h1 class="p-heading--two">Access the App Store for Linux <br>from your desktop</h1>
+        <p class="u-no-padding--top p-heading--four">Easily find and install new applications or remove existing installed applications with the Snap Store snap.</p>
+        <p class="u-hide--large u-hide--medium u-align--center">
+          <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" alt="Get the Snap Store snap" class="p-icon--snap-store u-fade-up">
+        </p>
+        <p>
+          <a href="/snap-store" class="p-button--positive">Get the Snap Store</a>
+        </p>
+      </div>
+      <div class="col-4 u-hide--small prefix-1">
+          <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" alt="Get the Snap Store snap" class="p-icon--snap-store u-fade-up">
+      </div>
+    </div>
+  </section>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Fixes:
https://github.com/canonical-websites/snapcraft.io/issues/1718
https://github.com/canonical-websites/snapcraft.io/issues/1722
https://github.com/canonical-websites/snapcraft.io/issues/1725


## QA Steps
1. Pull the branch or run the demo service
2. Visit homepage and notice the P in the front-page has updated style (hint: is bigger)
3. Visit `/store` and notice there is a slanted header, removed category filtering from front-page
4. Scroll down to see a new banner promoting Snap Store snap
5. #winning