### PR TITLE
Allow banners

### DIFF
--- a/static/js/libs/fileValidation.js
+++ b/static/js/libs/fileValidation.js
@@ -41,6 +41,19 @@ function imageRestrictions(file, restrictions) {
     image.addEventListener("load", () => {
       const width = image.naturalWidth;
       const height = image.naturalHeight;
+
+      if (
+        (file.name.indexOf("banner.") === 0 &&
+          width === 1218 &&
+          height === 240) ||
+        (file.name.indexOf("banner-icon.") === 0 &&
+          width === 240 &&
+          height === 240)
+      ) {
+        resolve(file);
+        return;
+      }
+
       const aspectRatio = width / height;
       let hasDimensionError = false;
       if (restrictions.width) {

--- a/static/js/libs/fileValidation.test.js
+++ b/static/js/libs/fileValidation.test.js
@@ -1,8 +1,8 @@
 import { validateRestrictions } from "./fileValidation";
 
-function generateFile(options) {
+function generateFile(options, name = "test") {
   const fileContents = "testymctestface";
-  return new File([fileContents], "test", options);
+  return new File([fileContents], name, options);
 }
 
 describe("validateRestrictions", () => {
@@ -372,6 +372,36 @@ describe("validateRestrictions", () => {
 
         expect(validation.errors).toBeUndefined();
       });
+    });
+
+    it("should allow through banner image", async () => {
+      const file = generateFile({ type: "image/png" }, "banner.jpg");
+
+      generateImage({
+        naturalWidth: 1218,
+        naturalHeight: 240
+      });
+
+      const validation = await validateRestrictions(file, {
+        ...restrictions
+      });
+
+      expect(validation.errors).toBeUndefined();
+    });
+
+    it("should allow through banner-icon image", async () => {
+      const file = generateFile({ type: "image/png" }, "banner-icon.png");
+
+      generateImage({
+        naturalWidth: 240,
+        naturalHeight: 240
+      });
+
+      const validation = await validateRestrictions(file, {
+        ...restrictions
+      });
+
+      expect(validation.errors).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1777

Allows through banner and banner icons that match those names and appropriate widths and heights.