### PR TITLE
Update styling of first snap flow breadcrumbs

### DIFF
--- a/templates/first-snap/_breadcrumb.html
+++ b/templates/first-snap/_breadcrumb.html
@@ -1,40 +1,42 @@
-<div class="row">
-  <ul class="p-breadcrumbs p-heading--four" style="max-width: 100%;">
-    <li class="p-breadcrumbs__item">
-      <a href="/first-snap/">Language</a>
-    </li>
-    <li class="p-breadcrumbs__item">
-      {% if fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
-        <a href="/first-snap/{{ language }}">Install Snapcraft</a>
-      {% else %}
-        Install Snapcraft
-      {% endif %}
-    </li>
-    <li class="p-breadcrumbs__item{% if fsf_step == 'install' %} is-disabled{% endif %}">
-      {% if fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
-        <a href="/first-snap/{{ language }}/{{ os }}/package">Package</a>
-      {% else %}
-        Package
-      {% endif %}
-    </li>
-    <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' %} is-disabled{% endif %}">
-      {% if fsf_step == 'test' or fsf_step == 'push' %}
-        <a href="/first-snap/{{ language }}/{{ os }}/build">Build</a>
-      {% else %}
-        Build
-      {% endif %}
-    </li>
-    {% if os and os.startswith('macos') %}
-      <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' %} is-disabled{% endif %}">
-        {% if fsf_step == 'push' %}
-          <a href="/first-snap/{{ language }}/{{ os }}/test">Test</a>
+<div class="p-strip is-shallow snapcraft-banner-background">
+  <div class="row">
+    <ul class="p-breadcrumbs p-heading--four" style="max-width: 100%;">
+      <li class="p-breadcrumbs__item">
+        <a href="/first-snap/">Language</a>
+      </li>
+      <li class="p-breadcrumbs__item">
+        {% if fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
+          <a href="/first-snap/{{ language }}">Install Snapcraft</a>
         {% else %}
-          Test
+          Install Snapcraft
         {% endif %}
       </li>
-    {% endif %}
-    <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' %} is-disabled{% endif %}">
-      Push
-    </li>
-  </ul>
+      <li class="p-breadcrumbs__item{% if fsf_step == 'install' %} is-disabled{% endif %}">
+        {% if fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
+          <a href="/first-snap/{{ language }}/{{ os }}/package">Package</a>
+        {% else %}
+          Package
+        {% endif %}
+      </li>
+      <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' %} is-disabled{% endif %}">
+        {% if fsf_step == 'test' or fsf_step == 'push' %}
+          <a href="/first-snap/{{ language }}/{{ os }}/build">Build</a>
+        {% else %}
+          Build
+        {% endif %}
+      </li>
+      {% if os and os.startswith('macos') %}
+        <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' %} is-disabled{% endif %}">
+          {% if fsf_step == 'push' %}
+            <a href="/first-snap/{{ language }}/{{ os }}/test">Test</a>
+          {% else %}
+            Test
+          {% endif %}
+        </li>
+      {% endif %}
+      <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' %} is-disabled{% endif %}">
+        Push
+      </li>
+    </ul>
+  </div>
 </div>

--- a/templates/first-snap/_breadcrumb.html
+++ b/templates/first-snap/_breadcrumb.html
@@ -2,23 +2,27 @@
   <div class="row">
     <ul class="p-breadcrumbs p-heading--four" style="max-width: 100%;">
       <li class="p-breadcrumbs__item">
-        <a href="/first-snap/">Language</a>
+        {% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
+          <a href="/first-snap/">Language</a>
+        {% else %}
+          Language
+        {% endif %}
       </li>
-      <li class="p-breadcrumbs__item">
+      <li class="p-breadcrumbs__item{% if fsf_step == 'language' %} is-disabled{% endif %}">
         {% if fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
           <a href="/first-snap/{{ language }}">Install Snapcraft</a>
         {% else %}
           Install Snapcraft
         {% endif %}
       </li>
-      <li class="p-breadcrumbs__item{% if fsf_step == 'install' %} is-disabled{% endif %}">
+      <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' %} is-disabled{% endif %}">
         {% if fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
           <a href="/first-snap/{{ language }}/{{ os }}/package">Package</a>
         {% else %}
           Package
         {% endif %}
       </li>
-      <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' %} is-disabled{% endif %}">
+      <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' %} is-disabled{% endif %}">
         {% if fsf_step == 'test' or fsf_step == 'push' %}
           <a href="/first-snap/{{ language }}/{{ os }}/build">Build</a>
         {% else %}
@@ -26,7 +30,7 @@
         {% endif %}
       </li>
       {% if os and os.startswith('macos') %}
-        <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' %} is-disabled{% endif %}">
+        <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' %} is-disabled{% endif %}">
           {% if fsf_step == 'push' %}
             <a href="/first-snap/{{ language }}/{{ os }}/test">Test</a>
           {% else %}
@@ -34,7 +38,7 @@
           {% endif %}
         </li>
       {% endif %}
-      <li class="p-breadcrumbs__item{% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' %} is-disabled{% endif %}">
+      <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' %} is-disabled{% endif %}">
         Push
       </li>
     </ul>

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -3,10 +3,10 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-  <div id="main-content" class="p-strip">
-    {% set fsf_step = "build" %}
-    {% include "first-snap/_breadcrumb.html" %}
+  {% set fsf_step = "build" %}
+  {% include "first-snap/_breadcrumb.html" %}
 
+  <div id="main-content" class="p-strip is-shallow">
     <div class="row">
       <div class="col-8">
         <ol class="p-list-step has-margin">

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -3,9 +3,10 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-  <div id="main-content" class="p-strip">
-    {% set fsf_step = "install" %}
-    {% include "first-snap/_breadcrumb.html" %}
+  {% set fsf_step = "install" %}
+  {% include "first-snap/_breadcrumb.html" %}
+
+  <div id="main-content" class="p-strip is-shallow">
     <div class="row">
       <p>Now we'll set up Snapcraft, the tool for building snaps.</p>
       <h4>What operating system are you developing on?</h4>

--- a/templates/first-snap/language.html
+++ b/templates/first-snap/language.html
@@ -3,10 +3,10 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-<div id="main-content" class="p-strip">
-  {% set fsf_step = "language" %}
-  {% include "first-snap/_breadcrumb.html" %}
+{% set fsf_step = "language" %}
+{% include "first-snap/_breadcrumb.html" %}
 
+<div id="main-content" class="p-strip is-shallow">
   <div class="row">
     <p>First pick the language your app is written in.</p>
   </div>

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -3,10 +3,9 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-  <div id="main-content" class="p-strip">
-    {% set fsf_step = "package" %}
-    {% include "first-snap/_breadcrumb.html" %}
-
+  {% set fsf_step = "package" %}
+  {% include "first-snap/_breadcrumb.html" %}
+  <div id="main-content" class="p-strip is-shallow">
     <div class="row">
       <p>Now we'll take a real world app, and package it as a snap</p>
     </div>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -3,9 +3,9 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-  <div id="main-content" class="p-strip">
-    {% set fsf_step = "push" %}
-    {% include "first-snap/_breadcrumb.html" %}
+  {% set fsf_step = "push" %}
+  {% include "first-snap/_breadcrumb.html" %}
+  <div id="main-content" class="p-strip is-shallow">
 
     <div class="row">
       <ol class="p-list-step has-margin">

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -3,9 +3,9 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-  <div id="main-content" class="p-strip">
-    {% set fsf_step = "test" %}
-    {% include "first-snap/_breadcrumb.html" %}
+  {% set fsf_step = "test" %}
+  {% include "first-snap/_breadcrumb.html" %}
+  <div id="main-content" class="p-strip is-shallow">
 
     <div class="row">
       <div class="col-8">


### PR DESCRIPTION
Fixes #1782

Puts first snap flow breadcrumbs into Snapcraft branded strip to match new design.
Fixes the issue that breadcrumb items were not correctly greyed out on 'languages' page.

### QA

- ./run or demo
- go to first snap flow (via language selector)
- all first snap flow pages should have updated breadcrumbs styling
- breadcrumb should work as before
- go to languages selection page, all items in breadcrumb apart from first one should be greyed out

<img width="1042" alt="Screenshot 2019-04-08 at 09 10 52" src="https://user-images.githubusercontent.com/83575/55705292-c1c47400-59de-11e9-83d6-4a0f9777706a.png">
