### PR TITLE
Add publisher screenshots to first snap flow publish step

### DIFF
--- a/templates/first-snap/push.html
+++ b/templates/first-snap/push.html
@@ -2,6 +2,28 @@
 {% extends "first-snap/_layout_fsf.html" %}
 
 {% block fsf_content %}
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row">
+      <h4>Before you publish your snap, you'll need an Ubuntu One account</h4>
+      <p>Gain access to a host of great features within snapcraft.io such as your very own store listing page, publisher dashboard and snap usage metrics.</p>
+    </div>
+
+    <div class="row">
+      <div class="col-4 mobile-col-1 tablet-col-2">
+        <img height="193" width="308" src="https://assets.ubuntu.com/v1/e3eacb56-fsf-publisher-listing.png" />
+      </div>
+      <div class="col-4 mobile-col-1 tablet-col-2">
+        <img height="193" width="308" src="https://assets.ubuntu.com/v1/3220411b-fsf-publisher-dashboard.png" />
+      </div>
+      <div class="col-4 mobile-col-1 tablet-col-2">
+        <img height="193" width="308" src="https://assets.ubuntu.com/v1/55c5070e-fsf-publisher-metrics.png" />
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <hr />
+  </div>
+
   <div class="row">
     <ol class="p-list-step has-margin">
       {% if not user %}


### PR DESCRIPTION
Fixes #1784

Adds screenshots of publisher pages to publish first snap flow step

### QA

- ./run or https://snapcraft-io-canonical-websites-pr-1806.run.demo.haus/
- go to the last step of first snap flow (https://snapcraft-io-canonical-websites-pr-1806.run.demo.haus/first-snap/python/linux/push)
- on top short info about benefits of having account should be visible with some screenshots


<img width="1043" alt="Screenshot 2019-04-10 at 14 51 43" src="https://user-images.githubusercontent.com/83575/55880566-42cb6900-5ba1-11e9-8399-f73802ae32fb.png">
