### PR TITLE
Remove deleted screenshots from state

### DIFF
--- a/static/js/publisher/form.js
+++ b/static/js/publisher/form.js
@@ -146,13 +146,6 @@ function initForm(config, initialState, errors) {
 
   let state = JSON.parse(JSON.stringify(initialState));
 
-  const stateInput = document.createElement("input");
-  stateInput.type = "hidden";
-  stateInput.name = "state";
-  stateInput.value = "";
-
-  formEl.appendChild(stateInput);
-
   const diffInput = document.createElement("input");
   diffInput.type = "hidden";
   diffInput.name = "changes";
@@ -315,16 +308,6 @@ function initForm(config, initialState, errors) {
 
     // if anything was changed, update state inputs and submit
     if (diff) {
-      // TODO: temporary soluton - save clean state in state input,
-      // so save still works until backend is update to understand diff
-      const cleanState = JSON.parse(JSON.stringify(state));
-      if (cleanState.images) {
-        cleanState.images = cleanState.images.filter(
-          image => image.status !== "delete"
-        );
-      }
-
-      stateInput.value = JSON.stringify(cleanState);
       diffInput.value = JSON.stringify(diff);
 
       // make sure we don't warn user about leaving the page when submitting

--- a/static/js/publisher/form.test.js
+++ b/static/js/publisher/form.test.js
@@ -294,11 +294,6 @@ describe("initForm", () => {
     form.parentNode.removeChild(form);
   });
 
-  test("should create state input", () => {
-    const stateInput = document.querySelector("[name='state']");
-    expect(stateInput.value).toEqual("");
-  });
-
   test("should create diff input", () => {
     const diffInput = document.querySelector("[name='changes']");
     expect(diffInput.value).toEqual("");

--- a/static/js/publisher/form/media.js
+++ b/static/js/publisher/form/media.js
@@ -28,15 +28,8 @@ class Media extends React.Component {
   }
 
   markForDeletion(key) {
-    const newMediaData = this.state.mediaData.map(item => {
-      if (item.url === key) {
-        item.status = "delete";
-      }
-      return item;
-    });
-
     this.setState({
-      mediaData: newMediaData
+      mediaData: this.state.mediaData.filter(item => item.url !== key)
     });
   }
 
@@ -65,10 +58,7 @@ class Media extends React.Component {
   }
 
   renderOverLimit() {
-    if (
-      this.state.mediaData.filter(item => item.status !== "delete").length >
-      this.props.mediaLimit
-    ) {
+    if (this.state.mediaData.length > this.props.mediaLimit) {
       return (
         <div className="p-notification--caution">
           <p className="p-notification__response">
@@ -155,9 +145,7 @@ class Media extends React.Component {
 
   renderInputs() {
     const { mediaLimit, restrictions } = this.props;
-    const currentMedia = this.state.mediaData.filter(
-      media => media.status !== "delete"
-    ).length;
+    const currentMedia = this.state.mediaData.length;
     const inputs = [];
 
     for (let i = 0; i < mediaLimit; i++) {
@@ -198,9 +186,7 @@ class Media extends React.Component {
   }
 
   render() {
-    const mediaList = this.state.mediaData.filter(
-      item => item.status !== "delete"
-    );
+    const mediaList = this.state.mediaData;
 
     return (
       <Fragment>

--- a/static/js/publisher/form/media.test.js
+++ b/static/js/publisher/form/media.test.js
@@ -26,21 +26,6 @@ describe("Media", () => {
     expect(container.querySelector(`[src="test"]`).length).toBeUndefined();
   });
 
-  it("should render without image, if the only image defined has status of `delete`", () => {
-    const { container } = render(
-      <Media
-        mediaData={[
-          {
-            url: "test",
-            status: "delete"
-          }
-        ]}
-      />
-    );
-
-    expect(container.querySelectorAll(imageSelector).length).toEqual(0);
-  });
-
   it("should set the focus state to an item", () => {
     const { container } = render(
       <Media
@@ -198,7 +183,7 @@ describe("Media", () => {
       cont = container;
     });
 
-    it("should set an item to be removed", () => {
+    it("should remove an item from images list", () => {
       const deleteImages = cont.querySelectorAll(
         ".p-listing-images__delete-image"
       );
@@ -208,10 +193,6 @@ describe("Media", () => {
 
       expect(updateState.mock.calls.length).toEqual(1);
       expect(updateState.mock.calls[0][0]).toEqual([
-        {
-          status: "delete",
-          url: "test"
-        },
         {
           status: "uploaded",
           url: "test-2"

--- a/static/js/publisher/preview.js
+++ b/static/js/publisher/preview.js
@@ -73,7 +73,7 @@ function transformStateImages(state) {
     state.images.forEach(image => {
       if (image.type === "icon") {
         newState.icon = image.url;
-      } else if (image.type === "screenshot" && image.status !== "delete") {
+      } else if (image.type === "screenshot") {
         newState.screenshots.push(image.url);
       }
     });

--- a/static/js/publisher/state.js
+++ b/static/js/publisher/state.js
@@ -76,8 +76,6 @@ function diffState(initialState, state) {
     // images is an array of objects so compare stringified version
     if (key === "images" && state[key]) {
       const images = state[key]
-        // remove images to delete from the diff
-        .filter(image => image.status !== "delete")
         // ignore selected status when comparing
         .map(image => {
           delete image.selected;

--- a/static/js/publisher/state.test.js
+++ b/static/js/publisher/state.test.js
@@ -99,31 +99,6 @@ describe("diffState", () => {
 
   // when comparing images
   describe("when comparing images in state", () => {
-    test("should remove images marked for deletion", () => {
-      expect(
-        diffState(
-          {
-            images: [
-              { url: "test1.png", status: "uploaded" },
-              { url: "test2.png", status: "uploaded" }
-            ]
-          },
-          {
-            images: [
-              { url: "test1.png", status: "uploaded" },
-              { url: "test2.png", status: "delete" },
-              { url: "test3.png", status: "new" }
-            ]
-          }
-        )
-      ).toEqual({
-        images: [
-          { url: "test1.png", status: "uploaded" },
-          { url: "test3.png", status: "new" }
-        ]
-      });
-    });
-
     test("should ignore selected status", () => {
       expect(
         diffState(


### PR DESCRIPTION
Removes deleted screenshot from form state (instead of just changing their status).
This cleans up different parts of code and will help with reordering screenshots.

### QA

- ./run or demo
- go to listing page of any snap
- add screenshots, delete screenshots, just test screenshots from different angles
- everything should work as before