### PR TITLE
First snap flow - pagination

### DIFF
--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -23,6 +23,17 @@ function install(language) {
         continueBtn.classList.remove("is--disabled");
         continueBtn.href = `/first-snap/${language}/${selectedOs}/package`;
       }
+      const paginationBtn = document.querySelector(
+        `#js-pagination-${selectedOs}`
+      );
+      if (paginationBtn) {
+        Array.prototype.slice
+          .call(document.querySelectorAll(`.p-pagination__link--next`))
+          .forEach(function(wrapper) {
+            wrapper.classList.add("u-hide");
+          });
+        paginationBtn.classList.remove("u-hide");
+      }
     }
   }
 
@@ -172,6 +183,12 @@ function push() {
       continueBtn.classList.remove("p-button--neutral");
       continueBtn.classList.remove("is--disabled");
       continueBtn.innerHTML = "Continue";
+    }
+
+    const paginationBtn = document.querySelector("#js-pagination-next");
+    if (paginationBtn) {
+      paginationBtn.href = `/${snapName}/listing?from=first-snap`;
+      paginationBtn.classList.remove("u-hide");
     }
   });
 }

--- a/static/js/public/first-snap-flow.js
+++ b/static/js/public/first-snap-flow.js
@@ -18,21 +18,10 @@ function install(language) {
     }
 
     if (!document.querySelector(".js-linux-manual")) {
-      const continueBtn = document.querySelector(".js-continue");
-      if (continueBtn) {
-        continueBtn.classList.remove("is--disabled");
-        continueBtn.href = `/first-snap/${language}/${selectedOs}/package`;
-      }
-      const paginationBtn = document.querySelector(
-        `#js-pagination-${selectedOs}`
-      );
+      const paginationBtn = document.querySelector(`#js-pagination-next`);
       if (paginationBtn) {
-        Array.prototype.slice
-          .call(document.querySelectorAll(`.p-pagination__link--next`))
-          .forEach(function(wrapper) {
-            wrapper.classList.add("u-hide");
-          });
-        paginationBtn.classList.remove("u-hide");
+        paginationBtn.classList.remove("is-disabled");
+        paginationBtn.href = `/first-snap/${language}/${selectedOs}/package`;
       }
     }
   }
@@ -93,9 +82,10 @@ function install(language) {
     selected.classList.remove("u-hide");
     unselected.classList.add("u-hide");
 
-    const continueBtn = document.querySelector(".js-continue");
-    if (continueBtn) {
-      continueBtn.href = `/first-snap/${language}/${type}/package`;
+    const paginationBtn = document.querySelector(`#js-pagination-next`);
+    if (paginationBtn) {
+      paginationBtn.classList.remove("is-disabled");
+      paginationBtn.href = `/first-snap/${language}/${type}/package`;
     }
   }
 
@@ -188,7 +178,7 @@ function push() {
     const paginationBtn = document.querySelector("#js-pagination-next");
     if (paginationBtn) {
       paginationBtn.href = `/${snapName}/listing?from=first-snap`;
-      paginationBtn.classList.remove("u-hide");
+      paginationBtn.classList.remove("is-disabled");
     }
   });
 }

--- a/static/sass/_patterns_pagination.scss
+++ b/static/sass/_patterns_pagination.scss
@@ -1,0 +1,14 @@
+@mixin snapcraft-p-pagination {
+  .p-pagination__link--previous,
+  .p-pagination__link--next {
+    &.is-disabled {
+      cursor: default;
+      opacity: .5;
+      pointer-events: none;
+
+      &:hover {
+        background-color: transparent;
+      }
+    }
+  }
+}

