### PR TITLE
Move 'Continue' button in FSF language selector

### DIFF
--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -8,6 +8,11 @@
       <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
       <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
     </ul>
+
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example C/C++ app in the Snap Store.</p>
+      <a class="p-button--positive" href="first-snap/c">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -17,10 +22,10 @@
 <b>summary</b>: DOS emulator
 <b>description</b>: |
   DOSBox is a x86 emulator with Tandy/Hercules/
-  CGA/EGA/VGA/SVGA graphics sound and DOS. It's 
-  been designed to run old DOS games under 
+  CGA/EGA/VGA/SVGA graphics sound and DOS. It's
+  been designed to run old DOS games under
   platforms that don't support it.
-  
+
 <b>confinement</b>: devmode
 <b>base</b>: core18
 
@@ -91,14 +96,9 @@
 <b>apps</b>:
   <b>dosbox</b>:
     <b>command</b>: dosbox
-	environment: 
+	environment:
       "LD_LIBRARY_PATH": "$SNAP/usr/lib/
 	  $SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
       "DISABLE_WAYLAND": "1"</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example C/C++ app in the Snap Store.
-    <a class="p-button--positive is-inline" href="first-snap/c">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_electron.html
+++ b/templates/home/_fsf_electron.html
@@ -8,6 +8,11 @@
       <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
       <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
     </ul>
+
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Electron app in the Snap Store.</p>
+      <a class="p-button--positive" href="https://docs.snapcraft.io/build-snaps/electron">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -36,10 +41,5 @@
     <b>"electron-builder"</b>: "^20.27.1"
   }
 }</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Electron app in the Snap Store.
-    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/electron">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -11,6 +11,11 @@
       However, end user discovery and update management remain a challenge.
       Snaps fill this gap, letting you distribute a Go app in an app store experience for end users.
     </p>
+
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Go app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/golang">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -19,7 +24,7 @@
 <b>version</b>: git
 <b>summary</b>: An interactive web server.
 <b>description</b>: |
-  HTTPLab let you inspect HTTP requests and forge 
+  HTTPLab let you inspect HTTP requests and forge
   responses.
 
 <b>confinement</b>: devmode
@@ -33,14 +38,9 @@
     <b>source-type</b>: git
     <b>build-packages</b>:
 	  - gcc
-		
+
 <b>apps</b>:
   <b>httplab</b>:
     <b>command</b>: bin/httplab</pre></code>
-</div>
-
-<div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Go app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/golang">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -5,22 +5,26 @@
       <li>Simplify installation instructions, regardless of distribution, to snap install myjavaapp.</li>
       <li>Directly control the delivery of automatic application updates.</li>
     </ul>
-	<p>Distributing a Java application for Linux and reaching the widest possible audience is complicated. Typically, the user has to make sure the JRE/SDK version and their environment are configured correctly. When a Linux distribution changes the delivered JRE, this can be problematic for applications. Snapcraft ensures the correct JRE is shipped alongside the application at all times.</p>
+	   <p>Distributing a Java application for Linux and reaching the widest possible audience is complicated. Typically, the user has to make sure the JRE/SDK version and their environment are configured correctly. When a Linux distribution changes the delivered JRE, this can be problematic for applications. Snapcraft ensures the correct JRE is shipped alongside the application at all times.</p>
+
+     <div class="p-flow-details__continue">
+       <p>In just a few steps, you’ll have an example Java app in the Snap Store.</p>
+       <a class="p-button--positive" href="/first-snap/java">Continue</a>
+     </div>
   </div>
 
   <div class='col-6'>
     <h4>Here's how <a href="https://snapcraft.io/freeplane-mindmapping">freeplane</a> defines snapcraft.yaml:</h4>
     <code class="p-code-yaml"><pre><b>name</b>: freeplane
 <b>version</b>: '1.6.10'
