### PR TITLE
Add missing --devmode to snap install in the FSF

### DIFF
--- a/webapp/first_snap/content/c/test.yaml
+++ b/webapp/first_snap/content/c/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous dosbox*.snap
+    command: sudo snap install --devmode --dangerous dosbox*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/golang/test.yaml
+++ b/webapp/first_snap/content/golang/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous *.snap
+    command: sudo snap install --devmode --dangerous *.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/java/test.yaml
+++ b/webapp/first_snap/content/java/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous freeplane*.snap
+    command: sudo snap install --devmode --dangerous freeplane*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/node/test.yaml
+++ b/webapp/first_snap/content/node/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous wethr*.snap
+    command: sudo snap install --devmode --dangerous wethr*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/pre-built/test.yaml
+++ b/webapp/first_snap/content/pre-built/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine using Multipass
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous
+    command: sudo snap install --devmode --dangerous
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/python/test.yaml
+++ b/webapp/first_snap/content/python/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous offlineimap*.snap
+    command: sudo snap install --devmode --dangerous offlineimap*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/ros2/test.yaml
+++ b/webapp/first_snap/content/ros2/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous ros2-talker-listener*.snap
+    command: sudo snap install --devmode --dangerous ros2-talker-listener*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/ruby/test.yaml
+++ b/webapp/first_snap/content/ruby/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous mdl*.snap
+    command: sudo snap install --devmode --dangerous mdl*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine

--- a/webapp/first_snap/content/rust/test.yaml
+++ b/webapp/first_snap/content/rust/test.yaml
@@ -6,7 +6,7 @@ macos:
   - action: Connect to the virtual machine
     command: multipass shell testvm
   - action: Install the snap inside the virtual machine
-    command: sudo snap install --dangerous xsv*.snap
+    command: sudo snap install --devmode --dangerous xsv*.snap
   - action: Confirm the snap is installed by listing your installed snaps
     command: snap list
   - action: Run the snap inside the virtual machine


### PR DESCRIPTION
As observed in https://github.com/canonical-websites/snapcraft.io/pull/1641/files#r262678393 we're missing `--devmode` on `snap install` for devmode snaps.