### PR TITLE
Fix slanted background not to collide with content on huge screens

### DIFF
--- a/static/sass/_patterns_strip_slanted.scss
+++ b/static/sass/_patterns_strip_slanted.scss
@@ -5,21 +5,37 @@
   $slanted-edge-padding: $horizontal-edge-padding * 2; // coloured area takes half the rectangle surface area; to visually compensate, we multiply it by 2
   $bleed: -3px; // stretch outside to compensate for aliasing; otherwise edge of image underneath becomes visible as you resize
 
+  $color-slanted-background: #106363;
+
   %vf-strip-slanted {
+    background-color: $color-slanted-background;
     background-position: 50% 50%;
-    background-color: #106363;
     margin-top: $bleed;
+    min-height: 30vh;
     overflow: hidden;
     position: relative;
-    min-height: 30vh;
 
     @media (max-width: $breakpoint-large) {
       background-size: cover;
       padding: $spv-inter--regular-scaleable 0 $slanted-edge-padding;
     }
+
     @media (min-width: $breakpoint-large) {
       background-size: 5000px 667px; // actual svg size
       padding: $spv-inter--regular-scaleable 0 $slanted-edge-padding;
+    }
+
+    // custom styles for extra large screens
+    @media (min-width: 2300px) {
+      padding-bottom: $slanted-edge-padding + 2rem;
+    }
+
+    @media (min-width: 3000px) {
+      padding-bottom: $slanted-edge-padding + 4rem;
+    }
+
+    @media (min-width: 3500px) {
+      padding-bottom: $slanted-edge-padding + 6rem;
     }
 
     &::after {


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/snap-squad/issues/946

Updates slanted strip styles to make sure background doesn't collide with content (on snap search page) on very large screens.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1742.run.demo.haus/
- go to the [store page](https://snapcraft-io-canonical-websites-pr-1742.run.demo.haus/store)
- open it on a very large screen (2500px wide or higher)
- there should be enough spacing for search input and button to be on a green slanted background (not overflow with white)


<img width="1920" alt="Screenshot 2019-03-26 at 13 18 49" src="https://user-images.githubusercontent.com/83575/54996499-c2660f00-4fc9-11e9-8d6d-033bd87cf362.png">
