### PR TITLE
Move snap owner banner to the top of the page

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -66,6 +66,15 @@
     <div class="snapcraft-details-preview">
   {% endif %}
   <div class="p-strip--light is-shallow snapcraft-banner-background">
+    {% if is_users_snap and not is_preview %}
+      <div class="row js-snap-owner-notification">
+        <div class="p-notification--information">
+          <p class="p-notification__response">
+            Ensure your snap always stays relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
+          </p>
+        </div>
+      </div>
+    {% endif %}
     <div class="row">
       <div class="p-snap-heading">
         {% if icon_url %}
@@ -133,15 +142,6 @@
       {% endif %}
         </div>
     </div>
-    {% if is_users_snap and not is_preview %}
-      <div class="row js-snap-owner-notification">
-        <div class="p-notification--information">
-          <p class="p-notification__response">
-            Ensure your snap always stays relevant and compelling. <a href="/{{ package_name }}/listing">Update its listing information here</a>.
-          </p>
-        </div>
-      </div>
-    {% endif %}
   </div>
 
   {% if not webapp_config['STORE_QUERY'] %}


### PR DESCRIPTION
Fixes #950 

Fixes spacing issues around owner notification by moving it up to the top of the page.

### QA
- ./run or  https://snapcraft-io-canonical-websites-pr-1760.run.demo.haus/
- go to snap details page of snap you own
- owner notification should appear on the top
- resize the screen, spacing should be fine on all the widths

<img width="1028" alt="Screenshot 2019-04-01 at 11 06 27" src="https://user-images.githubusercontent.com/83575/55316703-42c7bc80-546f-11e9-9253-0f78bdd489d8.png">
