### PR TITLE
Add missing links to working FSF guides

### DIFF
--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -12,7 +12,7 @@
       </header>
       <span>Pre-built apps</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/c" data-flow-link="c">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/c" data-flow-link="c">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/dcc8c108-logo-cpp.svg" alt="">
       </header>
@@ -24,13 +24,13 @@
       </header>
       <span>Go</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/java" data-flow-link="java">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/java" data-flow-link="java">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/f6840095-logo-java.svg" alt="">
       </header>
       <span>Java</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/node" data-flow-link="node">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/node" data-flow-link="node">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/7a4dcddb-logo-node.svg" alt="">
       </header>
@@ -42,13 +42,13 @@
       </header>
       <span>Electron</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ruby" data-flow-link="ruby">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/ruby" data-flow-link="ruby">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/eacdd4e1-logo-ruby.svg" alt="">
       </header>
       <span>Ruby</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/rust" data-flow-link="rust">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/rust" data-flow-link="rust">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/6677836e-logo-rust.svg" alt="">
       </header>
@@ -66,7 +66,7 @@
       </header>
       <span>ROS</span>
     </a>
-    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="https://docs.snapcraft.io/build-snaps/ros2" data-flow-link="ros2">
+    <a class="p-logo-link p-fluid-grid__item--small p-card p-flow-link" href="/first-snap/ros2" data-flow-link="ros2">
       <header class="p-card__header">
         <img src="https://assets.ubuntu.com/v1/7dad0dcc-logo-ros2.svg" alt="">
       </header>


### PR DESCRIPTION
A few of the landed FSF guides are missing links into the guide.