### PR TITLE
Fix disabled Revert button on publisher listing page

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -120,7 +120,7 @@ function initForm(config, initialState, errors) {
   const revertButton = formEl.querySelector(".js-form-revert");
   const previewButton = formEl.querySelector(".js-listing-preview");
   const revertURL = revertButton.getAttribute("href");
-  const disabledRevertClass = "is-disabled";
+  const disabledRevertClass = "is--disabled";
 
   function disableSubmit() {
     submitButton.disabled = "disabled";

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -309,7 +309,7 @@ describe("initForm", () => {
   });
 
   test("should disable the revert button", () => {
-    expect(revertButton.classList.contains("is-disabled")).toEqual(true);
+    expect(revertButton.classList.contains("is--disabled")).toEqual(true);
     expect(revertButton.href).toEqual("javascript:void(0);");
   });
 
@@ -325,7 +325,7 @@ describe("initForm", () => {
     });
 
     test("should enable revert button", () => {
-      expect(revertButton.classList.contains("is-disabled")).toEqual(false);
+      expect(revertButton.classList.contains("is--disabled")).toEqual(false);
       expect(revertButton.href).toEqual("/test");
     });
   });


### PR DESCRIPTION
Fixes #1697 

Correctly displays Revert button as disabled until there are any changes on Listing page.

This was caused by a typo in `is--disabled` class from Vanilla.
Reported also as Vanilla issue: https://github.com/vanilla-framework/vanilla-framework/issues/2236

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1738.run.demo.haus/
- go to Listing page of any snap
- Revert button should be disabled after page loads
- do some changes on the page
- Revert button should be enabled
- Revert the changes (by undoing them or clicking Revert)
- Revert should be disabled again
- try it with different fields on the (text, images, checkboxes)

<img width="1038" alt="Screenshot 2019-03-25 at 15 41 34" src="https://user-images.githubusercontent.com/83575/54928630-7dcc6c00-4f14-11e9-93cb-22b1a82a7ed4.png">
