### PR TITLE
Detect OS in first snap flow install step

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -30,14 +30,7 @@ function install(language) {
     const userAgent = window.navigator.userAgent;
     const isMac = !!userAgent.match(/Mac/);
     const isLinux = !!userAgent.match(/(Linux)|(X11)/);
-    const isWin = !!userAgent.match(/Windows/);
-    const userOS = isMac
-      ? "macos"
-      : isLinux
-        ? "linux"
-        : isWin
-          ? "windows"
-          : null;
+    const userOS = isMac ? "macos" : isLinux ? "linux" : null;
 
     Array.prototype.slice.call(osPickers).forEach(function(os) {
       if (os.dataset.os === userOS) {

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -6,40 +6,61 @@ function install(language) {
   const osPickers = document.querySelectorAll(".js-os-select");
   const osWrappers = document.querySelectorAll(".js-os-wrapper");
 
+  function select(selectedOs) {
+    if (osWrappers) {
+      Array.prototype.slice.call(osWrappers).forEach(function(wrapper) {
+        wrapper.classList.add("u-hide");
+      });
+    }
+    const selectedEl = document.querySelector(".js-" + selectedOs);
+    if (selectedEl) {
+      selectedEl.classList.remove("u-hide");
+    }
+
+    if (!document.querySelector(".js-linux-manual")) {
+      const continueBtn = document.querySelector(".js-continue");
+      if (continueBtn) {
+        continueBtn.classList.remove("is--disabled");
+        continueBtn.href = `/first-snap/${language}/${selectedOs}/package`;
+      }
+    }
+  }
+
   if (osPickers) {
+    const userAgent = window.navigator.userAgent;
+    const isMac = !!userAgent.match(/Mac/);
+    const isLinux = !!userAgent.match(/(Linux)|(X11)/);
+    const isWin = !!userAgent.match(/Windows/);
+    const userOS = isMac
+      ? "macos"
+      : isLinux
+        ? "linux"
+        : isWin
+          ? "windows"
+          : null;
+
     Array.prototype.slice.call(osPickers).forEach(function(os) {
+      if (os.dataset.os === userOS) {
+        os.classList.add("is-selected");
+      }
+
       os.addEventListener("click", function(e) {
         const osSelect = e.target.closest(".js-os-select");
         if (!osSelect) {
           return;
         }
 
-        const selectedOs = osSelect.dataset.os;
-
         osPickers.forEach(function(picker) {
           picker.classList.remove("is-selected");
         });
         osSelect.classList.add("is-selected");
-
-        if (osWrappers) {
-          Array.prototype.slice.call(osWrappers).forEach(function(wrapper) {
-            wrapper.classList.add("u-hide");
-          });
-        }
-        const selectedEl = document.querySelector(".js-" + selectedOs);
-        if (selectedEl) {
-          selectedEl.classList.remove("u-hide");
-        }
-
-        if (!document.querySelector(".js-linux-manual")) {
-          const continueBtn = document.querySelector(".js-continue");
-          if (continueBtn) {
-            continueBtn.classList.remove("is--disabled");
-            continueBtn.href = `/first-snap/${language}/${selectedOs}/package`;
-          }
-        }
+        select(osSelect.dataset.os);
       });
     });
+
+    if (userOS) {
+      select(userOS);
+    }
   }
 
   function onChange(e) {


### PR DESCRIPTION
Fixes #1781 

Automatically selects users operating system in first snap flow install step.

### QA

- ./run or demo
- go to first snap flow, choose language
- on OS selection page your OS should be already selected (if one of MacOS or Linux)
- on Windows nothing should get selected

<img width="1064" alt="Screenshot 2019-04-05 at 15 10 44" src="https://user-images.githubusercontent.com/83575/55630358-c6f2aa80-57b5-11e9-8aaf-63e900ebef9c.png">
