### PR TITLE
Consistently hide disabled screenshot navigation buttons

### DIFF
--- a/static/sass/_patterns_maas_modal.scss
+++ b/static/sass/_patterns_maas_modal.scss
@@ -122,9 +122,9 @@ $color-modal-controls: rgba($color-x-dark, .2);
     width: 3rem;
   }
 
-  .vbox-next:disabled:hover,
-  .vbox-prev:disabled:hover {
-    background-color: $color-x-light;
+  .vbox-next:disabled,
+  .vbox-prev:disabled {
+    display: none;
   }
 
   .vbox-prev {


### PR DESCRIPTION
Fixes #455

Hides inactive screenshots navigation button in fullscreen.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1741.run.demo.haus/
- go to snap details page of any snap with multiple screenshots
- make screen small enough to screenshot 'next' button to appear
- scroll to the last screenshot (button should disappear)
- click on last screenshot to open fullscreen
- 'next' button on full screen should not be visible
- use 'prev' button to move to first screenshot
- 'prev' button should not be visible on first screenshot

<img width="1259" alt="Screenshot 2019-03-26 at 11 28 54" src="https://user-images.githubusercontent.com/83575/54990376-e0784300-4fba-11e9-8dd9-0c41da996915.png">
