### PR TITLE
Pin Werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,9 @@ responses==0.9.0
 ruamel.yaml==0.15.72
 talisker==0.11.0
 
+# Temporary fix to SSO redirect issue
+Werkzeug==0.14.1
+
 # Development dependencies
 black==18.6b4
 Flask-Testing==0.6.2


### PR DESCRIPTION
## Done
Bumping werkzeug to 0.15 is causing problems in the SSO flow. This PR temporarily pins werkzeug to 0.14.1 until we get to understand what is causing the issue in the new version.

## QA
- `./run`
- Make sure the website is functional and that you can login using SSO.