### PR TITLE
GitHub badges on publicise page

### DIFF
--- a/templates/publisher/publicise/_publisher_publicise_layout.html
+++ b/templates/publisher/publicise/_publisher_publicise_layout.html
@@ -11,27 +11,31 @@ Publicise {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% 
 
   <div class="p-strip is-shallow">
     <div class="row">
-    <div class="col-3">
-      <div class="p-navigation--sidebar">
+      <div class="col-3">
+        <div class="p-navigation--sidebar">
 
-        <div class="sidebar__content js-sidebar-toggle u-hide" aria-hidden="true">
-          <ul class="p-list sidebar__first-level" data-js="sidebar-first-level">
-            <li>
-              <a class="sidebar__link {% if publicise_page == 'buttons' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/">Snap Store buttons</a>
-            </li>
-            <li>
-              <a class="sidebar__link {% if publicise_page == 'cards' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/cards">Embeddable cards</a>
-            </li>
-          </ul>
+          <div class="sidebar__content js-sidebar-toggle u-hide" aria-hidden="true">
+            <ul class="p-list sidebar__first-level" data-js="sidebar-first-level">
+              <li>
+                <a class="sidebar__link {% if publicise_page == 'buttons' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/">Snap Store buttons</a>
+              </li>
+              <li>
+                <a class="sidebar__link {% if publicise_page == 'badges' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/badges">GitHub badges</a>
+              </li>
+              <li>
+                <a class="sidebar__link {% if publicise_page == 'cards' %}is-selected{% endif %}" href="/{{ snap_name }}/publicise/cards">Embeddable cards</a>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="col-9">
-      {% block publicise_content %}
-      {% endblock %}
-    </div>
+      <div class="col-9">
+        {% block publicise_content %}
+        {% endblock %}
+      </div>
 
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -13,7 +13,7 @@
     <div class="col-7">
       <p class="snapcraft-publicise__images">
         <a href="https://snapcraft.io/{{ snap_name }}">
-          <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge" />
+          <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge.svg" />
         </a>
       </p>
     </div>
@@ -26,7 +26,7 @@
     <div class="col-7">
       <div class="p-code-copyable">
         <code class="p-code-copyable__input" id="snippet-badge-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
-  &lt;img alt="{{ snap_title }}" src="https://snapcraft.io/{{ snap_name }}/badge" /&gt;
+  &lt;img alt="{{ snap_title }}" src="https://snapcraft.io/{{ snap_name }}/badge.svg" /&gt;
 &lt;/a&gt;</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-html">Copy to clipboard</button>
       </div>
@@ -39,7 +39,7 @@
     </div>
     <div class="col-7">
       <div class="p-code-copyable">
-        <code class="p-code-copyable__input" id="snippet-badge-markdown">[![{{ snap_title }}](https://snapcraft.io/{{ snap_name }}/badge)](https://snapcraft.io/{{ snap_name }})</code>
+        <code class="p-code-copyable__input" id="snippet-badge-markdown">[![{{ snap_title }}](https://snapcraft.io/{{ snap_name }}/badge.svg)](https://snapcraft.io/{{ snap_name }})</code>
         <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-markdown">Copy to clipboard</button>
       </div>
     </div>

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -1,0 +1,57 @@
+{% set publicise_page="badges" %}
+{% extends "publisher/publicise/_publisher_publicise_layout.html" %}
+
+{% block publicise_content %}
+  <div class="row">
+    <h4>Promote your snap using embeddable GitHub badge</h4>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
+      Preview:
+    </div>
+    <div class="col-7">
+      <p class="snapcraft-publicise__images">
+        <img src="/{{snap_name}}/badge" />
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
+      <label>HTML:</label>
+    </div>
+    <div class="col-7">
+      <div class="p-code-copyable">
+        <code class="p-code-copyable__input" id="snippet-card-html">&lt;img src="https://snapcraft.io/{{ snap_name }}/badge" /&gt;</code>
+        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
+      <label>Markdown:</label>
+    </div>
+    <div class="col-7">
+      <div class="p-code-copyable">
+        <code class="p-code-copyable__input" id="snippet-card-html">![](https://snapcraft.io/{{ snap_name }}/badge)</code>
+        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts_modules %}
+<script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  Raven.context(function () {
+    if (typeof ClipboardJS !== 'undefined') {
+      new ClipboardJS('.js-clipboard-copy');
+    }
+  });
+</script>
+{% endblock %}

--- a/templates/publisher/publicise/github_badges.html
+++ b/templates/publisher/publicise/github_badges.html
@@ -12,7 +12,9 @@
     </div>
     <div class="col-7">
       <p class="snapcraft-publicise__images">
-        <img src="/{{snap_name}}/badge" />
+        <a href="https://snapcraft.io/{{ snap_name }}">
+          <img alt="{{ snap_title }}" src="/{{ snap_name }}/badge" />
+        </a>
       </p>
     </div>
   </div>
@@ -23,8 +25,10 @@
     </div>
     <div class="col-7">
       <div class="p-code-copyable">
-        <code class="p-code-copyable__input" id="snippet-card-html">&lt;img src="https://snapcraft.io/{{ snap_name }}/badge" /&gt;</code>
-        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
+        <code class="p-code-copyable__input" id="snippet-badge-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
+  &lt;img alt="{{ snap_title }}" src="https://snapcraft.io/{{ snap_name }}/badge" /&gt;
+&lt;/a&gt;</code>
+        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-html">Copy to clipboard</button>
       </div>
     </div>
   </div>
@@ -35,8 +39,8 @@
     </div>
     <div class="col-7">
       <div class="p-code-copyable">
-        <code class="p-code-copyable__input" id="snippet-card-html">![](https://snapcraft.io/{{ snap_name }}/badge)</code>
-        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-card-html">Copy to clipboard</button>
+        <code class="p-code-copyable__input" id="snippet-badge-markdown">[![{{ snap_title }}](https://snapcraft.io/{{ snap_name }}/badge)](https://snapcraft.io/{{ snap_name }})</code>
+        <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-badge-markdown">Copy to clipboard</button>
       </div>
     </div>
   </div>

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -50,7 +50,7 @@
           <div class="p-code-copyable">
             <code class="p-code-copyable__input" id="snippet-{{ lang }}-black-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
   &lt;img alt="{{ data.text }}" src="https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-black.svg" /&gt;
-  &lt;/a&gt;</code>
+&lt;/a&gt;</code>
             <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-{{ lang }}-black-html">Copy to clipboard</button>
           </div>
         </div>
@@ -95,7 +95,7 @@
           <div class="p-code-copyable">
             <code class="p-code-copyable__input" id="snippet-{{ lang }}-white-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
   &lt;img alt="{{ data.text }}" src="https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-white.svg" /&gt;
-  &lt;/a&gt;</code>
+&lt;/a&gt;</code>
             <button class="p-code-copyable__action js-clipboard-copy" data-clipboard-target="#snippet-{{ lang }}-white-html">Copy to clipboard</button>
           </div>
         </div>

--- a/tests/publisher/snaps/tests_publicise_badges.py
+++ b/tests/publisher/snaps/tests_publicise_badges.py
@@ -1,0 +1,87 @@
+import responses
+from tests.publisher.endpoint_testing import BaseTestCases
+
+
+class PublicisePageNotAuth(BaseTestCases.EndpointLoggedOut):
+    def setUp(self):
+        snap_name = "test-snap"
+        endpoint_url = "/{}/publicise/badges".format(snap_name)
+
+        super().setUp(snap_name=snap_name, endpoint_url=endpoint_url)
+
+
+class GetPubliciseBadgesPage(BaseTestCases.EndpointLoggedInErrorHandling):
+    def setUp(self):
+        snap_name = "test-snap"
+
+        api_url = "https://dashboard.snapcraft.io/dev/api/snaps/info/{}"
+        api_url = api_url.format(snap_name)
+        endpoint_url = "/{}/publicise/badges".format(snap_name)
+
+        super().setUp(
+            snap_name=snap_name,
+            endpoint_url=endpoint_url,
+            method_endpoint="GET",
+            api_url=api_url,
+            method_api="GET",
+        )
+
+    @responses.activate
+    def test_page_not_found(self):
+        payload = {"error_list": []}
+        responses.add(responses.GET, self.api_url, json=payload, status=404)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+
+        self.assertEqual(response.status_code, 404)
+        self.assert_template_used("404.html")
+
+    @responses.activate
+    def test_publicise_logged_in(self):
+        snap_name = "test-snap"
+
+        payload = {
+            "snap_id": "id",
+            "title": "test snap",
+            "private": False,
+            "snap_name": snap_name,
+            "keywords": [],
+            "media": [],
+        }
+
+        responses.add(responses.GET, self.api_url, json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_template_used("publisher/publicise/github_badges.html")
+
+        self.assert_context("snap_id", "id")
+        self.assert_context("snap_title", "test snap")
+        self.assert_context("snap_name", snap_name)
+
+    @responses.activate
+    def test_publicise_private_snap(self):
+        snap_name = "test-snap"
+
+        payload = {
+            "snap_id": "id",
+            "title": "test snap",
+            "private": True,
+            "snap_name": snap_name,
+            "keywords": [],
+            "media": [],
+        }
+
+        responses.add(responses.GET, self.api_url, json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url)
+
+        self.check_call_by_api_url(responses.calls)
+
+        self.assertEqual(response.status_code, 404)
+        self.assert_template_used("404.html")

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -51,7 +51,7 @@ class GetGitHubBadgeTest(TestCase):
                 "confinement,categories",
             ]
         )
-        self.endpoint_url = "/" + self.snap_name + "/badge"
+        self.endpoint_url = "/" + self.snap_name + "/badge.svg"
 
     def create_app(self):
         app = create_app(testing=True)

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -278,7 +278,7 @@ def snap_details_views(store, api, handle_errors):
             flask.url_for(".snap_details", snap_name=snap_name.lower())
         )
 
-    @store.route('/<regex("' + snap_regex + '"):snap_name>/badge')
+    @store.route('/<regex("' + snap_regex + '"):snap_name>/badge.svg')
     def snap_details_badge(snap_name):
         context = _get_context_snap_details(snap_name)
 


### PR DESCRIPTION
Fixes #1707 

Adds 'GitHub badges' section to Publicise page for publishers.

### QA

- ./run (currently demo doesn't allow to sign in)
- go to publicise page of any snap
- 'GitHub badges' should be available in side navigation
- go to that page
- Preview of badge specific for current snap should be available
- Copy HTML or Markdown and paste it to check if it works (make sure to update 'snapcraft.io' to demo URL: https://snapcraft-io-canonical-websites-pr-1732.run.demo.haus/)
- Make sure badge links to snap details page correctly

Badge markdown test:
[![Android Studio](https://snapcraft-io-canonical-websites-pr-1732.run.demo.haus/android-studio/badge.svg)](https://snapcraft.io/android-studio)

<img width="1045" alt="Screenshot 2019-03-25 at 14 47 58" src="https://user-images.githubusercontent.com/83575/54924584-02b38780-4f0d-11e9-8999-f5b4af74cb77.png">
