### PR TITLE
Don't loop asciinema on details pages

### DIFF
--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -6,5 +6,5 @@
           webkitallowfullscreen mozallowfullscreen allowfullscreen
           src="{{ video.url }}?loop=1&title=0&byline=0&portrait=0&transparent=0"></iframe>
 {% elif video.type == "asciinema" %}
-  <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-loop="1" data-preload="0"></script>
+  <script src="{{ video.url }}" id="asciicast-{{ video.id }}" async data-autoplay="1" data-preload="0"></script>
 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1763#event-2252195260

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/<snap_with_asciinema>
- Watch the asciinema, see that it doesn't loop