### PR TITLE
Add snap GitHub badge endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,13 @@ humanize==0.5.1
 Markdown==3.0.1
 prometheus_client==0.3.1
 mistune==0.8.4
+pybadges==1.1.0
 pybreaker==0.4.4
 pycountry==17.9.23
 pymacaroons==0.12.0
 python-dateutil==2.6.1
 raven[flask]==6.5.0
-requests==2.20.0
+requests==2.21.0
 requests-cache==0.4.13
 responses==0.9.0
 ruamel.yaml==0.15.72

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -1,0 +1,124 @@
+import responses
+from flask_testing import TestCase
+from webapp.app import create_app
+
+
+class GetGitHubBadgeTest(TestCase):
+    render_templates = False
+
+    snap_payload = {
+        "snap-id": "id",
+        "name": "snapName",
+        "snap": {
+            "title": "Snap Title",
+            "summary": "This is a summary",
+            "description": "this is a description",
+            "media": [],
+            "license": "license",
+            "prices": 0,
+            "publisher": {
+                "display-name": "Toto",
+                "username": "toto",
+                "validation": True,
+            },
+            "categories": [{"name": "test"}],
+        },
+        "channel-map": [
+            {
+                "channel": {
+                    "architecture": "amd64",
+                    "name": "stable",
+                    "risk": "stable",
+                    "track": "latest",
+                },
+                "created-at": "2018-09-18T14:45:28.064633+00:00",
+                "version": "1.0",
+                "confinement": "conf",
+                "download": {"size": 100000},
+            }
+        ],
+    }
+
+    def setUp(self):
+        self.snap_name = "toto"
+        self.api_url = "".join(
+            [
+                "https://api.snapcraft.io/v2/",
+                "snaps/info/",
+                self.snap_name,
+                "?fields=title,summary,description,license,contact,website,",
+                "publisher,prices,media,download,version,created-at,"
+                "confinement,categories",
+            ]
+        )
+        self.endpoint_url = "/" + self.snap_name + "/badge"
+
+    def create_app(self):
+        app = create_app(testing=True)
+        app.secret_key = "secret_key"
+        app.config["WTF_CSRF_METHODS"] = []
+
+        return app
+
+    @responses.activate
+    def test_api_404(self):
+        payload = {"error-list": []}
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=404
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 1
+        called = responses.calls[0]
+        assert called.request.url == self.api_url
+
+        assert response.status_code == 404
+
+    @responses.activate
+    def test_api_500(self):
+        payload = {"error-list": []}
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=500
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 1
+        called = responses.calls[0]
+        assert called.request.url == self.api_url
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_api_500_no_answer(self):
+        responses.add(
+            responses.Response(method="GET", url=self.api_url, status=500)
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        assert len(responses.calls) == 1
+        called = responses.calls[0]
+        assert called.request.url == self.api_url
+
+        assert response.status_code == 502
+
+    @responses.activate
+    def test_get_badge(self):
+        payload = self.snap_payload
+
+        responses.add(
+            responses.Response(
+                method="GET", url=self.api_url, json=payload, status=200
+            )
+        )
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 200)
+        # self.assert_context("snap_title", "Snap Title")

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -2,6 +2,7 @@ import flask
 
 import bleach
 import humanize
+from pybadges import badge
 import webapp.helpers as helpers
 import webapp.metrics.helper as metrics_helper
 import webapp.metrics.metrics as metrics
@@ -276,3 +277,27 @@ def snap_details_views(store, api, handle_errors):
         return flask.redirect(
             flask.url_for(".snap_details", snap_name=snap_name.lower())
         )
+
+    @store.route('/<regex("' + snap_regex + '"):snap_name>/badge')
+    def snap_details_badge(snap_name):
+        context = _get_context_snap_details(snap_name)
+
+        snap_link = flask.request.url_root + context["package_name"]
+
+        svg = badge(
+            left_text=context["snap_title"],
+            right_text="v" + context["version"],
+            right_color="#0e8420",  # Vanilla $color-positive
+            left_link=snap_link,
+            right_link=snap_link,
+            logo=(
+                "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+                "viewBox='0 0 32 32'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%23f"
+                "ff%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M18.03 1"
+                "8.03l5.95-5.95-5.95-2.65v8.6zM6.66 29.4l10.51-10.51-3.21-3.18"
+                "-7.3 13.69zM2.5 3.6l15.02 14.94V9.03L2.5 3.6zM27.03 9.03h-8.6"
+                "5l11.12 4.95-2.47-4.95z'/%3E%3C/svg%3E"
+            ),
+        )
+
+        return svg, 200, {"Content-Type": "image/svg+xml"}


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/939

Adds basic endpoint to serve GitHub badge SVG

### QA
- ./run or demo
- go to /[snap-name]/badge URL for any snap (https://snapcraft-io-canonical-websites-pr-1731.run.demo.haus/vscode/badge)
- snap badge should be displayed like:
![](https://snapcraft-io-canonical-websites-pr-1731.run.demo.haus/vscode/badge)