### PR TITLE
Limit screenshots to 5 on the frontend

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from urllib.parse import parse_qs, urlparse
 
 import humanize
@@ -360,11 +361,12 @@ def get_video_embed_code(url):
 
 
 def filter_screenshots(media):
+    banner_regex = r"/banner(\-icon)?(_.*)\.(png|jpg)"
     return [
         m["url"]
         for m in media
-        if m["type"] == "screenshot" and "banner" not in m["url"]
-    ]
+        if m["type"] == "screenshot" and not re.search(banner_regex, m["url"])
+    ][:5]
 
 
 def get_icon(media):


### PR DESCRIPTION
This PR limit's the number of screenshots displayed on snap details pages to assist in getting https://github.com/canonical-websites/snapcraft.io/pull/1696 landed, once https://bugs.launchpad.net/software-center-agent/+bug/1821151 lands.

It also enforces a notice on the listings page staging "Some images won't be visible" when you have over 5 screenshots (legacy from dashboard.snapcraft.io).