-<b>summary</b>: Application for Mind Mapping, Knowledge and Project 
-Management
+<b>summary</b>: Application for Mind Mapping, Knowledge and Project Management
 <b>description</b>: |
-  Freeplane is a free and open source software 
-  application that supports thinking, sharing 
-  information and getting things done at work, 
-  in school and at home. The core of the 
-  software is tools for mind mapping (also known 
-  as concept mapping or information mapping) 
+  Freeplane is a free and open source software
+  application that supports thinking, sharing
+  information and getting things done at work,
+  in school and at home. The core of the
+  software is tools for mind mapping (also known
+  as concept mapping or information mapping)
   and using mapped information.
 
 <b>confinement</b>: devmode
@@ -42,10 +46,5 @@ Management
 <b>apps</b>:
   <b>freeplane</b>:
     <b>command</b>: desktop-launch $SNAP/freeplane-1.6.10/freeplane.sh</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Java app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/java">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -8,10 +8,9 @@
       <li>Upgrades are not disruptive. Because upgrades are not in-place, users can keep your app open as it’s upgraded in the background.</li>
       <li>Upgrades are safe. If your app fails to upgrade, users automatically roll back to the previous revision.</li>
     </ul>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example MOOS app in the Snap Store.
-    <a class="p-button--positive is-inline" href="https://docs.snapcraft.io/build-snaps/moos">Continue</a>
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example MOOS app in the Snap Store.</p>
+      <a class="p-button--positive" href="https://docs.snapcraft.io/build-snaps/moos">Continue</a>
+    </div>
   </div>
 </div>

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -5,8 +5,12 @@
       <li>Easy to discover and install by millions using the Snap Store or command-line every day.</li>
       <li>Automatically updated to the latest stable version of your app.</li>
       <li>Revert to the previous version if an update fails, preserving data.</li>
-	</ul>
+	  </ul>
     <p>With npm you can distribute apps to other developers, but it’s not tailored to end users. Snaps let you distribute your Node app in an app store experience.</p>
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Node.js app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/node">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -33,10 +37,5 @@
 <b>apps</b>:
   <b>wethr</b>:
     <b>command</b>: wethr</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Node.js app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/node">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -13,6 +13,10 @@
         However, end user discovery and update management remain a challenge.
         Snaps fill this gap, letting you wrap your existing Linux build in an app store experience for end users.
       </p>
+      <div class="p-flow-details__continue">
+        <p>In just a few steps, you’ll have an example pre-built app in the Snap Store.</p>
+        <a class="p-button--positive" href="/first-snap/pre-built">Continue</a>
+      </div>
   </div>
 
   <div class='col-6'>
@@ -38,10 +42,5 @@
 <b>apps</b>:
   <b>geekbench4</b>:
     <b>command</b>: geekbench4</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example pre-built app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/pre-built">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -13,6 +13,10 @@
       Virtualenv lets you install an app’s dependencies in isolation, but it’s not automatically used for installs from PyPI.
       Snaps let you distribute a dependency-isolated Python app in an app store experience for end users.
     </p>
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Python app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/python">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -38,10 +42,5 @@
 <b>apps</b>:
   <b>offlineimap</b>:
     <b>command</b>: bin/offlineimap</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Python app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/python">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -7,6 +7,10 @@
       <li>Directly and reliably control the delivery of application updates using existing infrastructure.</li>
       <li>Extremely simple creation of daemons.</li>
     </ul>
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example ROS app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/ros">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -31,10 +35,5 @@
   <b>ros-talker-listener</b>:
     <b>command</b>: roslaunch roscpp_tutorials talker_listener.launch
 </pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example ROS app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/ros">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -7,6 +7,10 @@
       <li>Directly and reliably control the delivery of application updates using existing infrastructure.</li>
       <li>Extremely simple creation of daemons.</li>
     </ul>
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example ROS2 app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/ros2">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -34,10 +38,5 @@
   <b>ros2-talker-listener</b>:
     <b>command</b>: opt/ros/crystal/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
 </pre></code>
