### PR TITLE
Make the second FSF name warning less redundant

### DIFF
--- a/webapp/first_snap/content/c/package.yaml
+++ b/webapp/first_snap/content/c/package.yaml
@@ -119,6 +119,6 @@ explain:
           test-dosbox-{name}:
             command: bin/dosbox
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>dosbox</code> to <code>test-dosbox-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official DOSBox snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>dosbox</code> to <code>test-dosbox-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official DOSBox snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/golang/package.yaml
+++ b/webapp/first_snap/content/golang/package.yaml
@@ -59,6 +59,6 @@ explain:
           test-httplab-{name}:
             command: bin/httplab
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>httplab</code> to <code>test-httplab-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official httplab snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>httplab</code> to <code>test-httplab-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official httplab snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/java/package.yaml
+++ b/webapp/first_snap/content/java/package.yaml
@@ -66,5 +66,5 @@ explain:
             freeplane:
                 command: desktop-launch $SNAP/freeplane-1.6.10/freeplane.sh
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>freeplane</code> to <code>freeplane-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official freeplane snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.

--- a/webapp/first_snap/content/node/package.yaml
+++ b/webapp/first_snap/content/node/package.yaml
@@ -56,6 +56,6 @@ explain:
           test-wethr-{name}:
             command: bin/wethr
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>wethr</code> to <code>test-wethr-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official wethr snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>wethr</code> to <code>test-wethr-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official wethr snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/pre-built/package.yaml
+++ b/webapp/first_snap/content/pre-built/package.yaml
@@ -56,6 +56,6 @@ explain:
           test-geekbench4-{name}:
             command: geekbench4
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>geekbench4</code> to <code>test-geekbench4-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official geekbench4 snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>geekbench4</code> to <code>test-geekbench4-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official geekbench4 snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/python/package.yaml
+++ b/webapp/first_snap/content/python/package.yaml
@@ -59,6 +59,6 @@ explain:
           test-offlineimap-{name}:
             command: bin/offlineimap
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official offlineimap snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>offlineimap</code> to <code>test-offlineimap-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official offlineimap snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/ros2/package.yaml
+++ b/webapp/first_snap/content/ros2/package.yaml
@@ -62,6 +62,6 @@ explain:
           ros2-talker-listener:
             command: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>ros2-talker-listener</code> to <code>test-ros2-talker-listener-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official ros2-talker-listener snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/ruby/package.yaml
+++ b/webapp/first_snap/content/ruby/package.yaml
@@ -62,6 +62,6 @@ explain:
           mdl:
             command: bin/mdl
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>mdl</code> to <code>test-mdl-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official mdl snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>mdl</code> to <code>test-mdl-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official mdl snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.

--- a/webapp/first_snap/content/rust/package.yaml
+++ b/webapp/first_snap/content/rust/package.yaml
@@ -55,6 +55,6 @@ explain:
           xsv:
             command: xsv
     - warning: |
-        <span class="p-notification__status">Snap names are globally unique.</span> You should change any instance of <code>xsv</code> to <code>test-xsv-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official xsv snap.
+        <span class="p-notification__status"></span>As before, remember to change this instance of <code>xsv</code> to <code>test-xsv-{name}</code> (where <code>{name}</code> is your name) before continuing to avoid conflicting with the official xsv snap.
     - text: The <code>command</code> specifies the path to the binary to be run. This is resolved relative to the root of your snap contents and automatically searches in the usr/sbin, usr/bin, sbin, and bin subdirectories of your snap.
     - text: If your command name matches the snap name, users will be able run the command directly.


### PR DESCRIPTION
Discussion here:
https://github.com/canonical-websites/snapcraft.io/pull/1641#discussion_r267969364

This PR makes the warning about needing to change the snap name/command less redundant.