### PR TITLE
Move image up in Snap Store banner on mobile

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -53,11 +53,11 @@
   <section class="p-strip--image is-deep is-dark p-strip--snap-store">
     <div class="row u-vertically-center">
       <div class="col-7 u-fade-left--medium">
-        <h1 class="p-heading--two">Access the App Store for Linux <br class="u-hide--small u-hide--medium">from your desktop</h1>
-        <p class="u-no-padding--top p-heading--four">Easily find and install new applications or remove existing installed applications with the Snap Store snap.</p>
         <p class="u-hide--large u-hide--medium u-align--center">
           <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" alt="Get the Snap Store snap" class="p-icon--snap-store u-fade-up">
         </p>
+        <h1 class="p-heading--two">Access the App Store for Linux <br class="u-hide--small u-hide--medium">from your desktop</h1>
+        <p class="u-no-padding--top p-heading--four">Easily find and install new applications or remove existing installed applications with the Snap Store snap.</p>
         <p>
           <a href="/snap-store" class="p-button--positive">Get the Snap Store</a>
         </p>


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/947

Moves image to the top of the banner on mobile

### QA
- ./run or https://snapcraft-io-canonical-websites-pr-1740.run.demo.haus
- go to the store page
- open mobile view (change width of the window)
- scroll to the bottom of the page, store icon should be on the top of the banner

<img width="423" alt="Screenshot 2019-03-26 at 08 22 08" src="https://user-images.githubusercontent.com/83575/54979219-e2cea300-4fa2-11e9-9203-e7dc90201277.png">