-  </div>
-  
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example ROS2 app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/ros2">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -7,7 +7,12 @@
       <li>Directly control the delivery of automatic application updates.</li>
       <li>Extremely simple creation of services.</li>
     </ul>
-	<p>Linux install instructions for Ruby applications often get complicated. To prevent modules from different Ruby applications clashing with each other, developer tools like rvm or rbenv must be used. With snapcraft, it’s one command to produce a bundle that works anywhere.</p>
+    <p>Linux install instructions for Ruby applications often get complicated. To prevent modules from different Ruby applications clashing with each other, developer tools like rvm or rbenv must be used. With snapcraft, it’s one command to produce a bundle that works anywhere.</p>
+
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Ruby app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/ruby">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -36,10 +41,5 @@
 <b>apps</b>:
   <b>mdl</b>:
     <b>command</b>: bin/mdl</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Ruby app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/ruby">Continue</a>
   </div>
 </div>

--- a/templates/home/_fsf_rust.html
+++ b/templates/home/_fsf_rust.html
@@ -5,9 +5,13 @@
       <li>Easy to discover and install by millions using the Snap Store or command-line every day.</li>
       <li>Automatically updated to the latest stable version of your app.</li>
       <li>Revert to the previous version if an update fails, preserving data.</li>
-	</ul>
-You can distribute your apps across Linux using a musl-enabled version of Rust, with all the dependencies satisfied. However, end user discovery and update management remain a challenge. Snaps fill this gap, letting you distribute a Rust app in an app store experience for end users.
     </ul>
+    <p>You can distribute your apps across Linux using a musl-enabled version of Rust, with all the dependencies satisfied. However, end user discovery and update management remain a challenge. Snaps fill this gap, letting you distribute a Rust app in an app store experience for end users.</p>
+
+    <div class="p-flow-details__continue">
+      <p>In just a few steps, you’ll have an example Rust app in the Snap Store.</p>
+      <a class="p-button--positive" href="/first-snap/rust">Continue</a>
+    </div>
   </div>
 
   <div class='col-6'>
@@ -17,14 +21,14 @@ You can distribute your apps across Linux using a musl-enabled version of Rust, 
 <b>version</b>: git
 <b>summary</b>: A fast CSV command line toolkit written in Rust
 <b>description</b>: |
-  xsv is a command line program for indexing, 
-  slicing, analyzing, splitting and joining CSV 
-  files. Commands should be simple, fast and 
+  xsv is a command line program for indexing,
+  slicing, analyzing, splitting and joining CSV
+  files. Commands should be simple, fast and
   composable:
   - Simple tasks should be easy.
-  - Performance trade offs should be exposed 
+  - Performance trade offs should be exposed
     in the CLI interface.
-  - Composition should not come at the 
+  - Composition should not come at the
     expense of performance.
 
 <b>confinement</b>: devmode
@@ -38,10 +42,5 @@ You can distribute your apps across Linux using a musl-enabled version of Rust, 
 <b>apps</b>:
   <b>xsv</b>:
     <b>command</b>: bin/xsv</pre></code>
-  </div>
-
-  <div class="p-flow-details__continue">
-    In just a few steps, you’ll have an example Rust app in the Snap Store.
-    <a class="p-button--positive is-inline" href="/first-snap/rust">Continue</a>
   </div>
 </div>


### PR DESCRIPTION
Fixes #1780

Moves 'Continue' button under the description of languages to make them easier to find and reach.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1794.run.demo.haus/
- click on any language selector
- continue button should be in the description
- try different (all if you fancy) languages to check everything was updated.

<img width="1030" alt="Screenshot 2019-04-05 at 12 43 04" src="https://user-images.githubusercontent.com/83575/55622404-686f0180-57a0-11e9-821a-1e819b399ab7.png">
