### PR TITLE
Removes “by” from publisher name

### DIFF
--- a/templates/store/_snap-header-information.html
+++ b/templates/store/_snap-header-information.html
@@ -1,4 +1,4 @@
-by {{ display_name(publisher, username) }}
+{{ display_name(publisher, username) }}
 {% if developer_validation and developer_validation == VERIFIED_PUBLISHER %}
 <span class="p-verified p-tooltip p-tooltip--top-center" aria-describedby="{{ package_name }}-tooltip">
   <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg" />


### PR DESCRIPTION
A big advantage of snaps is that the author and publisher are usually the same person. In the few cases where they aren’t, it’s important that we don’t imply that the publisher is the author: it can upset the real author, and sour them on the platform.

Dropping the “by” from the store page:
- avoids this implication
- marginally simplifies the page
- is consistent with how the publisher is presented on the [App Store Preview](https://itunes.apple.com/us/app/skype-for-iphone/id304878510), [Microsoft Store](https://www.microsoft.com/en-us/p/skype/9wzdncrfj364?activetab=pivot:overviewtab), and [Google Play](https://play.google.com/store/apps/details?id=com.skype.raider&hl=en_US).