### PR TITLE
Correctly check published status in revision not snap data

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -124,7 +124,7 @@ My published snaps — Linux software in the Snap Store
           {% for snap in snaps|sort %}
             {% with %}
               {% set dispute_pending = snaps[snap].status == "DisputePending" %}
-              {% set published = snaps[snap].status == "Published" %}
+              {% set published = snaps[snap].latest_revisions[0].status == "Published" %}
               <tr>
                 <td>
                   <a href="/account/snaps/{{snap}}/listing" class="u-vertically-center">


### PR DESCRIPTION
Fixes #1749 

Correctly check published status in revision not snap data.

Note: This just a quick fix that reverts back to checking status of latest revision. It works just as before the bug was introduced, but has a separate issue when latest revision is published but not released to any channel yet (reported separately in #1765).

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1764.run.demo.haus/
- Sign in to see your snaps list
- Look at 'Latest release' column, any released snap should correctly show channel name

<img width="1047" alt="Screenshot 2019-04-02 at 09 43 57" src="https://user-images.githubusercontent.com/83575/55384800-eecedd80-552b-11e9-94e4-b8b5b3d35595.png">
