### PR TITLE
Show latest release in snap list

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -82,9 +82,9 @@ My published snaps — Linux software in the Snap Store
           <section class="p-strip--light is-shallow p-snapcraft-first-snap__notification">
             <div class="row">
               <div class="col-9">
-                {% if snaps[snap].latest_revisions[0].channels[0] %}
+                {% if snaps[snap].latest_release %}
                   <p>
-                    You've released {{ snap }} to the "{{ snaps[snap].latest_revisions[0].channels[0] }}" channel!
+                    You've released {{ snap }} to the "{{ snaps[snap].latest_release.channels[0] }}" channel!
                   </p>
                 {% else %}
                   <p>
@@ -93,8 +93,8 @@ My published snaps — Linux software in the Snap Store
                 {% endif %}
                 <p>
                   Want to improve the listing in stores?
-                  <a href="/account/snaps/{{ snap }}/listing">Edit Store listing</a>
-                  {% if not snaps[snap].latest_revisions[0].channels[0] %}
+                  <a href="/{{ snap }}/listing">Edit Store listing</a>
+                  {% if not snaps[snap].latest_release %}
                     <br />
                     Is your snap ready to release?
                     <a href="https://docs.snapcraft.io/build-snaps/release" target="_blank">Release it</a>
@@ -124,10 +124,14 @@ My published snaps — Linux software in the Snap Store
           {% for snap in snaps|sort %}
             {% with %}
               {% set dispute_pending = snaps[snap].status == "DisputePending" %}
-              {% set published = snaps[snap].latest_revisions[0].status == "Published" %}
+              {% if snaps[snap].latest_release %}
+                {% set published = snaps[snap].latest_release.status == "Published" %}
+              {% else %}
+                {% set published = False %}
+              {% endif %}
               <tr>
                 <td>
-                  <a href="/account/snaps/{{snap}}/listing" class="u-vertically-center">
+                  <a href="/{{snap}}/listing" class="u-vertically-center">
                     {% if snaps[snap].icon_url %}
                       <img src="{{ snaps[snap].icon_url }}" class="p-snap-list__image" />
                     {% else %}
@@ -159,15 +163,16 @@ My published snaps — Linux software in the Snap Store
                   {% endif %}
                 </td>
                 {% if published %}
-                  <td>{{ snaps[snap].latest_revisions[0].channels[0] }}</td>
+                  <td>{{ snaps[snap].latest_release.channels[0] }}</td>
+                  <td>
+                    <a href="/{{snap}}/releases">
+                      {{ snaps[snap].latest_release.version }}
+                    </a>
+                  </td>
                 {% else %}
-                  <td>Not released</td>
+                  <td><a href="/{{snap}}/releases">Not released</a></td>
+                  <td></td>
                 {% endif %}
-                <td>
-                  <a href="/{{snap}}/releases">
-                    {{ snaps[snap].latest_revisions[0].version }}
-                  </a>
-                </td>
               </tr>
             {% endwith %}
           {% endfor %}

--- a/tests/publisher/tests_account_snaps.py
+++ b/tests/publisher/tests_account_snaps.py
@@ -88,7 +88,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Approved",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     }
                 }
@@ -114,6 +118,49 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("registered_snaps", {})
 
     @responses.activate
