### PR TITLE
banner regex update

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -361,7 +361,8 @@ def get_video_embed_code(url):
 
 
 def filter_screenshots(media):
-    banner_regex = r"/banner(\-icon)?(_.*)\.(png|jpg)"
+    banner_regex = r"/banner(\-icon)?(_.*)?\.(png|jpg)"
+
     return [
         m["url"]
         for m in media


### PR DESCRIPTION
Banner image and icons are showing on snap details: https://snapcraft.io/skype.

This updated the regex to match those screenshots by making the `_hash` section of the path optional.