### PR TITLE
Updated italics legend markdown

### DIFF
--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -320,7 +320,7 @@
               </div>
               <div class="col-4">
                 <p><small>
-                  <b>Italics:</b> <code>__Foo__</code>
+                  <b>Italics:</b> <code>_Foo_</code>
                 </small></p>
                 <p><small>
                   <b>Code:</b> Text indented with 3 spaces or inside <code>`</code>


### PR DESCRIPTION
### QA Steps

1. Pull the branch or run the demo service
2. Visit the `/listing` page of a snap you own
3. Tap/click on Show supported markdown syntax
4. Notice the legend on italics is stating `_foo_`
5. #winning