### PR TITLE
Fix multiple code on a line

### DIFF
--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -93,7 +93,7 @@ class TestMarkdownParser(unittest.TestCase):
         """
         markdown = "```code block```"
         result = parse_markdown_description(markdown)
-        expected_result = "<p><code>``code block``</code></p>\n"
+        expected_result = "<p>```code block```</p>\n"
 
         self.assertEqual(result, expected_result)
 
@@ -134,11 +134,22 @@ class TestMarkdownParser(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_parse_code_line(self):
-        """Code (text blocks inside ` or ``` pairs)
+        """Code (text blocks inside `)
         """
         markdown = "`code line`"
         result = parse_markdown_description(markdown)
         expected_result = "<p><code>code line</code></p>\n"
+
+        self.assertEqual(result, expected_result)
+
+    def test_parse_multiple_code_line(self):
+        """Code (text blocks inside `)
+        """
+        markdown = "`code line` and `code line`"
+        result = parse_markdown_description(markdown)
+        expected_result = (
+            "<p><code>code line</code> and <code>code line</code></p>\n"
+        )
 
         self.assertEqual(result, expected_result)
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -73,7 +73,7 @@ class DescriptionInlineGrammar(InlineGrammar):
 
         # Rewrite to respect this convention:
         # https://github.com/CanonicalLtd/snap-squad/issues/936
-        self.code = re.compile(r"^(`)([\S ]+)\1")
+        self.code = re.compile(r"^(`)([ \S]*?[^`])\1(?!`)")
 
 
 class DescriptionInline(InlineLexer):


### PR DESCRIPTION
Fixes #1762 

Make sure multiple code blocks on a line are working

# qa

- On a snap add the following description: 

```
`this` is `a` line `with` a `lot` of `code`
```
- make sure the snap is well displayed 
- You can also check this snap: http://localhost:8004/b2