+    def test_uploaded_snaps_with_latest_release(self):
+        payload = {
+            "snaps": {
+                "16": {
+                    "test": {
+                        "status": "Approved",
+                        "snap-name": "test",
+                        "latest_revisions": [
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": ["edge"],
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+        responses.add(responses.GET, self.api_url, json=payload, status=200)
+
+        response = self.client.get(self.endpoint_url)
+        self.assertEqual(200, response.status_code)
+        # Add pyQuery basic context checks
+
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
+        self.assertEqual(
+            self.authorization, called.request.headers.get("Authorization")
+        )
+
+        result_snaps = payload["snaps"]["16"]
+        result_snaps["test"]["latest_release"] = result_snaps["test"][
+            "latest_revisions"
+        ][0]
+
+        assert response.status_code == 200
+        self.assert_template_used("publisher/account-snaps.html")
+        self.assert_context("current_user", "Toto")
+        self.assert_context("snaps", result_snaps)
+        self.assert_context("registered_snaps", {})
+
+    @responses.activate
     def test_uploaded_snaps_registered_snaps(self):
         payload = {
             "snaps": {
@@ -122,7 +169,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Approved",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     },
                     "test2": {
@@ -159,7 +210,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "status": "Approved",
                 "snap-name": "test",
                 "latest_revisions": [
-                    {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                    {
+                        "test": "test",
+                        "since": "2018-01-01T00:00:00Z",
+                        "channels": [],
+                    }
                 ],
             }
         }
@@ -179,7 +234,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Approved",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     },
                     "test2": {
@@ -191,7 +250,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Revoked",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     },
                     "test4": {
@@ -228,7 +291,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                 "status": "Approved",
                 "snap-name": "test",
                 "latest_revisions": [
-                    {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                    {
+                        "test": "test",
+                        "since": "2018-01-01T00:00:00Z",
+                        "channels": [],
+                    }
                 ],
             }
         }

--- a/tests/publisher/tests_api_snaps.py
+++ b/tests/publisher/tests_api_snaps.py
@@ -55,7 +55,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Approved",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     }
                 }
@@ -87,7 +91,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Approved",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     },
                     "test2": {
@@ -124,7 +132,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Approved",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     },
                     "test2": {
@@ -136,7 +148,11 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "status": "Revoked",
                         "snap-name": "test",
                         "latest_revisions": [
-                            {"test": "test", "since": "2018-01-01T00:00:00Z"}
+                            {
+                                "test": "test",
+                                "since": "2018-01-01T00:00:00Z",
+                                "channels": [],
+                            }
                         ],
                     },
                     "test4": {

--- a/tests/publisher/tests_publisher_logic.py
+++ b/tests/publisher/tests_publisher_logic.py
@@ -23,7 +23,7 @@ class PublisherLogicTest(unittest.TestCase):
                     "snap1": {
                         "status": "Approved",
                         "latest_revisions": [
-                            {"since": "2018-01-01T00:00:00Z"}
+                            {"since": "2018-01-01T00:00:00Z", "channels": []}
                         ],
                     }
                 }
@@ -36,7 +36,9 @@ class PublisherLogicTest(unittest.TestCase):
         expected_user_snaps = {
             "snap1": {
                 "status": "Approved",
-                "latest_revisions": [{"since": "2018-01-01T00:00:00Z"}],
+                "latest_revisions": [
+                    {"since": "2018-01-01T00:00:00Z", "channels": []}
+                ],
             }
         }
 
@@ -69,7 +71,7 @@ class PublisherLogicTest(unittest.TestCase):
                     "snap1": {
                         "status": "Approved",
                         "latest_revisions": [
-                            {"since": "2018-01-01T00:00:00Z"}
+                            {"since": "2018-01-01T00:00:00Z", "channels": []}
                         ],
                     },
                     "snap2": {"status": "Approved", "latest_revisions": None},
@@ -83,7 +85,9 @@ class PublisherLogicTest(unittest.TestCase):
         expected_user_snaps = {
             "snap1": {
                 "status": "Approved",
-                "latest_revisions": [{"since": "2018-01-01T00:00:00Z"}],
+                "latest_revisions": [
+                    {"since": "2018-01-01T00:00:00Z", "channels": []}
+                ],
             }
         }
         expected_registered_snaps = {

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -25,6 +25,13 @@ def get_snaps_account_info(account_info):
 
     now = datetime.datetime.utcnow()
 
+    for snap in user_snaps:
+        snap_info = user_snaps[snap]
+        for revision in snap_info["latest_revisions"]:
+            if len(revision["channels"]) > 0:
+                snap_info["latest_release"] = revision
+                break
+
     if len(user_snaps) == 1:
         for snap in user_snaps:
             snap_info = user_snaps[snap]


### PR DESCRIPTION
Fixes https://github.com/canonical-websites/snapcraft.io/issues/1765

## QA
- Pull the branch
- `./run`
- Visit http://0.0.0.0:8004/snaps
- All snaps that have a release should show a channel and version

Note: I expect the tests to fail - my local setup has borked so I couldn't get any meaningful test failure messages.