--- a/static/sass/_patterns_pagination.scss
+++ b/static/sass/_patterns_pagination.scss
@@ -1,6 +1,12 @@
 @mixin snapcraft-p-pagination {
   .p-pagination__link--previous,
   .p-pagination__link--next {
+    $color-darken-transparent: rgba(0, 0, 0, .1);
+
+    &:hover {
+      background-color: $color-darken-transparent;
+    }
+
     &.is-disabled {
       cursor: default;
       opacity: .5;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -232,6 +232,10 @@ $color-navigation-background: #252525;
 @import 'snapcraft_p-file-input';
 @include snapcraft-p-file-input;
 
+@import 'patterns_pagination';
+@include snapcraft-p-pagination;
+
+
 html,
 body {
   background: $color-x-light; // This will be fix on vanilla https://github.com/vanilla-framework/vanilla-framework/issues/2129

--- a/templates/first-snap/_breadcrumb.html
+++ b/templates/first-snap/_breadcrumb.html
@@ -3,9 +3,9 @@
     <ul class="p-breadcrumbs p-heading--four" style="max-width: 100%;">
       <li class="p-breadcrumbs__item">
         {% if fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
-          <a href="/first-snap/">Language</a>
+          <a href="/first-snap/">Select language</a>
         {% else %}
-          Language
+          Select language
         {% endif %}
       </li>
       <li class="p-breadcrumbs__item{% if fsf_step == 'language' %} is-disabled{% endif %}">
@@ -17,29 +17,29 @@
       </li>
       <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' %} is-disabled{% endif %}">
         {% if fsf_step == 'build' or fsf_step == 'test' or fsf_step == 'push' %}
-          <a href="/first-snap/{{ language }}/{{ os }}/package">Package</a>
+          <a href="/first-snap/{{ language }}/{{ os }}/package">Package snap</a>
         {% else %}
-          Package
+          Package snap
         {% endif %}
       </li>
       <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' %} is-disabled{% endif %}">
         {% if fsf_step == 'test' or fsf_step == 'push' %}
-          <a href="/first-snap/{{ language }}/{{ os }}/build">Build</a>
+          <a href="/first-snap/{{ language }}/{{ os }}/build">Build snap</a>
         {% else %}
-          Build
+          Build snap
         {% endif %}
       </li>
       {% if os and os.startswith('macos') %}
         <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' %} is-disabled{% endif %}">
           {% if fsf_step == 'push' %}
-            <a href="/first-snap/{{ language }}/{{ os }}/test">Test</a>
+            <a href="/first-snap/{{ language }}/{{ os }}/test">Test snap</a>
           {% else %}
-            Test
+            Test snap
           {% endif %}
         </li>
       {% endif %}
       <li class="p-breadcrumbs__item{% if fsf_step == 'language' or fsf_step == 'install' or fsf_step == 'package' or fsf_step == 'build' or fsf_step == 'test' %} is-disabled{% endif %}">
-        Push
+        Publish to store
       </li>
     </ul>
   </div>

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -3,11 +3,21 @@
 {% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
 
 {% block content %}
-{% include "first-snap/_breadcrumb.html" %}
-<div id="main-content" class="p-strip is-shallow">
-  {% block fsf_content %}
-  {% endblock %}
-</div>
+  {% include "first-snap/_breadcrumb.html" %}
+  <div id="main-content" class="p-strip is-shallow">
+    {% block fsf_content %}
+    {% endblock %}
+  </div>
+
+  {% if self.fsf_pagination() %}
+  <div class="p-strip u-no-padding snapcraft-banner-background">
+    <div class="row">
+      <div class="p-pagination">
+        {% block fsf_pagination %}{% endblock %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
 {% endblock %}
 
 {% block scripts_modules %}

--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -1,0 +1,33 @@
+{% extends webapp_config['LAYOUT'] %}
+
+{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
+
+{% block content %}
+{% include "first-snap/_breadcrumb.html" %}
+<div id="main-content" class="p-strip is-shallow">
+  {% block fsf_content %}
+  {% endblock %}
+</div>
+{% endblock %}
+
+{% block scripts_modules %}
+  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
+  <!-- begin intercom live embed code -->
+  <script>
+    window.intercomSettings = {
+      app_id: "s1rasgdr"
+    };
+  </script>
+  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
+  <!-- end intercom live embed code -->
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    Raven.context(function() {
+      if (typeof ClipboardJS !== 'undefined') {
+        new ClipboardJS('.js-clipboard-copy');
+      }
+    });
+  </script>
+{% endblock %}

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -34,20 +34,6 @@
       </ol>
     </div>
   </div>
-
-  <div class="row">
-    <hr />
-  </div>
-
-  <div class="row">
-    {% if os.startswith('macos') %}
-      Once built, it's time to test the snap.
-      <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/test">Continue</a>
-    {% else %}
-      If it's working, the next step is to push it to the Snap Store.
-      <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
-    {% endif %}
-  </div>
 {% endblock %}
 
 {% block fsf_pagination %}

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -1,80 +1,51 @@
-{% extends webapp_config['LAYOUT'] %}
+{% set fsf_step = "build" %}
+{% extends "first-snap/_layout_fsf.html" %}
 
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
-
-{% block content %}
-  {% set fsf_step = "build" %}
-  {% include "first-snap/_breadcrumb.html" %}
-
-  <div id="main-content" class="p-strip is-shallow">
-    <div class="row">
-      <div class="col-8">
-        <ol class="p-list-step has-margin">
-          {% for step in steps %}
-              <li class="p-list-step__item">
-                <h4 class="p-list-step__title">
-                  <span class="p-list-step__bullet">{{ loop.index }}</span>
-                  {{ step.action }}
-                </h4>
-                {% if step.command %}
-                  {% set snippet_value = step.command %}
-                  {% set snippet_id = loop.index %}
-                  {% if snippet_value.count('\n') == 0 %}
-                    {% include "/partials/_code-snippet.html" %}
-                  {% else %}
-                    {% include "/partials/_code-snippet-multi.html" %}
-                  {% endif %}
+{% block fsf_content %}
+  <div class="row">
+    <div class="col-8">
+      <ol class="p-list-step has-margin">
+        {% for step in steps %}
+            <li class="p-list-step__item">
+              <h4 class="p-list-step__title">
+                <span class="p-list-step__bullet">{{ loop.index }}</span>
+                {{ step.action }}
+              </h4>
+              {% if step.command %}
+                {% set snippet_value = step.command %}
+                {% set snippet_id = loop.index %}
+                {% if snippet_value.count('\n') == 0 %}
+                  {% include "/partials/_code-snippet.html" %}
+                {% else %}
+                  {% include "/partials/_code-snippet-multi.html" %}
                 {% endif %}
-              </li>
-          {% endfor %}
-          {% for step in steps %}
-            {% if loop.last and step.warning %}
-              <div class="p-notification--caution">
-                <p class="p-notification__response">
-                  {{ step.warning|safe }}
-                </p>
-              </div>
-            {% endif %}
-          {% endfor %}
-        </ol>
-      </div>
+              {% endif %}
+            </li>
+        {% endfor %}
+        {% for step in steps %}
+          {% if loop.last and step.warning %}
+            <div class="p-notification--caution">
+              <p class="p-notification__response">
+                {{ step.warning|safe }}
+              </p>
+            </div>
+          {% endif %}
+        {% endfor %}
+      </ol>
     </div>
-
-    <div class="row">
-      <hr />
-    </div>
-
-    <div class="row">
-      {% if os.startswith('macos') %}
-        Once built, it's time to test the snap.
-        <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/test">Continue</a>
-      {% else %}
-        If it's working, the next step is to push it to the Snap Store.
-        <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
-      {% endif %}
-    </div>
-
   </div>
-{% endblock %}
 
-{% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
-  <!-- begin intercom live embed code -->
-  <script>
-    window.intercomSettings = {
-      app_id: "s1rasgdr"
-    };
-  </script>
-  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
-  <!-- end intercom live embed code -->
-{% endblock %}
+  <div class="row">
+    <hr />
+  </div>
 
-{% block scripts %}
-  <script>
-    Raven.context(function() {
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
-    });
-  </script>
+  <div class="row">
+    {% if os.startswith('macos') %}
+      Once built, it's time to test the snap.
+      <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/test">Continue</a>
+    {% else %}
+      If it's working, the next step is to push it to the Snap Store.
+      <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
+    {% endif %}
+  </div>
 {% endblock %}

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -39,17 +39,17 @@
 {% block fsf_pagination %}
   <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/package">
     <span class="p-pagination__label">Previous</span>
-    <span class="p-pagination__title">Package</span>
+    <span class="p-pagination__title">Package snap</span>
   </a>
   {% if os and os.startswith('macos') %}
     <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/test">
       <span class="p-pagination__label">Next</span>
-      <span class="p-pagination__title">Test</span>
+      <span class="p-pagination__title">Test snap</span>
     </a>
   {% else %}
     <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/push">
       <span class="p-pagination__label">Next</span>
-      <span class="p-pagination__title">Push</span>
+      <span class="p-pagination__title">Publish to store</span>
     </a>
   {% endif %}
 {% endblock %}

--- a/templates/first-snap/build.html
+++ b/templates/first-snap/build.html
@@ -49,3 +49,21 @@
     {% endif %}
   </div>
 {% endblock %}
+
+{% block fsf_pagination %}
+  <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/package">
+    <span class="p-pagination__label">Previous</span>
+    <span class="p-pagination__title">Package</span>
+  </a>
+  {% if os and os.startswith('macos') %}
+    <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/test">
+      <span class="p-pagination__label">Next</span>
+      <span class="p-pagination__title">Test</span>
+    </a>
+  {% else %}
+    <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/push">
+      <span class="p-pagination__label">Next</span>
+      <span class="p-pagination__title">Push</span>
+    </a>
+  {% endif %}
+{% endblock %}

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -37,16 +37,16 @@
 {% block fsf_pagination %}
   <a class="p-pagination__link--previous" href="/first-snap/">
     <span class="p-pagination__label">Previous</span>
-    <span class="p-pagination__title">Language</span>
+    <span class="p-pagination__title">Select language</span>
   </a>
 
   <a id="js-pagination-linux" class="p-pagination__link--next u-hide" href="/first-snap/{{ language }}/linux/package">
     <span class="p-pagination__label">Next</span>
-    <span class="p-pagination__title">Package</span>
+    <span class="p-pagination__title">Package snap</span>
   </a>
   <a id="js-pagination-macos" class="p-pagination__link--next u-hide" href="/first-snap/{{ language }}/macos/package">
     <span class="p-pagination__label">Next</span>
-    <span class="p-pagination__title">Package</span>
+    <span class="p-pagination__title">Package snap</span>
   </a>
 {% endblock %}
 

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -45,6 +45,18 @@
   </div>
 {% endblock %}
 
+{% block fsf_pagination %}
+  <a class="p-pagination__link--previous" href="/first-snap/">
+    <span class="p-pagination__label">Previous</span>
+    <span class="p-pagination__title">Language</span>
+  </a>
+  {# TODO: disable when not selected, update on selection #}
+  <a class="p-pagination__link--next" href="/first-snap/{{ language }}/macos/package">
+    <span class="p-pagination__label">Next</span>
+    <span class="p-pagination__title">Package</span>
+  </a>
+{% endblock %}
+
 {% block scripts %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
   <script>

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -50,8 +50,12 @@
     <span class="p-pagination__label">Previous</span>
     <span class="p-pagination__title">Language</span>
   </a>
-  {# TODO: disable when not selected, update on selection #}
-  <a class="p-pagination__link--next" href="/first-snap/{{ language }}/macos/package">
+
+  <a id="js-pagination-linux" class="p-pagination__link--next u-hide" href="/first-snap/{{ language }}/linux/package">
+    <span class="p-pagination__label">Next</span>
+    <span class="p-pagination__title">Package</span>
+  </a>
+  <a id="js-pagination-macos" class="p-pagination__link--next u-hide" href="/first-snap/{{ language }}/macos/package">
     <span class="p-pagination__label">Next</span>
     <span class="p-pagination__title">Package</span>
   </a>

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -1,67 +1,48 @@
-{% extends webapp_config['LAYOUT'] %}
+{% set fsf_step = "install" %}
+{% extends "first-snap/_layout_fsf.html" %}
 
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
-
-{% block content %}
-  {% set fsf_step = "install" %}
-  {% include "first-snap/_breadcrumb.html" %}
-
-  <div id="main-content" class="p-strip is-shallow">
-    <div class="row">
-      <p>Now we'll set up Snapcraft, the tool for building snaps.</p>
-      <h4>What operating system are you developing on?</h4>
-    </div>
-    <div class="row">
-      <div class="col-6 p-fluid-grid">
-        <a class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center js-os-select" data-os="linux">
-          <header class="p-card__header">
-            <img src="https://assets.ubuntu.com/v1/e95bac0c-tux.svg" alt="">
-          </header>
-          <span>Linux</span>
-        </a>
-        <span class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center js-os-select" data-os="macos">
-          <header class="p-card__header">
-            <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="">
-          </header>
-          <span>macOS</span>
-        </span>
-        <span class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center is-disabled" data-os="windows">
-          <header class="p-card__header">
-            <img src="https://assets.ubuntu.com/v1/a9bfe4c5-win.svg" alt="">
-          </header>
-          <span>Windows</span>
-        </span>
-      </div>
-    </div>
-
-    {% include "first-snap/_install-linux.html" %}
-
-    {% include "first-snap/_install-macos.html" %}
-
-    {% include "first-snap/_install-windows.html" %}
-
-    <div class="row">
-      <hr />
-    </div>
-
-    <div class="row">
-      <p class="u-float--left">Next, we'll package an example snap.</p>
-      <a class="p-button--positive u-float--right js-continue is--disabled">Continue</a>
-    </div>
-
+{% block fsf_content %}
+  <div class="row">
+    <p>Now we'll set up Snapcraft, the tool for building snaps.</p>
+    <h4>What operating system are you developing on?</h4>
   </div>
-{% endblock %}
+  <div class="row">
+    <div class="col-6 p-fluid-grid">
+      <a class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center js-os-select" data-os="linux">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/e95bac0c-tux.svg" alt="">
+        </header>
+        <span>Linux</span>
+      </a>
+      <span class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center js-os-select" data-os="macos">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="">
+        </header>
+        <span>macOS</span>
+      </span>
+      <span class="p-logo-link p-fluid-grid__item--small p-card u-align-text--center is-disabled" data-os="windows">
+        <header class="p-card__header">
+          <img src="https://assets.ubuntu.com/v1/a9bfe4c5-win.svg" alt="">
+        </header>
+        <span>Windows</span>
+      </span>
+    </div>
+  </div>
 
-{% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
-  <!-- begin intercom live embed code -->
-  <script>
-    window.intercomSettings = {
-      app_id: "s1rasgdr"
-    };
-  </script>
-  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
-  <!-- end intercom live embed code -->
+  {% include "first-snap/_install-linux.html" %}
+
+  {% include "first-snap/_install-macos.html" %}
+
+  {% include "first-snap/_install-windows.html" %}
+
+  <div class="row">
+    <hr />
+  </div>
+
+  <div class="row">
+    <p class="u-float--left">Next, we'll package an example snap.</p>
+    <a class="p-button--positive u-float--right js-continue is--disabled">Continue</a>
+  </div>
 {% endblock %}
 
 {% block scripts %}
@@ -71,4 +52,5 @@
       snapcraft.public.firstSnapFlow.install({{ language|tojson }});
     });
   </script>
+  {{ super() }}
 {% endblock %}

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -40,11 +40,7 @@
     <span class="p-pagination__title">Select language</span>
   </a>
 
-  <a id="js-pagination-linux" class="p-pagination__link--next u-hide" href="/first-snap/{{ language }}/linux/package">
-    <span class="p-pagination__label">Next</span>
-    <span class="p-pagination__title">Package snap</span>
-  </a>
-  <a id="js-pagination-macos" class="p-pagination__link--next u-hide" href="/first-snap/{{ language }}/macos/package">
+  <a id="js-pagination-next" class="p-pagination__link--next is-disabled">
     <span class="p-pagination__label">Next</span>
     <span class="p-pagination__title">Package snap</span>
   </a>

--- a/templates/first-snap/install-snapcraft.html
+++ b/templates/first-snap/install-snapcraft.html
@@ -30,19 +30,8 @@
   </div>
 
   {% include "first-snap/_install-linux.html" %}
-
   {% include "first-snap/_install-macos.html" %}
-
   {% include "first-snap/_install-windows.html" %}
-
-  <div class="row">
-    <hr />
-  </div>
-
-  <div class="row">
-    <p class="u-float--left">Next, we'll package an example snap.</p>
-    <a class="p-button--positive u-float--right js-continue is--disabled">Continue</a>
-  </div>
 {% endblock %}
 
 {% block fsf_pagination %}

--- a/templates/first-snap/language.html
+++ b/templates/first-snap/language.html
@@ -1,29 +1,12 @@
-{% extends webapp_config['LAYOUT'] %}
-
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
-
-{% block content %}
 {% set fsf_step = "language" %}
-{% include "first-snap/_breadcrumb.html" %}
+{% extends "first-snap/_layout_fsf.html" %}
 
-<div id="main-content" class="p-strip is-shallow">
-  <div class="row">
-    <p>First pick the language your app is written in.</p>
-  </div>
-
-  {% include "partials/fsf_language.html" %}
+{% block fsf_content %}
+<div class="row">
+  <p>First pick the language your app is written in.</p>
 </div>
-{% endblock %}
 
-{% block scripts_modules %}
-  <!-- begin intercom live embed code -->
-  <script>
-    window.intercomSettings = {
-      app_id: "s1rasgdr"
-    };
-  </script>
-  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
-  <!-- end intercom live embed code -->
+{% include "partials/fsf_language.html" %}
 {% endblock %}
 
 {% block scripts %}
@@ -33,4 +16,5 @@
     snapcraft.public.initFSFLanguageSelect(document.querySelector('.js-fsf-language-select'));
   });
 </script>
+{{ super() }}
 {% endblock %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -140,15 +140,6 @@
       </ol>
     </div>
   </div>
-
-  <div class="row">
-    <hr />
-  </div>
-
-  <div class="row">
-    <p class="u-float--left">Next, we'll build and test the snap.</p>
-    <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/build">Continue</a>
-  </div>
 {% endblock %}
 
 {% block fsf_pagination %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -149,6 +149,6 @@
   </a>
   <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/build">
     <span class="p-pagination__label">Next</span>
-    <span class="p-pagination__title">Build</span>
+    <span class="p-pagination__title">Build snap</span>
   </a>
 {% endblock %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -150,3 +150,14 @@
     <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/build">Continue</a>
   </div>
 {% endblock %}
+
+{% block fsf_pagination %}
+  <a class="p-pagination__link--previous" href="/first-snap/{{ language }}">
+    <span class="p-pagination__label">Previous</span>
+    <span class="p-pagination__title">Install Snapcraft</span>
+  </a>
+  <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/build">
+    <span class="p-pagination__label">Next</span>
+    <span class="p-pagination__title">Build</span>
+  </a>
+{% endblock %}

--- a/templates/first-snap/package.html
+++ b/templates/first-snap/package.html
@@ -1,180 +1,152 @@
-{% extends webapp_config['LAYOUT'] %}
+{% set fsf_step = "package" %}
+{% extends "first-snap/_layout_fsf.html" %}
 
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
-
-{% block content %}
-  {% set fsf_step = "package" %}
-  {% include "first-snap/_breadcrumb.html" %}
-  <div id="main-content" class="p-strip is-shallow">
-    <div class="row">
-      <p>Now we'll take a real world app, and package it as a snap</p>
-    </div>
-
-    <div class="row">
-      <div class="col-8">
-        <ol class="p-list-step has-margin">
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
-              Download a copy of the app
-            </h4>
-            {% set snippet_value = steps.download %}
-            {% set snippet_id = "download" %}
-            {% include "/partials/_code-snippet.html" %}
-          </li>
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">2</span>
-              Open the snapcraft.yaml file in the root of the project
-            </h4>
-            {% set snippet_value = steps.createDir %}
-            {% set snippet_id = "createdir" %}
-            {% include "/partials/_code-snippet-multi.html" %}
-          </li>
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">3</span>
-              The snapcraft.yaml file starts with a small amount of human-readable metadata.
-            </h4>
-            <div class="p-list-step__content">
-              {% set snippet_value = steps.metadata %}
-              {% set snippet_id = "metadata" %}
-              {% include "/partials/_code.html" %}
-              {% for item in steps.explain.metadata %}
-                {% if item.text %}
-                  <p>{{ item.text|safe }}</p>
-                {% elif item.code %}
-                  <pre><code>{{ item.code }}</code></pre>
-                {% elif item.warning %}
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      {{ item.warning|safe }}
-                    </p>
-                  </div>
-                {% endif %}
-              {% endfor %}
-            </div>
-          </li>
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">4</span>
-              Security model
-            </h4>
-            <div class="p-list-step__content">
-              {% for item in steps.explain.security %}
-                {% if item.text %}
-                  <p>{{ item.text|safe }}</p>
-                {% elif item.code %}
-                  <pre><code>{{ item.code }}</code></pre>
-                {% elif item.warning %}
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      {{ item.warning|safe }}
-                    </p>
-                  </div>
-                {% endif %}
-              {% endfor %}
-            </div>
-          </li>
-          {% if steps.explain.base %}
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">5</span>
-              Base
-            </h4>
-            <div class="p-list-step__content">
-              {% for item in steps.explain.base %}
-                {% if item.text %}
-                  <p>{{ item.text|safe }}</p>
-                {% elif item.code %}
-                  <pre><code>{{ item.code }}</code></pre>
-                {% elif item.warning %}
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      {{ item.warning|safe }}
-                    </p>
-                  </div>
-                {% endif %}
-              {% endfor %}
-            </div>
-          </li>
-          {% endif %}
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">6</span>
-              Parts
-            </h4>
-            <div class="p-list-step__content">
-              {% for item in steps.explain.parts %}
-                {% if item.text %}
-                  <p>{{ item.text|safe }}</p>
-                {% elif item.code %}
-                  <pre><code>{{ item.code }}</code></pre>
-                {% elif item.warning %}
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      {{ item.warning|safe }}
-                    </p>
-                  </div>
-                {% endif %}
-              {% endfor %}
-            </div>
-          </li>
-          <li class="p-list-step__item">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">7</span>
-              Apps
-            </h4>
-            <div class="p-list-step__content">
-              {% for item in steps.explain.apps %}
-              {% if item.text %}
-              <p>{{ item.text|safe }}</p>
-              {% elif item.code %}
-              <pre><code>{{ item.code }}</code></pre>
-              {% elif item.warning %}
-              <div class="p-notification--caution">
-                <p class="p-notification__response">
-                  {{ item.warning|safe }}
-                </p>
-              </div>
-              {% endif %}
-              {% endfor %}
-            </div>
-          </li>
-        </ol>
-      </div>
-    </div>
-
-    <div class="row">
-      <hr />
-    </div>
-
-    <div class="row">
-      <p class="u-float--left">Next, we'll build and test the snap.</p>
-      <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/build">Continue</a>
-    </div>
-
+{% block fsf_content %}
+  <div class="row">
+    <p>Now we'll take a real world app, and package it as a snap</p>
   </div>
-{% endblock %}
 
-{% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
-  <!-- begin intercom live embed code -->
-  <script>
-    window.intercomSettings = {
-      app_id: "s1rasgdr"
-    };
-  </script>
-  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
-  <!-- end intercom live embed code -->
-{% endblock %}
+  <div class="row">
+    <div class="col-8">
+      <ol class="p-list-step has-margin">
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Download a copy of the app
+          </h4>
+          {% set snippet_value = steps.download %}
+          {% set snippet_id = "download" %}
+          {% include "/partials/_code-snippet.html" %}
+        </li>
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Open the snapcraft.yaml file in the root of the project
+          </h4>
+          {% set snippet_value = steps.createDir %}
+          {% set snippet_id = "createdir" %}
+          {% include "/partials/_code-snippet-multi.html" %}
+        </li>
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">3</span>
+            The snapcraft.yaml file starts with a small amount of human-readable metadata.
+          </h4>
+          <div class="p-list-step__content">
+            {% set snippet_value = steps.metadata %}
+            {% set snippet_id = "metadata" %}
+            {% include "/partials/_code.html" %}
+            {% for item in steps.explain.metadata %}
+              {% if item.text %}
+                <p>{{ item.text|safe }}</p>
+              {% elif item.code %}
+                <pre><code>{{ item.code }}</code></pre>
+              {% elif item.warning %}
+                <div class="p-notification--caution">
+                  <p class="p-notification__response">
+                    {{ item.warning|safe }}
+                  </p>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </li>
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Security model
+          </h4>
+          <div class="p-list-step__content">
+            {% for item in steps.explain.security %}
+              {% if item.text %}
+                <p>{{ item.text|safe }}</p>
+              {% elif item.code %}
+                <pre><code>{{ item.code }}</code></pre>
+              {% elif item.warning %}
+                <div class="p-notification--caution">
+                  <p class="p-notification__response">
+                    {{ item.warning|safe }}
+                  </p>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </li>
+        {% if steps.explain.base %}
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">5</span>
+            Base
+          </h4>
+          <div class="p-list-step__content">
+            {% for item in steps.explain.base %}
+              {% if item.text %}
+                <p>{{ item.text|safe }}</p>
+              {% elif item.code %}
+                <pre><code>{{ item.code }}</code></pre>
+              {% elif item.warning %}
+                <div class="p-notification--caution">
+                  <p class="p-notification__response">
+                    {{ item.warning|safe }}
+                  </p>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </li>
+        {% endif %}
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">6</span>
+            Parts
+          </h4>
+          <div class="p-list-step__content">
+            {% for item in steps.explain.parts %}
+              {% if item.text %}
+                <p>{{ item.text|safe }}</p>
+              {% elif item.code %}
+                <pre><code>{{ item.code }}</code></pre>
+              {% elif item.warning %}
+                <div class="p-notification--caution">
+                  <p class="p-notification__response">
+                    {{ item.warning|safe }}
+                  </p>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </li>
+        <li class="p-list-step__item">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">7</span>
+            Apps
+          </h4>
+          <div class="p-list-step__content">
+            {% for item in steps.explain.apps %}
+            {% if item.text %}
+            <p>{{ item.text|safe }}</p>
+            {% elif item.code %}
+            <pre><code>{{ item.code }}</code></pre>
+            {% elif item.warning %}
+            <div class="p-notification--caution">
+              <p class="p-notification__response">
+                {{ item.warning|safe }}
+              </p>
+            </div>
+            {% endif %}
+            {% endfor %}
+          </div>
+        </li>
+      </ol>
+    </div>
+  </div>
 
-{% block scripts %}
-  <script>
-    Raven.context(function() {
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
-    });
-  </script>
+  <div class="row">
+    <hr />
+  </div>
+
+  <div class="row">
+    <p class="u-float--left">Next, we'll build and test the snap.</p>
+    <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/build">Continue</a>
+  </div>
 {% endblock %}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -95,7 +95,7 @@
     </a>
   {% endif %}
 
-  <a id="js-pagination-next" class="p-pagination__link--next u-hide" href="/snaps">
+  <a id="js-pagination-next" class="p-pagination__link--next is-disabled" href="/snaps">
     <span class="p-pagination__label">Next</span>
     <span class="p-pagination__title">Go to listing</span>
   </a>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -86,12 +86,12 @@
   {% if os and os.startswith('macos') %}
     <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/test">
       <span class="p-pagination__label">Previous</span>
-      <span class="p-pagination__title">Test</span>
+      <span class="p-pagination__title">Test snap</span>
     </a>
   {% else %}
     <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/build">
       <span class="p-pagination__label">Previous</span>
-      <span class="p-pagination__title">Build</span>
+      <span class="p-pagination__title">Build snap</span>
     </a>
   {% endif %}
 

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -88,6 +88,25 @@
   </div>
 {% endblock %}
 
+{% block fsf_pagination %}
+  {% if os and os.startswith('macos') %}
+    <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/test">
+      <span class="p-pagination__label">Previous</span>
+      <span class="p-pagination__title">Test</span>
+    </a>
+  {% else %}
+    <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/build">
+      <span class="p-pagination__label">Previous</span>
+      <span class="p-pagination__title">Build</span>
+    </a>
+  {% endif %}
+  {# TODO: disable until pushed #}
+  <a class="p-pagination__link--next" href="/snaps/">
+    <span class="p-pagination__label">Next</span>
+    <span class="p-pagination__title">Go to listing</span>
+  </a>
+{% endblock %}
+
 {% block scripts %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
   {% if user %}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -1,121 +1,101 @@
-{% extends webapp_config['LAYOUT'] %}
+{% set fsf_step = "push" %}
+{% extends "first-snap/_layout_fsf.html" %}
 
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
-
-{% block content %}
-  {% set fsf_step = "push" %}
-  {% include "first-snap/_breadcrumb.html" %}
-  <div id="main-content" class="p-strip is-shallow">
-
-    <div class="row">
-      <ol class="p-list-step has-margin">
-        {% if not user %}
-          <li class="p-list-step__item col-8">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
-              Create an Ubuntu One account
-            </h4>
-            <div class="p-list-step__content">
-              <p>This lets you make releases, alter your store listing and see usage metrics.</p>
-              <div class="row">
-                <p class="col-5">
-                  <img src="https://assets.ubuntu.com/v1/cd588a80-ubuntu-one.png" />
-                </p>
-              </div>
-              <a href="/login" class="p-button--positive p-link--external">Register / Sign in...</a>
-            </div>
-          </li>
-        {% else %}
-          <li class="p-list-step__item col-8 u-no-margin--left">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
-              Create an Ubuntu One account <i class="p-icon--success"></i>
-            </h4>
-            <div class="p-list-step__content">
-              <p>This lets you make releases, alter your store listing and see usage metrics.</p>
-              <div class="row">
-                <p class="col-5">
-                  <img src="https://assets.ubuntu.com/v1/cd588a80-ubuntu-one.png" />
-                </p>
-              </div>
-            </div>
-          </li>
-          <li class="p-list-step__item col-8 u-no-margin--left">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">2</span>
-              Okay {{ user.display_name }}, now log in with the same account at the terminal
-            </h4>
-            {% set snippet_value = "snapcraft login" %}
-            {% set snippet_id = "snapcraft-login" %}
-            {% include "/partials/_code-snippet.html" %}
-          </li>
-          <li class="p-list-step__item col-8 u-no-margin--left">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">3</span>
-              Register the snap name from the snapcraft.yaml
-            </h4>
-            {% set snippet_value = "snapcraft register " + snap_name %}
-            {% set snippet_id = "snapcraft-login" %}
-            {% set snippet_id = "snapcraft-register" %}
-            {% include "/partials/_code-snippet.html" %}
-            <div class="p-notification--caution">
-              <p class="p-notification__response">
-                <span class="p-notification__status"></span>
-                Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
+{% block fsf_content %}
+  <div class="row">
+    <ol class="p-list-step has-margin">
+      {% if not user %}
+        <li class="p-list-step__item col-8">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Create an Ubuntu One account
+          </h4>
+          <div class="p-list-step__content">
+            <p>This lets you make releases, alter your store listing and see usage metrics.</p>
+            <div class="row">
+              <p class="col-5">
+                <img src="https://assets.ubuntu.com/v1/cd588a80-ubuntu-one.png" />
               </p>
             </div>
-          </li>
+            <a href="/login" class="p-button--positive p-link--external">Register / Sign in...</a>
+          </div>
+        </li>
+      {% else %}
+        <li class="p-list-step__item col-8 u-no-margin--left">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">1</span>
+            Create an Ubuntu One account <i class="p-icon--success"></i>
+          </h4>
+          <div class="p-list-step__content">
+            <p>This lets you make releases, alter your store listing and see usage metrics.</p>
+            <div class="row">
+              <p class="col-5">
+                <img src="https://assets.ubuntu.com/v1/cd588a80-ubuntu-one.png" />
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list-step__item col-8 u-no-margin--left">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">2</span>
+            Okay {{ user.display_name }}, now log in with the same account at the terminal
+          </h4>
+          {% set snippet_value = "snapcraft login" %}
+          {% set snippet_id = "snapcraft-login" %}
+          {% include "/partials/_code-snippet.html" %}
+        </li>
+        <li class="p-list-step__item col-8 u-no-margin--left">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">3</span>
+            Register the snap name from the snapcraft.yaml
+          </h4>
+          {% set snippet_value = "snapcraft register " + snap_name %}
+          {% set snippet_id = "snapcraft-login" %}
+          {% set snippet_id = "snapcraft-register" %}
+          {% include "/partials/_code-snippet.html" %}
+          <div class="p-notification--caution">
+            <p class="p-notification__response">
+              <span class="p-notification__status"></span>
+              Make sure the name matches what has been used previously (i.e <code>{{ snap_name }}</code>)
+            </p>
+          </div>
+        </li>
 
-          <li class="p-list-step__item col-8 u-no-margin--left">
-            <h4 class="p-list-step__title">
-              <span class="p-list-step__bullet">4</span>
-              Push to the Snap store
-            </h4>
-            {% set snippet_value = "snapcraft push --release edge *.snap" %}
-            {% set snippet_id = "snapcraft-push" %}
-            {% include "/partials/_code-snippet.html" %}
-          </li>
-        {% endif %}
-      </ol>
-    </div>
-
-    <div class="row">
-      <hr />
-    </div>
-
-    <div class="row">
-      <p class="u-float--left">
-        Once you've pushed to the Snap store, edit your snap public presentation.
-      </p>
-      <a class="p-button--neutral u-float--right js-continue is--disabled">
-        <i class="p-icon--spinner u-animation--spin"></i>
-        &nbsp;Waiting for push...</a>
-    </div>
+        <li class="p-list-step__item col-8 u-no-margin--left">
+          <h4 class="p-list-step__title">
+            <span class="p-list-step__bullet">4</span>
+            Push to the Snap store
+          </h4>
+          {% set snippet_value = "snapcraft push --release edge *.snap" %}
+          {% set snippet_id = "snapcraft-push" %}
+          {% include "/partials/_code-snippet.html" %}
+        </li>
+      {% endif %}
+    </ol>
   </div>
-{% endblock %}
 
-{% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
-  <!-- begin intercom live embed code -->
-  <script>
-    window.intercomSettings = {
-      app_id: "s1rasgdr"
-    };
-  </script>
-  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
-  <!-- end intercom live embed code -->
+  <div class="row">
+    <hr />
+  </div>
+
+  <div class="row">
+    <p class="u-float--left">
+      Once you've pushed to the Snap store, edit your snap public presentation.
+    </p>
+    <a class="p-button--neutral u-float--right js-continue is--disabled">
+      <i class="p-icon--spinner u-animation--spin"></i>
+      &nbsp;Waiting for push...</a>
+  </div>
 {% endblock %}
 
 {% block scripts %}
   <script src="{{ static_url('js/dist/public.js') }}"></script>
+  {% if user %}
   <script>
     Raven.context(function() {
-      {% if user %}
-        snapcraft.public.firstSnapFlow.push({{ language|tojson }});
-      {% endif %}
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
+      snapcraft.public.firstSnapFlow.push({{ language|tojson }});
     });
   </script>
+  {% endif %}
+  {{ super() }}
 {% endblock %}

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -100,8 +100,8 @@
       <span class="p-pagination__title">Build</span>
     </a>
   {% endif %}
-  {# TODO: disable until pushed #}
-  <a class="p-pagination__link--next" href="/snaps/">
+
+  <a id="js-pagination-next" class="p-pagination__link--next u-hide" href="/snaps">
     <span class="p-pagination__label">Next</span>
     <span class="p-pagination__title">Go to listing</span>
   </a>

--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -69,22 +69,16 @@
           {% set snippet_value = "snapcraft push --release edge *.snap" %}
           {% set snippet_id = "snapcraft-push" %}
           {% include "/partials/_code-snippet.html" %}
+
+          <p>
+            Once you've pushed to the Snap store, edit your snap public presentation.
+          </p>
+          <a class="p-button--neutral js-continue is--disabled">
+            <i class="p-icon--spinner u-animation--spin"></i>
+            &nbsp;Waiting for push...</a>
         </li>
       {% endif %}
     </ol>
-  </div>
-
-  <div class="row">
-    <hr />
-  </div>
-
-  <div class="row">
-    <p class="u-float--left">
-      Once you've pushed to the Snap store, edit your snap public presentation.
-    </p>
-    <a class="p-button--neutral u-float--right js-continue is--disabled">
-      <i class="p-icon--spinner u-animation--spin"></i>
-      &nbsp;Waiting for push...</a>
   </div>
 {% endblock %}
 

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -37,10 +37,10 @@
 {% block fsf_pagination %}
   <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/build">
     <span class="p-pagination__label">Previous</span>
-    <span class="p-pagination__title">Build</span>
+    <span class="p-pagination__title">Build snap</span>
   </a>
   <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/push">
     <span class="p-pagination__label">Next</span>
-    <span class="p-pagination__title">Push</span>
+    <span class="p-pagination__title">Publish to store</span>
   </a>
 {% endblock %}

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -1,73 +1,44 @@
-{% extends webapp_config['LAYOUT'] %}
+{% set fsf_step = "test" %}
+{% extends "first-snap/_layout_fsf.html" %}
 
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1gN_xcaAFFP_ckDvWeNDpD9ogbRXFgcXN0w0ITZQB0e4/edit#gid=779498506{% endblock %}
-
-{% block content %}
-  {% set fsf_step = "test" %}
-  {% include "first-snap/_breadcrumb.html" %}
-  <div id="main-content" class="p-strip is-shallow">
-
-    <div class="row">
-      <div class="col-8">
-        <ol class="p-list-step has-margin">
-          {% for step in steps %}
-            <li class="p-list-step__item">
-              <h4 class="p-list-step__title">
-                <span class="p-list-step__bullet">{{ loop.index }}</span>
-                {{ step.action|safe }}
-              </h4>
-              {% if step.command %}
-                {% set snippet_value = step.command %}
-                {% set snippet_id = loop.index %}
-                {% if snippet_value.count('\n') == 0 %}
-                  {% include "/partials/_code-snippet.html" %}
-                {% else %}
-                  {% include "/partials/_code-snippet-multi.html" %}
-                {% endif %}
+{% block fsf_content %}
+  <div class="row">
+    <div class="col-8">
+      <ol class="p-list-step has-margin">
+        {% for step in steps %}
+          <li class="p-list-step__item">
+            <h4 class="p-list-step__title">
+              <span class="p-list-step__bullet">{{ loop.index }}</span>
+              {{ step.action|safe }}
+            </h4>
+            {% if step.command %}
+              {% set snippet_value = step.command %}
+              {% set snippet_id = loop.index %}
+              {% if snippet_value.count('\n') == 0 %}
+                {% include "/partials/_code-snippet.html" %}
+              {% else %}
+                {% include "/partials/_code-snippet-multi.html" %}
               {% endif %}
-              {% if step.warning %}
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      {{ step.warning|safe }}
-                    </p>
-                  </div>
-                {% endif %}
-            </li>
-          {% endfor %}
-        </ol>
-      </div>
+            {% endif %}
+            {% if step.warning %}
+                <div class="p-notification--caution">
+                  <p class="p-notification__response">
+                    {{ step.warning|safe }}
+                  </p>
+                </div>
+              {% endif %}
+          </li>
+        {% endfor %}
+      </ol>
     </div>
-
-    <div class="row">
-      <hr />
-    </div>
-
-    <div class="row">
-      If it's working, the next step is to push it to the Snap Store.
-      <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
-    </div>
-
   </div>
-{% endblock %}
 
-{% block scripts_modules %}
-  <script src="{{ static_url('js/modules/clipboard.min.js') }}"></script>
-  <!-- begin intercom live embed code -->
-  <script>
-    window.intercomSettings = {
-      app_id: "s1rasgdr"
-    };
-  </script>
-  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();</script>
-  <!-- end intercom live embed code -->
-{% endblock %}
+  <div class="row">
+    <hr />
+  </div>
 
-{% block scripts %}
-  <script>
-    Raven.context(function() {
-      if (typeof ClipboardJS !== 'undefined') {
-        new ClipboardJS('.js-clipboard-copy');
-      }
-    });
-  </script>
+  <div class="row">
+    If it's working, the next step is to push it to the Snap Store.
+    <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
+  </div>
 {% endblock %}

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -32,15 +32,6 @@
       </ol>
     </div>
   </div>
-
-  <div class="row">
-    <hr />
-  </div>
-
-  <div class="row">
-    If it's working, the next step is to push it to the Snap Store.
-    <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
-  </div>
 {% endblock %}
 
 {% block fsf_pagination %}

--- a/templates/first-snap/test.html
+++ b/templates/first-snap/test.html
@@ -42,3 +42,14 @@
     <a class="p-button--positive u-float--right js-continue" href="/first-snap/{{ language }}/{{ os }}/push">Continue</a>
   </div>
 {% endblock %}
+
+{% block fsf_pagination %}
+  <a class="p-pagination__link--previous" href="/first-snap/{{ language }}/{{ os }}/build">
+    <span class="p-pagination__label">Previous</span>
+    <span class="p-pagination__title">Build</span>
+  </a>
+  <a class="p-pagination__link--next" href="/first-snap/{{ language }}/{{ os }}/push">
+    <span class="p-pagination__label">Next</span>
+    <span class="p-pagination__title">Push</span>
+  </a>
+{% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,7 +5359,7 @@ node-pre-gyp@^0.6.39:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@^4.5.3:
+node-sass@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
   dependencies:


### PR DESCRIPTION
Fixes #1783

Adds pagination links to bottom of first snap flow steps.

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1803.run.demo.haus/
- go to first snap flow
- all steps (apart from language selection) should have a pagination links on the bottom
- pagination on OS selection should link properly to chosen OS
- pagination on 'Publish' step should enable 'next' link when snap is pushed
- all pagination links between steps should work correctly (check both Mac OS and Linux paths)

<img width="1094" alt="Screenshot 2019-04-09 at 15 06 11" src="https://user-images.githubusercontent.com/83575/55803986-c0c53c80-5adb-11e9-9047-5d6509b2b96f.png">
